### PR TITLE
Fix #55

### DIFF
--- a/src/frontends/lean/elaborator.cpp
+++ b/src/frontends/lean/elaborator.cpp
@@ -2630,8 +2630,8 @@ expr elaborator::visit_equation(expr const & e, unsigned num_fns) {
         }
         expr rhs     = instantiate_rev(equation_rhs(it), rhs_subst);
         expr new_rhs = visit(rhs, some_expr(new_lhs_type));
-        // synthesize_no_tactics();
-        // new_rhs       = instantiate_mvars(new_rhs);
+        synthesize_no_tactics();
+        new_rhs       = instantiate_mvars(new_rhs);
         new_rhs       = enforce_type(new_rhs, new_lhs_type, "equation type mismatch", it);
         expr new_eq = copy_tag(it, mk_equation(new_lhs, new_rhs, ignore_equation_if_unused(it)));
         expr r = copy_tag(ref, fns.mk_lambda(new_locals.mk_lambda(new_eq)));

--- a/src/frontends/lean/elaborator.cpp
+++ b/src/frontends/lean/elaborator.cpp
@@ -2630,8 +2630,8 @@ expr elaborator::visit_equation(expr const & e, unsigned num_fns) {
         }
         expr rhs     = instantiate_rev(equation_rhs(it), rhs_subst);
         expr new_rhs = visit(rhs, some_expr(new_lhs_type));
-        synthesize_no_tactics();
-        new_rhs       = instantiate_mvars(new_rhs);
+        // synthesize_no_tactics();
+        // new_rhs       = instantiate_mvars(new_rhs);
         new_rhs       = enforce_type(new_rhs, new_lhs_type, "equation type mismatch", it);
         expr new_eq = copy_tag(it, mk_equation(new_lhs, new_rhs, ignore_equation_if_unused(it)));
         expr r = copy_tag(ref, fns.mk_lambda(new_locals.mk_lambda(new_eq)));

--- a/src/library/type_context.cpp
+++ b/src/library/type_context.cpp
@@ -2354,7 +2354,8 @@ bool type_context_old::is_def_eq_binding(expr e1, expr e2) {
 
 optional<expr> type_context_old::mk_class_instance_at(local_context const & lctx, expr const & type) {
     if (m_cache->get_frozen_local_instances() &&
-        m_cache->get_frozen_local_instances() == lctx.get_frozen_local_instances()) {
+        m_cache->get_frozen_local_instances() == lctx.get_frozen_local_instances() &&
+        equal_locals(m_lctx, lctx)) {
         return mk_class_instance(type);
     } else {
         context_cacheless tmp_cache(*m_cache, true);

--- a/tests/lean/destructive_let_issue.lean
+++ b/tests/lean/destructive_let_issue.lean
@@ -1,0 +1,17 @@
+/- Bug documented at https://github.com/leanprover-community/lean/issues/55  -/
+
+example : bool :=
+  let x : false → Prop := λ x, match x with end in
+  let x : bool := match 4 with
+  | j := @to_bool (j = j) _
+  end in tt
+
+example : bool :=
+  let x := match 0 with y := ff end in
+  match 0 with
+  | k := k = k
+  end
+
+example : ℕ → bool
+| 0 := let _ := 3 in tt
+| (k+1) := k = k

--- a/tests/lean/destructive_let_issue.lean
+++ b/tests/lean/destructive_let_issue.lean
@@ -1,5 +1,9 @@
 /- Bug documented at https://github.com/leanprover-community/lean/issues/55  -/
 
+-- set_option trace.elaborator_detail true
+-- set_option trace.type_context.is_def_eq true
+-- set_option trace.type_context.is_def_eq_detail true
+
 example : bool :=
   let x : false → Prop := λ x, match x with end in
   let x : bool := match 4 with
@@ -13,5 +17,21 @@ example : bool :=
   end
 
 example : ℕ → bool
-| 0 := let _ := 3 in tt
+| 0 := tt
 | (k+1) := k = k
+
+example : ℕ → bool
+| 0 := let x := tt in tt
+| (k+1) := k = k
+
+example : ℕ → bool
+| 0 := let _ := tt in tt
+| (k+1) := k = k
+
+example : ℕ → bool
+| 0 := let _ := tt in tt
+| (k+1) := if k = k then tt else ff
+
+example : ℕ → bool
+| 0 := let _ := tt in tt
+| (k+1) := if h : k = k then tt else ff -- succeeds


### PR DESCRIPTION
Fixes #55 by adding an additional check to `type_context_old::mk_class_instance_at(lctx,type)`. There are cases where local contexts have the same frozen local instances but have different declarations, and this caused a unification to fail since the relevant locals were not added to the scope.