### PR TITLE
fix(src/shell/emscripten.h): Emscripten FS issue

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -125,6 +125,7 @@ matrix:
         LEAN_EMSCRIPTEN_BUILD=Main
         UPLOAD=ON
      before_install:
+       - mkdir build
        - docker run -dit --name emscripten -v $(pwd):/src trzeci/emscripten:sdk-incoming-64bit bash
      install: true
      script:
@@ -155,6 +156,7 @@ matrix:
   #    env:
   #       LEAN_EMSCRIPTEN_BUILD=Test
   #    before_install:
+  #      - mkdir build
   #      - docker run -dit --name emscripten -v $(pwd):/src trzeci/emscripten:sdk-incoming-64bit bash
   #    install: true
   #    script:

--- a/script/ci_emscripten_docker.sh
+++ b/script/ci_emscripten_docker.sh
@@ -2,7 +2,6 @@
 set -exu
 apt-get update
 apt-get install -y m4
-mkdir build
 cd build
 emconfigure cmake ../src $OPTIONS
 NODE_OPTIONS="--max-old-space-size=4096" emmake make # -j2 leads to intermittent build errors

--- a/src/shell/emscripten.h
+++ b/src/shell/emscripten.h
@@ -15,11 +15,13 @@ Authors: Gabriel Ebner, Bryan Gin-ge Chen
         });
 // emscripten cannot mount all of / in the vfs,
 // we can only mount subdirectories...
+// /home and /tmp are created automatically by emscripten
+// see createDefaultDirectories in emscripten's library_fs.js
 #define LEAN_EMSCRIPTEN_FS EM_ASM( \
         try { \
             var cwd = process.cwd(); \
             var cwdRoot = '/' + cwd.split('/')[1]; \
-            FS.mkdir(cwdRoot); \
+            if (cwdRoot !== '/home' && cwdRoot !== '/tmp') FS.mkdir(cwdRoot); \
             FS.mount(NODEFS, { root:cwdRoot }, cwdRoot); \
             FS.chdir(cwd); \
         } catch (e) { \


### PR DESCRIPTION
Emscripten's filesystem contains `/home` by default and so attempting to create the directory again before mounting resulted in an error. I didn't see this on my local setup since macOS's home is under `/User`. I addressed this by including a test for Emscripten's default directories in the relevant code.

Another fix is to the travis scripts. We now create the `build` directory outside of docker to prevent permissions issues later on when trying to write the `lean-(version)-browser.zip` file.

Hopefully this fixes the issues keeping the browser build from being uploaded to the `lean-nightly` release!