### PR TITLE
Annotate pretty-printed output with full constant names

### DIFF
--- a/src/frontends/lean/pp.cpp
+++ b/src/frontends/lean/pp.cpp
@@ -929,7 +929,7 @@ auto pretty_fn::pp_field_notation(expr const & e) -> result {
     expr const & f   = get_app_args(e, args);
     bool ignore_hide = true;
     format s_fmt     = pp_child(args.back(), max_bp(), ignore_hide).fmt();
-    return result(max_bp()-1, s_fmt + format(".") + mk_link(const_name(f), format(const_name(f).get_string())));
+    return result(max_bp()+1, s_fmt + format(".") + mk_link(const_name(f), format(const_name(f).get_string())));
 }
 
 auto pretty_fn::pp_app(expr const & e) -> result {

--- a/src/frontends/lean/pp.h
+++ b/src/frontends/lean/pp.h
@@ -88,6 +88,7 @@ private:
     bool                    m_structure_projections;
     bool                    m_use_holes;
     bool                    m_annotations;
+    bool                    m_links;
 
     name mk_metavar_name(name const & m, optional<name> const & prefix = optional<name>());
     name mk_metavar_name(name const & m, name const & prefix) {
@@ -103,6 +104,10 @@ private:
     optional<name> is_aliased(name const & n) const;
 
     format escape(name const & n);
+
+    format mk_link(name const & dest, format const & body);
+    result mk_link(name const & dest, result const & body);
+    format mk_link(expr const & dest, format const & body);
 
     format pp_child(level const & l);
     format pp_max(level l);

--- a/src/frontends/lean/pp.h
+++ b/src/frontends/lean/pp.h
@@ -86,6 +86,7 @@ private:
     bool                    m_structure_instances;
     bool                    m_structure_instances_qualifier;
     bool                    m_structure_projections;
+    bool                    m_generalized_field_notation;
     bool                    m_use_holes;
     bool                    m_annotations;
     bool                    m_links;

--- a/src/library/local_context.cpp
+++ b/src/library/local_context.cpp
@@ -242,7 +242,8 @@ optional<local_decl> local_context::find_local_decl(name const & n) const {
 }
 
 optional<local_decl> local_context::find_local_decl(expr const & e) const {
-    lean_assert(is_local_decl_ref(e));
+    // lean_assert(is_local_decl_ref(e));
+    if (!is_local_decl_ref(e)) return {};
     return find_local_decl(mlocal_name(e));
 }
 

--- a/src/library/pp_options.cpp
+++ b/src/library/pp_options.cpp
@@ -120,6 +120,10 @@ Author: Leonardo de Moura
 #define LEAN_DEFAULT_PP_ANNOTATIONS false
 #endif
 
+#ifndef LEAN_DEFAULT_PP_LINKS
+#define LEAN_DEFAULT_PP_LINKS false
+#endif
+
 namespace lean {
 static name * g_pp_max_depth         = nullptr;
 static name * g_pp_max_steps         = nullptr;
@@ -148,6 +152,7 @@ static name * g_pp_structure_projections    = nullptr;
 static name * g_pp_instantiate_mvars = nullptr;
 static name * g_pp_use_holes         = nullptr;
 static name * g_pp_annotations       = nullptr;
+static name * g_pp_links             = nullptr;
 static name * g_pp_all               = nullptr;
 static list<options> * g_distinguishing_pp_options = nullptr;
 
@@ -180,6 +185,7 @@ void initialize_pp_options() {
     g_pp_instantiate_mvars = new name{"pp", "instantiate_mvars"};
     g_pp_use_holes         = new name{"pp", "use_holes"};
     g_pp_annotations       = new name{"pp", "annotations"};
+    g_pp_links             = new name{"pp", "links"};
 
     register_unsigned_option(*g_pp_max_depth, LEAN_DEFAULT_PP_MAX_DEPTH,
                              "(pretty printer) maximum expression depth, after that it will use ellipsis");
@@ -243,6 +249,8 @@ void initialize_pp_options() {
                          "(pretty printer) use holes '{! !}' when pretty printing metavariables and `sorry`");
     register_bool_option(*g_pp_annotations, LEAN_DEFAULT_PP_ANNOTATIONS,
                          "(pretty printer) display internal annotations (for debugging purposes only)");
+    register_bool_option(*g_pp_links, LEAN_DEFAULT_PP_LINKS,
+                         "(pretty printer) add links to constants using control characters");
 
     options universes_true(*g_pp_universes, true);
     options full_names_true(*g_pp_full_names, true);
@@ -336,4 +344,5 @@ bool     get_pp_instantiate_mvars(options const & o)    { return o.get_bool(*g_p
 bool     get_pp_use_holes(options const & o)            { return o.get_bool(*g_pp_use_holes, LEAN_DEFAULT_PP_USE_HOLES); }
 bool     get_pp_annotations(options const & o)          { return o.get_bool(*g_pp_annotations, LEAN_DEFAULT_PP_ANNOTATIONS); }
 bool     get_pp_all(options const & opts)               { return opts.get_bool(*g_pp_all, LEAN_DEFAULT_PP_ALL); }
+bool     get_pp_links(options const & opts)             { return opts.get_bool(*g_pp_links, LEAN_DEFAULT_PP_LINKS); }
 }

--- a/src/library/pp_options.cpp
+++ b/src/library/pp_options.cpp
@@ -108,6 +108,10 @@ Author: Leonardo de Moura
 #define LEAN_DEFAULT_PP_STRUCTURE_PROJECTIONS true
 #endif
 
+#ifndef LEAN_DEFAULT_PP_GENERALIZED_FIELD_NOTATION
+#define LEAN_DEFAULT_PP_GENERALIZED_FIELD_NOTATION false
+#endif
+
 #ifndef LEAN_DEFAULT_PP_INSTANTIATE_MVARS
 #define LEAN_DEFAULT_PP_INSTANTIATE_MVARS true
 #endif
@@ -149,6 +153,7 @@ static name * g_pp_delayed_abstraction = nullptr;
 static name * g_pp_structure_instances = nullptr;
 static name * g_pp_structure_instances_qualifier = nullptr;
 static name * g_pp_structure_projections    = nullptr;
+static name * g_pp_generalized_field_notation    = nullptr;
 static name * g_pp_instantiate_mvars = nullptr;
 static name * g_pp_use_holes         = nullptr;
 static name * g_pp_annotations       = nullptr;
@@ -182,6 +187,7 @@ void initialize_pp_options() {
     g_pp_structure_instances = new name{"pp", "structure_instances"};
     g_pp_structure_instances_qualifier = new name{"pp", "structure_instances_qualifier"};
     g_pp_structure_projections = new name{"pp", "structure_projections"};
+    g_pp_generalized_field_notation = new name{"pp", "generalized_field_notation"};
     g_pp_instantiate_mvars = new name{"pp", "instantiate_mvars"};
     g_pp_use_holes         = new name{"pp", "use_holes"};
     g_pp_annotations       = new name{"pp", "annotations"};
@@ -240,6 +246,8 @@ void initialize_pp_options() {
                          "this option is ignored when pp.structure_instances is false");
     register_bool_option(*g_pp_structure_projections, LEAN_DEFAULT_PP_STRUCTURE_PROJECTIONS,
                          "(pretty printer) display structure projections using field notation");
+    register_bool_option(*g_pp_generalized_field_notation, LEAN_DEFAULT_PP_GENERALIZED_FIELD_NOTATION,
+                         "(pretty printer) display function application using field notation if possible");
     register_bool_option(*g_pp_all, LEAN_DEFAULT_PP_ALL,
                          "(pretty printer) display coercions, implicit parameters, proof terms, fully qualified names, universes, "
                          "and disable beta reduction and notation during pretty printing");
@@ -339,6 +347,7 @@ bool     get_pp_hide_comp_irrel(options const & opts)   { return opts.get_bool(*
 bool     get_pp_delayed_abstraction(options const & opts) { return opts.get_bool(*g_pp_delayed_abstraction, LEAN_DEFAULT_PP_DELAYED_ABSTRACTION); }
 bool     get_pp_structure_instances(options const & opts) { return opts.get_bool(*g_pp_structure_instances, LEAN_DEFAULT_PP_STRUCTURE_INSTANCES); }
 bool     get_pp_structure_instances_qualifier(options const & opts) { return opts.get_bool(*g_pp_structure_instances_qualifier, LEAN_DEFAULT_PP_STRUCTURE_INSTANCES_QUALIFIER); }
+bool     get_pp_generalized_field_notation(options const & opts) { return opts.get_bool(*g_pp_generalized_field_notation, LEAN_DEFAULT_PP_GENERALIZED_FIELD_NOTATION); }
 bool     get_pp_structure_projections(options const & opts) { return opts.get_bool(*g_pp_structure_projections, LEAN_DEFAULT_PP_STRUCTURE_PROJECTIONS); }
 bool     get_pp_instantiate_mvars(options const & o)    { return o.get_bool(*g_pp_instantiate_mvars, LEAN_DEFAULT_PP_INSTANTIATE_MVARS); }
 bool     get_pp_use_holes(options const & o)            { return o.get_bool(*g_pp_use_holes, LEAN_DEFAULT_PP_USE_HOLES); }

--- a/src/library/pp_options.h
+++ b/src/library/pp_options.h
@@ -50,6 +50,7 @@ bool     get_pp_structure_projections(options const & opts);
 bool     get_pp_instantiate_mvars(options const & o);
 bool     get_pp_use_holes(options const & o);
 bool     get_pp_annotations(options const & o);
+bool     get_pp_links(options const & o);
 bool     get_pp_all(options const & opts);
 
 void initialize_pp_options();

--- a/src/library/pp_options.h
+++ b/src/library/pp_options.h
@@ -47,6 +47,7 @@ bool     get_pp_delayed_abstraction(options const & opts);
 bool     get_pp_structure_instances(options const & opts);
 bool     get_pp_structure_instances_qualifier(options const & opts);
 bool     get_pp_structure_projections(options const & opts);
+bool     get_pp_generalized_field_notation(options const & opts);
 bool     get_pp_instantiate_mvars(options const & o);
 bool     get_pp_use_holes(options const & o);
 bool     get_pp_annotations(options const & o);

--- a/src/library/type_context.cpp
+++ b/src/library/type_context.cpp
@@ -1227,7 +1227,9 @@ void type_context_old::ensure_num_tmp_mvars(unsigned num_uvars, unsigned num_mva
 
 optional<level> type_context_old::get_tmp_uvar_assignment(unsigned idx) const {
     lean_assert(in_tmp_mode());
-    lean_assert(idx < m_tmp_data->m_uassignment.size());
+    // FIXME(gabriel): this assertion is violated by postponed level assignments of temporary metavariables in the simplifier
+    // lean_assert(idx < m_tmp_data->m_uassignment.size());
+    if (idx >= m_tmp_data->m_uassignment.size()) return {};
     return m_tmp_data->m_uassignment[idx];
 }
 
@@ -1250,7 +1252,10 @@ optional<expr> type_context_old::get_tmp_assignment(expr const & e) const {
 void type_context_old::assign_tmp(level const & u, level const & l) {
     lean_assert(in_tmp_mode());
     lean_assert(is_idx_metauniv(u));
-    lean_assert(to_meta_idx(u) < m_tmp_data->m_uassignment.size());
+    // FIXME(gabriel): this assertion is violated by postponed level assignments of temporary metavariables in the simplifier
+    // lean_assert(to_meta_idx(u) < m_tmp_data->m_uassignment.size());
+    if (to_meta_idx(u) >= m_tmp_data->m_uassignment.size())
+        m_tmp_data->m_uassignment.resize(to_meta_idx(u) + 1);
     unsigned idx = to_meta_idx(u);
     if (!m_scopes.empty() && !m_tmp_data->m_uassignment[idx]) {
         m_tmp_data->m_trail.emplace_back(tmp_trail_kind::Level, idx);

--- a/tests/lean/1836.lean.expected.out
+++ b/tests/lean/1836.lean.expected.out
@@ -4,5 +4,5 @@ A : pType,
 B : Type,
 b : B,
 f : A.carrier → {carrier := B, Point := b}.carrier,
-pf : f (A.Point) = {carrier := B, Point := b}.Point
-⊢ b = f (A.Point) → pf == _ → {f := f, p := pf} = {f := f, p := pf}
+pf : f A.Point = {carrier := B, Point := b}.Point
+⊢ b = f A.Point → pf == _ → {f := f, p := pf} = {f := f, p := pf}

--- a/tests/lean/add_defn_eqns.lean.expected.out
+++ b/tests/lean/add_defn_eqns.lean.expected.out
@@ -52,7 +52,7 @@ def foo_append._main : Π {α : Type u}, list α → list α → list α :=
     (λ («_» : list α) (_F : list.below α «_»),
        (λ («_» : list α) (_F : list.below α «_»),
           list.cases_on «_» (λ (_F : list.below α list.nil), id_rhs (list α) xs)
-            (λ (hd : α) (tl : list α) (_F : list.below α (hd :: tl)), id_rhs (list α) (hd :: (_F.fst).fst))
+            (λ (hd : α) (tl : list α) (_F : list.below α (hd :: tl)), id_rhs (list α) (hd :: _F.fst.fst))
             _F)
          «_»
          _F)
@@ -81,7 +81,7 @@ def vec.map._main : Π {α : Type u} {β : Type v}, (α → β) → Π (n : ℕ)
                eq.rec
                  (λ («_» : vec α (nat.succ n_1))
                   (_F : nat.below (λ (n : ℕ), vec α n → vec β n) (nat.succ n_1)) (H_2 : «_» == vec.cons a a_1),
-                    eq.rec (id_rhs (vec β (nat.succ n_1)) (vec.cons (f a) ((_F.fst).fst a_1))) _)
+                    eq.rec (id_rhs (vec β (nat.succ n_1)) (vec.cons (f a) (_F.fst.fst a_1))) _)
                  _
                  «_»
                  _F)
@@ -119,7 +119,7 @@ def vec.map'._main : Π {α : Type u} {β : Type v}, (α → β) → Π {n : ℕ
                eq.rec
                  (λ («_» : vec α (nat.succ n_1))
                   (_F : nat.below (λ {n : ℕ}, vec α n → vec β n) (nat.succ n_1)) (H_2 : «_» == vec.cons a a_1),
-                    eq.rec (id_rhs (vec β (nat.succ n_1)) (vec.cons (f a) ((_F.fst).fst a_1))) _)
+                    eq.rec (id_rhs (vec β (nat.succ n_1)) (vec.cons (f a) (_F.fst.fst a_1))) _)
                  _
                  «_»
                  _F)

--- a/tests/lean/pp_generalized_field_notation.lean
+++ b/tests/lean/pp_generalized_field_notation.lean
@@ -1,0 +1,17 @@
+set_option pp.generalized_field_notation true
+
+#check int.nat_abs_zero
+#check int.sign_zero
+#check int.sign_mul_nat_abs
+
+lemma list.reverse_reverse {α} (xs : list α) : xs.reverse.reverse = xs :=
+sorry
+
+#check list.reverse_reverse
+
+def prod.swap {α β} : α × β → β × α | ⟨a, b⟩ := ⟨b, a⟩
+
+lemma prod.swap_swap {α β} (p : α × β) : p.swap.swap = p :=
+by cases p; refl
+
+#check prod.swap_swap

--- a/tests/lean/pp_generalized_field_notation.lean.expected.out
+++ b/tests/lean/pp_generalized_field_notation.lean.expected.out
@@ -2,5 +2,5 @@ int.nat_abs_zero : 0.nat_abs = 0
 int.sign_zero : 0.sign = 0
 int.sign_mul_nat_abs : ∀ (a : ℤ), a.sign * ↑(a.nat_abs) = a
 pp_generalized_field_notation.lean:7:0: warning: declaration 'list.reverse_reverse' uses sorry
-list.reverse_reverse : ∀ (xs : list ?M_1), (xs.reverse).reverse = xs
-prod.swap_swap : ∀ (p : ?M_1 × ?M_2), (p.swap).swap = p
+list.reverse_reverse : ∀ (xs : list ?M_1), xs.reverse.reverse = xs
+prod.swap_swap : ∀ (p : ?M_1 × ?M_2), p.swap.swap = p

--- a/tests/lean/pp_generalized_field_notation.lean.expected.out
+++ b/tests/lean/pp_generalized_field_notation.lean.expected.out
@@ -1,0 +1,6 @@
+int.nat_abs_zero : 0.nat_abs = 0
+int.sign_zero : 0.sign = 0
+int.sign_mul_nat_abs : ∀ (a : ℤ), a.sign * ↑(a.nat_abs) = a
+pp_generalized_field_notation.lean:7:0: warning: declaration 'list.reverse_reverse' uses sorry
+list.reverse_reverse : ∀ (xs : list ?M_1), (xs.reverse).reverse = xs
+prod.swap_swap : ∀ (p : ?M_1 × ?M_2), (p.swap).swap = p

--- a/tests/lean/pp_links.lean
+++ b/tests/lean/pp_links.lean
@@ -1,0 +1,8 @@
+open tactic
+
+structure point (α : Type*) :=
+(x : α) (y : α)
+
+example : ∀ i : ℤ, (i, i).snd = i + 0 + (point.mk 0 i).x := by do
+os ← get_options,
+set_options (os.set_bool `pp.links tt)

--- a/tests/lean/pp_links.lean.expected.out
+++ b/tests/lean/pp_links.lean.expected.out
@@ -1,0 +1,6 @@
+pp_links.lean:6:63: error: tactic failed, there are unsolved goals
+state:
+⊢ ∀ (i : intℤ),
+    (i, i).prod.sndsndeq =
+      ihas_add.add + 0has_add.add +
+        point.mk{point.xx := 0, point.yy := i}.point.xx

--- a/tests/lean/proj_notation.lean.expected.out
+++ b/tests/lean/proj_notation.lean.expected.out
@@ -2,9 +2,9 @@ p.fst : ℕ
 p.fst : ℕ
 p.snd : ℕ
 p.snd : ℕ
-f (p.fst) : ℕ
+f p.fst : ℕ
 p.fst + p.snd : ℕ
-λ (c : car), (c.pos).x : car → ℕ
+λ (c : car), c.pos.x : car → ℕ
 proj_notation.lean:29:19: error: invalid field notation, 'fst' is not a valid "field" because environment does not contain 'car.fst'
   c
 which has type
@@ -24,4 +24,4 @@ has type
 λ (n : ℕ), ⁇ : ℕ → ?M_1
 p.fst : ℕ
 p.snd : ℕ
-λ (c : car), (c.pos).y : car → ℕ
+λ (c : car), c.pos.y : car → ℕ


### PR DESCRIPTION
Motivation: we want to have links for all constants in the API documentation, even if they are behind notation.  See companion PR leanprover-community/doc-gen#3.

This PR adds the option `pp.links` which, if set to true, annotates things like `ℤ` and `+` and the `fst` in `p.fst` with the corresponding constant names (i.e., `int`, `has_add.add`, and `prod.fst`).  The markup syntax for this annotation is as follows:

`<U+E000>prod.fst<U+E001>fst<U+E002>`

The Unicode code points `U+E000`, `U+E001`, `U+E002` are taken from the Private Use Area.  Hopefully nobody uses them for anything else.