### PR TITLE
fix(73): Update github issue hyperlinks

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -13,11 +13,12 @@ for you (the contributors) and us (the maintainers).
 
 # Opening Issues
 
--  Checked that your issue isn't [already filed](https://github.com/leanprover/lean/issues).
+-  Checked that your issue isn't [already filed](https://github.com/leanprover-community/lean/issues).
 - Specifically look over:
-  * the [wishlist](https://github.com/leanprover/lean/issues?q=is%3Aissue+is%3Aopen+label%3AI-wishlist),
-  * open [RFCs](https://github.com/leanprover/lean/issues?q=is%3Aissue+is%3Aopen+label%3ARFC),
-  * open [feature requests](https://github.com/leanprover/lean/issues?q=is%3Aissue+is%3Aopen+label%3AFeature).
+  * the [wishlist](https://github.com/leanprover-community/lean/issues?q=is%3Aissue+is%3Aopen+label%3AI-wishlist),
+  * open [RFCs](https://github.com/leanprover-community/lean/issues?q=is%3Aissue+is%3Aopen+label%3ARFC),
+  * open [feature requests](https://github.com/leanprover-community/lean/issues?q=is%3Aissue+is%3Aopen+label%3AFeature).
+  * The issue may be present on the original Lean project (https://github.com/leanprover/lean) in which case please reopen the issue here and link to the old issue.
 - Reduce the issue to a self-contained, reproducible test case.
 
 # Opening Pull Requests

--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,9 +1,9 @@
 ### Prerequisites
 
 * [ ] Put an X between the brackets on this line if you have done all of the following:
-    * Checked that your issue isn't already [filed](https://github.com/leanprover/lean/issues).
-        * Specifically, check out the [wishlist](https://github.com/leanprover/lean/issues?q=is%3Aissue+is%3Aopen+label%3AI-wishlist), open [RFCs](https://github.com/leanprover/lean/issues?q=is%3Aissue+is%3Aopen+label%3ARFC),
-        or [feature requests](https://github.com/leanprover/lean/issues?q=is%3Aissue+is%3Aopen+label%3AFeature).
+    * Checked that your issue isn't already [filed](https://github.com/leanprover-community/lean/issues).
+        * Specifically, check out the [wishlist](https://github.com/leanprover-community/lean/issues?q=is%3Aissue+is%3Aopen+label%3AI-wishlist), open [RFCs](https://github.com/leanprover-community/lean/issues?q=is%3Aissue+is%3Aopen+label%3ARFC),
+        or [feature requests](https://github.com/leanprover-community/lean/issues?q=is%3Aissue+is%3Aopen+label%3AFeature).
     * Reduced the issue to a self-contained, reproducible test case.
 
 ### Description

--- a/README.md
+++ b/README.md
@@ -43,8 +43,8 @@ Miscellaneous
 Roadmap
 -------------
 
-- [Open RFC issues](https://github.com/leanprover/lean/issues?q=is%3Aissue+is%3Aopen+label%3ARFC)
-- [Features](https://github.com/leanprover/lean/issues?q=is%3Aissue+is%3Aopen+label%3AFeature)
-- [Wish list](https://github.com/leanprover/lean/issues?q=is%3Aissue+is%3Aopen+label%3AI-wishlist)
-- [High priority issues](https://github.com/leanprover/lean/issues?q=is%3Aissue+is%3Aopen+label%3AP-high)
-- [Medium priority issues](https://github.com/leanprover/lean/issues?q=is%3Aissue+is%3Aopen+label%3AP-medium)
+- [Open RFC issues](https://github.com/leanprover-community/lean/issues?q=is%3Aissue+is%3Aopen+label%3ARFC)
+- [Features](https://github.com/leanprover-community/lean/issues?q=is%3Aissue+is%3Aopen+label%3AFeature)
+- [Wish list](https://github.com/leanprover-community/lean/issues?q=is%3Aissue+is%3Aopen+label%3AI-wishlist)
+- [High priority issues](https://github.com/leanprover-community/lean/issues?q=is%3Aissue+is%3Aopen+label%3AP-high)
+- [Medium priority issues](https://github.com/leanprover-community/lean/issues?q=is%3Aissue+is%3Aopen+label%3AP-medium)

--- a/doc/export_format.md
+++ b/doc/export_format.md
@@ -14,7 +14,7 @@ lean --export=export.out --recursive
 There are several checkers available that can read these files:
 * [trepplein](https://github.com/gebner/trepplein), a type-checker written in Scala.
 * [tc](https://github.com/dselsam/tc), a type-checker written in Haskell.
-* [leanchecker](https://github.com/leanprover/lean/tree/master/src/checker), a bare-bones version of the Lean kernel.
+* [leanchecker](https://github.com/leanprover-community/lean/tree/master/src/checker), a bare-bones version of the Lean kernel.
 
 Hierarchical names
 ------------------

--- a/doc/faq.md
+++ b/doc/faq.md
@@ -51,7 +51,7 @@ The Emacs Lean mode is available via [MELPA](https://melpa.org/). The VS Code Le
 
 * Is Lean sound? How big is the kernel? Should I trust it?
 
-Lean has a relatively small kernel. The [leanchecker](https://github.com/leanprover/lean/tree/master/src/checker) is a bare-bones version of the Lean kernel.
+Lean has a relatively small kernel. The [leanchecker](https://github.com/leanprover-community/lean/tree/master/src/checker) is a bare-bones version of the Lean kernel.
 There are also two independent checkers: [tc](https://github.com/leanprover/tc) and [trepplein](https://github.com/gebner/trepplein).
 We have implemented several kernel extensions to improve performance and make sure the system is reasonably responsive for interactive use.
 We strongly recommend you frequently check your project without these extensions. The command line option `-t0` disables all of them.
@@ -60,6 +60,6 @@ If you are really concerned about soundness, we recommend you often export your 
 
 * Should I open a new issue?
 
-We use [github](https://github.com/leanprover/lean/issues) to track bugs and new features.
+We use [github](https://github.com/leanprover-community/lean/issues) to track bugs and new features.
 Bug reports are always welcome, but nitpicking issues are not (e.g., the error message is confusing).
 RFC issues are created by developers only.

--- a/doc/make/index.md
+++ b/doc/make/index.md
@@ -30,7 +30,7 @@ make
 Setting up a basic debug build using `make`:
 
 ```bash
-git clone https://github.com/leanprover/lean
+git clone https://github.com/leanprover-community/lean
 cd lean
 mkdir -p build/debug
 cd build/debug
@@ -46,7 +46,7 @@ Building JS / wasm binaries with Emscripten
 Setting up a basic release build using `make`:
 
 ```bash
-git clone https://github.com/leanprover/lean
+git clone https://github.com/leanprover-community/lean
 cd lean
 mkdir -p build/emscripten
 cd build/emscripten


### PR DESCRIPTION
[skip ci]
fixes #73

Update issue hyperlinks in documentation files.
It might be worth deleting the 'roadmap' section of the readme but that can be done elsewhere.
