### PR TITLE
VM float cleanup

### DIFF
--- a/src/library/vm/init_module.cpp
+++ b/src/library/vm/init_module.cpp
@@ -52,6 +52,7 @@ void initialize_vm_core_module() {
 }
 
 void finalize_vm_core_module() {
+    finalize_vm_float();
     finalize_vm_string();
     finalize_vm_array();
     finalize_vm_parser();
@@ -72,7 +73,6 @@ void finalize_vm_core_module() {
     finalize_vm_int();
     finalize_vm_nat();
     finalize_vm_core();
-    finalize_vm_float();
 }
 
 void initialize_vm_module() {

--- a/src/library/vm/vm_float.cpp
+++ b/src/library/vm/vm_float.cpp
@@ -13,7 +13,7 @@ namespace lean{
 // [TODO] make a typedef or template for `float` so can generalise to other IEEE-754 impls.
 struct vm_float : public vm_external {
     float m_val;
-    vm_float(float const & v) : m_val(v) {}
+    vm_float(float v) : m_val(v) {}
     virtual ~vm_float() {}
     virtual void dealloc() override {
         this->~vm_float();
@@ -25,19 +25,18 @@ struct vm_float : public vm_external {
     }
 };
 
-vm_obj mk_vm_float(float d) {
+static vm_obj mk_vm_float(float d) {
     return mk_vm_external(new (get_vm_allocator().allocate(sizeof(vm_float))) vm_float(d));
 }
-optional<float> try_to_float(vm_obj const & o) {
-    if (LEAN_LIKELY(is_external(o))) {
-        float f = static_cast<vm_float*>(to_external(o))->m_val;
-        return optional<float>(f);
-    } else {
-        return optional<float>();
-    }
+
+vm_obj to_obj(float d) {
+    return mk_vm_float(d);
 }
+
 float to_float(vm_obj const & o) {
-    return try_to_float(o).value();
+    auto ext_vm_float = dynamic_cast<vm_float*>(to_external(o));
+    lean_vm_check(ext_vm_float);
+    return ext_vm_float->m_val;
 }
 
 vm_obj float_of_nat(vm_obj const & a) {

--- a/src/library/vm/vm_float.h
+++ b/src/library/vm/vm_float.h
@@ -5,8 +5,8 @@ Authors: E.W.Ayers, R.Y.Lewis */
 #include "library/vm/vm.h"
 
 namespace lean{
-double to_float(vm_obj const & o);
-optional<double> try_to_float(vm_obj const & o);
+vm_obj to_obj(float f);
+float to_float(vm_obj const & o);
 void initialize_vm_float();
 void finalize_vm_float();
 }


### PR DESCRIPTION
Fix the finalization order of the `vm_float` module and rename `mk_vm_float` to `to_obj` according to the naming convention.