### PR TITLE
fix(build): generate emscripten zip for releases

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -141,10 +141,10 @@ matrix:
        - while sleep 5m; do echo "=====[ $SECONDS seconds ]====="; done & # https://blog.humphd.org/building-large-code-on-travis/
        - docker exec -it -e "OPTIONS=$OPTIONS" emscripten script/ci_emscripten_docker.sh
        - pkill -9 sleep
+       - bash script/ci_emscripten_zip.sh
        - |
          if [[ $GH_TOKEN && $TRAVIS_PULL_REQUEST == false && $TRAVIS_BRANCH == master ]]
           then
-          bash script/ci_emscripten_zip.sh
           bash script/deploy_nightly.sh build/lean-*
          fi
 


### PR DESCRIPTION
Previously, during travis jobs, the emscripten build was only stored in a ZIP under `build/` for builds on `master`. This change causes the ZIP file to be generated for all travis jobs, in particular, for release builds. 