### PR TITLE
feat(olean): store module documentation in .olean files

### DIFF
--- a/tests/lean/doc_string_ctr.lean.expected.out
+++ b/tests/lean/doc_string_ctr.lean.expected.out
@@ -1,3 +1,0 @@
-Makes foo.
-Makes foo of foo.
-Doesn't make foo.

--- a/tests/lean/doc_strings.lean
+++ b/tests/lean/doc_strings.lean
@@ -1,3 +1,6 @@
+/-! This module has a doc.. -/
+/-! ..or two. -/
+
 inductive foo : Type
 /-- Makes foo. -/
 | a : foo
@@ -11,3 +14,4 @@ open tactic
 run_cmd doc_string `foo.a >>= trace
 run_cmd doc_string `foo.b >>= trace
 run_cmd doc_string `two >>= trace
+run_cmd module_doc_strings >>= trace

--- a/tests/lean/doc_strings.lean.expected.out
+++ b/tests/lean/doc_strings.lean.expected.out
@@ -1,0 +1,8 @@
+Makes foo.
+Makes foo of foo.
+Doesn't make foo.
+[(none, This module has a doc..),
+ (none, ..or two.),
+ ((some foo.a), Makes foo.),
+ ((some foo.b), Makes foo of foo.),
+ ((some two), Doesn't make foo.)]


### PR DESCRIPTION
This PR makes documentation output work when used via `--doc=mydoc.md`. Fixes #51. It's something that I hacked together really quickly, so most likely not the prettiest solution. The Lean build system is a fairly complicated multithreaded thing, and I don't fully understand the implications of the changes here. I would appreciate it if someone more knowledgeable in the Lean module/environment/extension system could take a look - I will leave a couple of comments at places I'm not sure about.

It works a little *too* well, in that the documentation includes not only the current module's declarations, but also all transitively imported declarations - the standard library and maybe mathlib. Given this input:
```lean
/-! Module doc 1 -/
/-! Module doc 2 -/

/-- Foo is an inductive type. -/
inductive foo: Type
| a: foo
| b: foo -> foo

/-- foo_test is documented. -/
def foo_test := foo.b foo.a

/-- Meta bar is documented. -/
meta def bar: nat := 1337
```
the documentation is:

    $DOCS_FOR_ALL_OF_THE_STANDARD_LIBRARY

    Module doc 1

    Module doc 2

    <a name="foo"></a>**Inductive** foo
    ```lean
    inductive  foo :  Type
    ```
    **Constructors:**
    ```lean
    foo.a :  foo
    foo.b :  foo → foo
    ```
    Foo is an inductive type.

    <a name="foo_test"></a>**Definition** foo_test
    ```lean
    def foo_test :  foo
    ```
    foo_test is documented.

    <a name="bar"></a>**Definition** bar
    ```lean
    meta def bar :  ℕ
    ```
    Meta bar is documented.

On a final note, the documentation output format is a bit strange - it looks like Markdown with inline HTML. It seems it could be more useful if Lean could output the docs as a stupid-simple JSON file with module-declaration-docstring mappings to be consumed by a postprocessing stage. Maybe [lumpy-leandoc](https://github.com/ratmice/lumpy-leandoc) (CC @ratmice)?