### PR TITLE
fix(level): give level.instantiate correct type

### DIFF
--- a/library/init/meta/level.lean
+++ b/library/init/meta/level.lean
@@ -32,7 +32,7 @@ meta constant level.eqv : level → level → bool
 /-- Return tt iff the first level occurs in the second -/
 meta constant level.occurs : level → level → bool
 /-- Replace a parameter named n with l in the first level if the list contains the pair (n, l) -/
-meta constant level.instantiate : level → list (name × level) → list level
+meta constant level.instantiate : level → list (name × level) → level
 meta constant level.to_format : level → options → format
 meta constant level.to_string : level → string
 

--- a/src/library/vm/vm_level.cpp
+++ b/src/library/vm/vm_level.cpp
@@ -129,7 +129,7 @@ vm_obj level_fold(vm_obj const &, vm_obj const & l, vm_obj const & a, vm_obj con
     return r;
 }
 
-// meta_constant level.instantiate : level → list (name × level) → list level
+// meta_constant level.instantiate : level → list (name × level) → level
 vm_obj level_instantiate(vm_obj const & o, vm_obj const & lst) {
     level const & l = to_level(o);
     buffer<name> ns;

--- a/tests/lean/level_instantiate.lean
+++ b/tests/lean/level_instantiate.lean
@@ -1,0 +1,9 @@
+#check level.instantiate
+
+#eval level.to_string $ level.instantiate (level.param `x) [(`x, level.param `y)]
+
+#eval level.to_string $ level.instantiate (level.param `x) [(`x, level.param `y), (`y, level.param `z)]
+
+#eval level.to_string $ level.instantiate (level.param `x) [(`x, level.param `y), (`x, level.param `z)]
+
+#eval level.to_string $ level.instantiate (level.max (level.param `x) (level.param `y)) [(`x, level.param `y), (`y, level.param `z)]

--- a/tests/lean/level_instantiate.lean.expected.out
+++ b/tests/lean/level_instantiate.lean.expected.out
@@ -1,0 +1,5 @@
+level.instantiate : level → list (name × level) → level
+"y"
+"y"
+"y"
+"max y z"


### PR DESCRIPTION
`level.instantiate` should return a single level rather than a list of levels. I don't think this builtin is used in mathlib, I tested it on `leanprover/mathlib` and nothing broke.