### PR TITLE
feat(tactic/interactive): generalize custom tactic monads in `begin ... end` blocks

### DIFF
--- a/library/init/meta/smt/interactive.lean
+++ b/library/init/meta/smt/interactive.lean
@@ -30,6 +30,11 @@ using_smt tac
 meta def execute_with (cfg : smt_config) (tac : smt_tactic unit) : tactic unit :=
 using_smt tac cfg
 
+meta instance : interactive.executor smt_tactic :=
+{ config_type := smt_config,
+  inhabited := ⟨{}⟩,
+  execute_with := λ cfg tac, using_smt tac cfg, }
+
 namespace interactive
 open lean.parser
 open interactive

--- a/library/init/meta/tactic.lean
+++ b/library/init/meta/tactic.lean
@@ -73,6 +73,47 @@ meta def {u₁ u₂} tactic.down {α : Type u₂} (t : tactic (ulift.{u₁} α))
 | exception t ref s       := exception t ref s
 end
 
+namespace interactive
+
+/-- Typeclass for custom interaction monads, which provides
+    the information required to convert an interactive-mode
+    construction to a `tactic` which can actually be executed.
+
+    Given a `[monad m]`, `execute_with` explains how to turn a `begin ... end`
+    block, or a `by ...` statement into a `tactic α` which can actually be
+    executed. The `inhabited` first argument facilitates the passing of an
+    optional configuration parameter `config`, using the syntax:
+    ```
+    begin [custom_monad] with config,
+        ...
+    end
+    ```
+-/
+meta class executor (m : Type → Type u) [monad m] :=
+(config_type : Type)
+[inhabited : inhabited config_type]
+(execute_with : config_type → m unit → tactic unit)
+
+attribute [inline] executor.execute_with
+
+@[inline]
+meta def executor.execute_explicit (m : Type → Type u)
+   [monad m] [e : executor m] : m unit → tactic unit :=
+executor.execute_with e.inhabited.default
+
+@[inline]
+meta def executor.execute_with_explicit (m : Type → Type u)
+   [monad m] [executor m] : executor.config_type m → m unit → tactic unit :=
+executor.execute_with
+
+/-- Default `executor` instance for `tactic`s themselves -/
+meta instance : executor tactic :=
+{ config_type := unit,
+  inhabited := ⟨()⟩,
+  execute_with := λ _, id }
+
+end interactive
+
 namespace tactic
 variables {α : Type u}
 

--- a/src/library/constants.cpp
+++ b/src/library/constants.cpp
@@ -158,6 +158,7 @@ name const * g_int_neg_ne_of_pos = nullptr;
 name const * g_int_ne_neg_of_pos = nullptr;
 name const * g_int_neg_ne_zero_of_ne = nullptr;
 name const * g_int_zero_ne_neg_of_ne = nullptr;
+name const * g_interactive_executor = nullptr;
 name const * g_interactive_param_desc = nullptr;
 name const * g_interactive_parse = nullptr;
 name const * g_io_core = nullptr;
@@ -515,6 +516,7 @@ void initialize_constants() {
     g_int_ne_neg_of_pos = new name{"int", "ne_neg_of_pos"};
     g_int_neg_ne_zero_of_ne = new name{"int", "neg_ne_zero_of_ne"};
     g_int_zero_ne_neg_of_ne = new name{"int", "zero_ne_neg_of_ne"};
+    g_interactive_executor = new name{"interactive", "executor"};
     g_interactive_param_desc = new name{"interactive", "param_desc"};
     g_interactive_parse = new name{"interactive", "parse"};
     g_io_core = new name{"io_core"};
@@ -873,6 +875,7 @@ void finalize_constants() {
     delete g_int_ne_neg_of_pos;
     delete g_int_neg_ne_zero_of_ne;
     delete g_int_zero_ne_neg_of_ne;
+    delete g_interactive_executor;
     delete g_interactive_param_desc;
     delete g_interactive_parse;
     delete g_io_core;
@@ -1230,6 +1233,7 @@ name const & get_int_neg_ne_of_pos_name() { return *g_int_neg_ne_of_pos; }
 name const & get_int_ne_neg_of_pos_name() { return *g_int_ne_neg_of_pos; }
 name const & get_int_neg_ne_zero_of_ne_name() { return *g_int_neg_ne_zero_of_ne; }
 name const & get_int_zero_ne_neg_of_ne_name() { return *g_int_zero_ne_neg_of_ne; }
+name const & get_interactive_executor_name() { return *g_interactive_executor; }
 name const & get_interactive_param_desc_name() { return *g_interactive_param_desc; }
 name const & get_interactive_parse_name() { return *g_interactive_parse; }
 name const & get_io_core_name() { return *g_io_core; }

--- a/src/library/constants.h
+++ b/src/library/constants.h
@@ -160,6 +160,7 @@ name const & get_int_neg_ne_of_pos_name();
 name const & get_int_ne_neg_of_pos_name();
 name const & get_int_neg_ne_zero_of_ne_name();
 name const & get_int_zero_ne_neg_of_ne_name();
+name const & get_interactive_executor_name();
 name const & get_interactive_param_desc_name();
 name const & get_interactive_parse_name();
 name const & get_io_core_name();

--- a/tests/lean/interactive/my_tac_class.lean
+++ b/tests/lean/interactive/my_tac_class.lean
@@ -26,8 +26,8 @@ meta def istep {α : Type} (line0 col0 line col : nat) (t : mytac α) : mytac un
     | none := interaction_monad.silent_fail new_s
     end)⟩
 
-meta def execute (tac : mytac unit) : tactic unit :=
-tac.run 0 >> return ()
+meta instance : interactive.executor mytac :=
+{ config_type := unit, execute_with := λ _ tac, tac.run 0 >> return () }
 
 meta def save_info (p : pos) : mytac unit :=
 do v ← get,

--- a/tests/lean/interactive/rb_map_ts.lean
+++ b/tests/lean/interactive/rb_map_ts.lean
@@ -27,8 +27,8 @@ meta def istep {α : Type} (line0 col0 line col : nat) (t : mytac α) : mytac un
     | none := interaction_monad.silent_fail new_s
     end)⟩
 
-meta def execute (tac : mytac unit) : tactic unit :=
-tac.run (name_map.mk nat) >> return ()
+meta instance : interactive.executor mytac :=
+{ config_type := unit, execute_with := λ _ tac, tac.run (name_map.mk nat) >> return () }
 
 meta def save_info (p : pos) : mytac unit :=
 do v ← get,

--- a/tests/lean/run/my_tac_class.lean
+++ b/tests/lean/run/my_tac_class.lean
@@ -27,8 +27,8 @@ meta def istep {α : Type} (line0 col0 line col : nat) (t : mytac α) : mytac un
     | none := interaction_monad.silent_fail new_s
     end)⟩
 
-meta def execute (tac : mytac unit) : tactic unit :=
-tac.run 0 >> return ()
+meta instance : interactive.executor mytac :=
+{ config_type := unit, execute_with := λ _ tac, tac.run 0 >> return () }
 
 meta def save_info (p : pos) : mytac unit :=
 do v ← get,


### PR DESCRIPTION
In core lean in order to define a custom interaction monad (i.e. the data required to be able to use `begin ... end` and `by ...` blocks), you need to define several functions (as detailed in the header of [src/frontends/lean/tactic_notation.cpp](https://github.com/leanprover-community/lean/blob/master/src/frontends/lean/tactic_notation.cpp)). Of note are the lines:
````
7) There is a definition Tac.execute (tac : Tac unit) : tactic unit
8) There is a definition Tac.execute_with (cfg : config) (tac : Tac unit) : tactic unit
````
We generalise these pair of functions into an instance which can be made available for any custom `Tac` you would like, without hard-coding functions with these specific hardcoded names (which cannot then be overridden, for example). We instead just offload this task to the typeclass resolution mechanism. I think there is a reasonable argument that the other auxiliary functions for a custom tactic monad should just be moved into a single instance of `interactive_structure` (or some other name) for that purpose, but I leaned on the conservative side here (since that would be a simple refactoring given the new instance I've introduced anyway). As a side-effect, there is no more special casing for handling `begin ... end` tactic blocks compared to any other kind of custom interactive block.