### PR TITLE
Remove compiler warnings on newer gccs

### DIFF
--- a/src/frontends/lean/parser.cpp
+++ b/src/frontends/lean/parser.cpp
@@ -2641,7 +2641,7 @@ void parser::maybe_throw_error(parser_error && err) {
             m_error_since_last_cmd = true;
         }
     } else {
-        throw err;
+        throw std::move(err);
     }
 }
 

--- a/src/kernel/expr.cpp
+++ b/src/kernel/expr.cpp
@@ -736,7 +736,7 @@ expr copy_tag(expr const & e, expr && new_e) {
     tag t = e.get_tag();
     if (t != nulltag)
         new_e.set_tag(t);
-    return new_e;
+    return std::move(new_e);
 }
 
 expr update_app(expr const & e, expr const & new_fn, expr const & new_arg) {

--- a/src/library/discr_tree.cpp
+++ b/src/library/discr_tree.cpp
@@ -118,7 +118,7 @@ auto discr_tree::ensure_unshared(node && n) -> node {
     else if (n.is_shared())
         return node(new (get_allocator().allocate()) node_cell(*n.m_ptr));
     else
-        return n;
+        return std::move(n);
 }
 
 discr_tree::node::node(node_cell * ptr):m_ptr(ptr) { if (m_ptr) ptr->inc_ref(); }

--- a/src/library/inductive_compiler/basic.cpp
+++ b/src/library/inductive_compiler/basic.cpp
@@ -68,7 +68,7 @@ using inductive::mk_intro_rule;
 class add_basic_inductive_decl_fn {
     environment                           m_env;
     options const &                       m_opts;
-    name_map<implicit_infer_kind> const & m_implicit_infer_map;
+    name_map<implicit_infer_kind>         m_implicit_infer_map;
     ginductive_decl const &               m_decl;
     bool                                  m_is_trusted;
     void mk_basic_aux_decls() {

--- a/src/library/inductive_compiler/util.cpp
+++ b/src/library/inductive_compiler/util.cpp
@@ -72,7 +72,7 @@ void assert_def_eq(environment const & DEBUG_CODE(env), expr const & DEBUG_CODE(
         // TODO(dhs): this is only for debugging
         // We prefer to enter GDB than to throw an exception
         lean_assert(false);
-        throw ex;
+        throw std::move(ex);
     }
 }
 
@@ -84,7 +84,7 @@ void assert_type_correct(environment const & env, expr const & e) {
         // TODO(dhs): this is only for debugging
         // We prefer to enter GDB than to throw an exception
         lean_assert(false);
-        throw ex;
+        throw std::move(ex);
     }
 }
 

--- a/src/library/replace_visitor.cpp
+++ b/src/library/replace_visitor.cpp
@@ -52,7 +52,7 @@ expr replace_visitor::visit_macro(expr const & e) {
 expr replace_visitor::save_result(expr const & e, expr && r, bool shared) {
     if (shared)
         m_cache.insert(std::make_pair(e, r));
-    return r;
+    return std::move(r);
 }
 expr replace_visitor::visit(expr const & e) {
     check_system("expression replacer");

--- a/src/util/rb_tree.h
+++ b/src/util/rb_tree.h
@@ -85,13 +85,13 @@ class rb_tree : private CMP {
         if (n.is_shared()) {
             return node(new (get_allocator().allocate()) node_cell(*n.m_ptr));
         } else {
-            return n;
+            return std::move(n);
         }
     }
 
     static node set_black(node && n) {
         if (n.is_black())
-            return n;
+            return std::move(n);
         node r = ensure_unshared(n.steal());
         r->m_red = false;
         return r;
@@ -139,7 +139,7 @@ class rb_tree : private CMP {
         h->m_right = ensure_unshared(h->m_right.steal());
         h->m_left->m_red  = !h->m_left->m_red;
         h->m_right->m_red = !h->m_right->m_red;
-        return h;
+        return std::move(h);
     }
 
     LEAN_STATIC node fixup(node && h) {
@@ -150,7 +150,7 @@ class rb_tree : private CMP {
             h = rotate_right(h.steal());
         if (h->m_left.is_red() && h->m_right.is_red())
             h = flip_colors(h.steal());
-        return h;
+        return std::move(h);
     }
 
     node insert(node && n, T const & v) {
@@ -177,7 +177,7 @@ class rb_tree : private CMP {
             h          = rotate_left(h.steal());
             return flip_colors(h.steal());
         } else {
-            return h;
+            return std::move(h);
         }
     }
 
@@ -188,7 +188,7 @@ class rb_tree : private CMP {
             h          = rotate_right(h.steal());
             return flip_colors(h.steal());
         } else {
-            return h;
+            return std::move(h);
         }
     }
 

--- a/src/util/small_object_allocator.h
+++ b/src/util/small_object_allocator.h
@@ -39,5 +39,5 @@ public:
 
 inline void * operator new(size_t s, lean::small_object_allocator & r) { return r.allocate(s); }
 inline void * operator new[](size_t s, lean::small_object_allocator & r) { return r.allocate(s); }
-inline void operator delete(void *, lean::small_object_allocator &) { lean_unreachable(); }
-inline void operator delete[](void *, lean::small_object_allocator &) { lean_unreachable(); }
+// inline void operator delete(void *, lean::small_object_allocator &) { lean_unreachable(); }
+// inline void operator delete[](void *, lean::small_object_allocator &) { lean_unreachable(); }

--- a/src/util/small_object_allocator.h
+++ b/src/util/small_object_allocator.h
@@ -39,5 +39,5 @@ public:
 
 inline void * operator new(size_t s, lean::small_object_allocator & r) { return r.allocate(s); }
 inline void * operator new[](size_t s, lean::small_object_allocator & r) { return r.allocate(s); }
-// inline void operator delete(void *, lean::small_object_allocator &) { lean_unreachable(); }
-// inline void operator delete[](void *, lean::small_object_allocator &) { lean_unreachable(); }
+inline void operator delete(void *, lean::small_object_allocator &) { /* unreachable */ }
+inline void operator delete[](void *, lean::small_object_allocator &) { /* unreachable */ }

--- a/src/util/trie.h
+++ b/src/util/trie.h
@@ -30,7 +30,7 @@ class trie : public KeyCMP {
         if (n.is_shared())
             return trie(new cell(*n.m_ptr));
         else
-            return n;
+            return std::move(n);
     }
 
     template<typename It>


### PR DESCRIPTION
# `-Wreturn-std-move`

Newer C++ compilers include a compiler warning for when an argument is given move semantics (the `&&` thing) but is copied because `std::move` is not used.

I added std::move to all of the places that this warning came up because I got sick of seeing them in my build.

# Removed a `const &`

In  `src/library/inductive_compiler/basic.cpp`, `add_basic_inductive_decl_fn`'s `m_implicit_infer_map` field caused an error because it is implicitly cast to a reference. When I look at `name_map<T>`, it is already a pointer so it seems to my naive eyes that the best way to remove this warning is for the `m_implicit_infer_map` to be a value instead of a reference.

I made the warning go away and all the tests pass so it works in that sense.

# Commented out some Lean unreachables.

I am least sure about this change. In ` src/util/small_object_allocator.h`, I get `warning: 'operator delete' has a non-throwing exception specification but can still throw [-Wexceptions]`.

I can't figure out what I need to change to the signature of the delete operator to make this warning go away but since it should be unreachable anyway I just commented it out. This is probably a bad idea.



