### PR TITLE
feat(library/init/meta/interactive): make `add_interactive` copy doc …

### DIFF
--- a/library/init/meta/interactive.lean
+++ b/library/init/meta/interactive.lean
@@ -1559,6 +1559,10 @@ private meta def add_interactive_aux (new_namespace : name) : list name → comm
   (name.mk_string h _) ← return d_name,
   let new_name := `tactic.interactive <.> h,
   add_decl (declaration.defn new_name ls ty (expr.const d_name (ls.map level.param)) hints trusted),
+  do {
+    doc ← doc_string d_name,
+    add_doc_string new_name doc
+  } <|> skip,
   add_interactive_aux ns
 
 /--

--- a/library/init/meta/interactive.lean
+++ b/library/init/meta/interactive.lean
@@ -1557,7 +1557,7 @@ private meta def add_interactive_aux (new_namespace : name) : list name → comm
   d_name ← resolve_constant n,
   (declaration.defn _ ls ty val hints trusted) ← env.get d_name,
   (name.mk_string h _) ← return d_name,
-  let new_name := `tactic.interactive <.> h,
+  let new_name := new_namespace <.> h,
   add_decl (declaration.defn new_name ls ty (expr.const d_name (ls.map level.param)) hints trusted),
   do {
     doc ← doc_string d_name,

--- a/tests/lean/run/add_interactive.lean
+++ b/tests/lean/run/add_interactive.lean
@@ -8,6 +8,9 @@ tactic.interactive.exact q
 
 /- Copy tactic my_exact to tactic.interactive. -/
 run_cmd add_interactive [`my_exact]
+
+/- Copy tactic my_exact to test_namespace. -/
+run_cmd add_interactive [`my_exact] `test_namespace
 end bla
 
 example : true :=
@@ -20,6 +23,11 @@ open tactic
 run_cmd do
   old_doc ← doc_string `foo.bla.my_exact,
   new_doc ← doc_string `tactic.interactive.my_exact,
-  if old_doc = new_doc then skip else fail "doc strings do not match"
+  if old_doc = new_doc then skip else fail "doc strings of foo.bla.my_exact and tactic.interactive.my_exact do not match"
+
+run_cmd do
+  old_doc ← doc_string `foo.bla.my_exact,
+  new_doc ← doc_string `test_namespace.my_exact,
+  if old_doc = new_doc then skip else fail "doc strings of foo.bla.my_exact and test_namespace.my_exact do not match"
 
 end foo

--- a/tests/lean/run/add_interactive.lean
+++ b/tests/lean/run/add_interactive.lean
@@ -2,6 +2,7 @@ namespace foo
 namespace bla
 open lean.parser interactive interactive.types
 
+/-- test doc string -/
 meta def my_exact (q : parse texpr) :=
 tactic.interactive.exact q
 
@@ -13,4 +14,12 @@ example : true :=
 begin
   my_exact trivial
 end
+
+open tactic
+
+run_cmd do
+  old_doc ← doc_string `foo.bla.my_exact,
+  new_doc ← doc_string `tactic.interactive.my_exact,
+  if old_doc = new_doc then skip else fail "doc strings do not match"
+
 end foo


### PR DESCRIPTION
…string

I noticed that some tactics in mathlib (`pi_instance`, `fsplit`, `injections_and_clear`) that were created by `add_interactive` did not carry over their docstrings. This should fix that.

# Pull Request Description

Ensure you have read the contribution guide before filling in a description of the
pull request, regardless of whether it is complete or a work in progress.
All Pull Requests should include test case(s) which demonstrates the intended
behavior of a feature, or a regression test demonstrating that the fix resolves
the issue.
