### PR TITLE
Fix some cases when adding lean language to the start of a code block

### DIFF
--- a/library/init/meta/attribute.lean
+++ b/library/init/meta/attribute.lean
@@ -36,7 +36,7 @@ A __user attribute__ is an attribute defined by the user (ie, not built in to Le
 
 ### Data
 A `user_attribute` consists of the following pieces of data:
-- `name` is the name of the attribute, eg ```simp``
+- `name` is the name of the attribute, eg ```simp```
 - `descr` is a plaintext description of the attribute for humans.
 - `after_set` is an optional handler that will be called after the attribute has been applied to a declaration.
     Failing the tactic will fail the entire `attribute/def/...` command, i.e. the attribute will

--- a/library/init/meta/expr.lean
+++ b/library/init/meta/expr.lean
@@ -77,7 +77,7 @@ end⟩
   -/
 meta constant macro_def : Type
 
-/-- An expression. eg ```(4+5)``.
+/-- An expression. eg ```(4+5)```.
 
     The `elab` flag is indicates whether the `expr` has been elaborated and doesn't contain any placeholder macros.
     For example the equality `x = x` is represented in `expr ff` as ``app (app (const `eq _) x) x`` while in `expr tt` it is represented as ``app (app (app (const `eq _) t) x) x`` (one more argument).

--- a/library/init/meta/tactic.lean
+++ b/library/init/meta/tactic.lean
@@ -690,7 +690,7 @@ match t with
 | _                 := return []
 end
 
-/-- Same as `intros`, except with the given names for the new hypotheses. Use the name ```_`` to instead use the binder's name.-/
+/-- Same as `intros`, except with the given names for the new hypotheses. Use the name ```_``` to instead use the binder's name.-/
 meta def intro_lst : list name → tactic (list expr)
 | []      := return []
 | (n::ns) := do H ← intro n, Hs ← intro_lst ns, return (H :: Hs)

--- a/src/library/documentation.cpp
+++ b/src/library/documentation.cpp
@@ -128,8 +128,19 @@ static std::string add_lean_suffix_to_code_blocks(std::string const & s) {
     unsigned i = 0;
     bool in_block = false;
     while (i < sz) {
-        if (!in_block && s[i] == '`' && sz >= 4 && i < sz - 3 && s[i+1] == '`' && s[i+2] == '`' && isspace(s[i+3])) {
-            r += "```lean";
+        if (!in_block && s[i] == '`' && sz >= 4 && i < sz - 3 && s[i+1] == '`' && s[i+2] == '`') {
+            unsigned end = i+3;
+            // It could be like ```1 + 1``` i.e. non-alpha,
+            // so checking not_space seems best.
+            bool has_non_space = false;
+            while (has_non_space == false && end < sz && s[end] != '\n') {
+                 has_non_space = isspace(s[end]) == 0;
+                 end++;
+            }
+
+            if (has_non_space) r += "```";
+            else r += "```lean";
+
             r += s[i+3];
             i += 4;
             in_block = true;


### PR DESCRIPTION
The commit message for fb74ebb basically covers the before and after,
Not all doc strings were being checked for balance,

The first commit fixes the unbalanced doc strings that were in core
before the patch, since now those doc strings will cause an error.

Further some doc strings, containing an "info string", (e.g. language),
were in some cases being mangled, when trying to add the default lean language.
because it only recognized doc strings immediately followed by white space as the start
of a code block.