### PR TITLE
fix(library/check): do not assign metavariables in tactic.type_check

### DIFF
--- a/src/library/check.h
+++ b/src/library/check.h
@@ -14,7 +14,7 @@ namespace lean {
    This procedure is use to check the proof-term produced by tactics such as
    rewrite.
 */
-void check(type_context_old & ctx, expr const & e);
+void check(type_context_old & ctx, expr const & e, bool assign_mvars = true);
 void initialize_check();
 void finalize_check();
 }

--- a/src/library/tactic/tactic_state.cpp
+++ b/src/library/tactic/tactic_state.cpp
@@ -966,7 +966,8 @@ vm_obj tactic_type_check(vm_obj const & e, vm_obj const & m, vm_obj const & s0) 
     try {
         tactic_state_context_cache cache(s);
         type_context_old ctx = cache.mk_type_context(to_transparency_mode(m));
-        check(ctx, to_expr(e));
+        bool assign_mvars = false;
+        check(ctx, to_expr(e), assign_mvars);
         return tactic::mk_success(s);
     } catch (exception & ex) {
         return tactic::mk_exception(ex, s);

--- a/tests/lean/run/type_check_mvar.lean
+++ b/tests/lean/run/type_check_mvar.lean
@@ -1,0 +1,9 @@
+open tactic
+
+example : true := by do
+eq ← mk_const ``eq,
+ty ← mk_meta_univ >>= mk_meta_var ∘ expr.sort,
+let zero := `(0 : ℕ),
+let e := eq ty zero zero,
+success_if_fail $ type_check e,
+triv


### PR DESCRIPTION
The `tactic.type_check` function has a slightly surprising behavior: it can assign metavariables during type-checking.  For example the term `@eq.{?l_1} ?m_1 nat.zero nat.zero` type-checks according to `tactic.type_check` (where `?l_1` and `?m_1` are unassigned metavariables).  The tactic state is also not updated to reflect the metavariables assigned during type-checking.

This PR changes the behavior of `tactic.type_check` to *not* assign metavariables.