### PR TITLE
feat(library/init/meta/simp_tactic) `simp` with reversed lemmas

### DIFF
--- a/library/init/meta/interactive.lean
+++ b/library/init/meta/interactive.lean
@@ -1193,6 +1193,12 @@ meta def mk_simp_set_core (no_dflt : bool) (attr_names : list name) (hs : list s
 do (hs, gex, hex, all_hyps) ← decode_simp_arg_list_with_symm hs,
    when (all_hyps ∧ at_star ∧ not hex.empty) $ fail "A tactic of the form `simp [*, -h] at *` is currently not supported",
    s      ← join_user_simp_lemmas no_dflt attr_names,
+   -- Erase `h` from the default simp set for calls of the form `simp [←h]`.
+   let to_erase := hs.foldl (λ l h, match h with
+                                    | (const id _, tt) := id :: l
+                                    | _ := l
+                                    end ) [],
+   let s := s.erase to_erase,
    (s, u) ← simp_lemmas.append_pexprs s [] hs,
    s      ← if not at_star ∧ all_hyps then do
               ctx ← collect_ctx_simps,

--- a/library/init/meta/interactive.lean
+++ b/library/init/meta/interactive.lean
@@ -1197,7 +1197,7 @@ do (hs, gex, hex, all_hyps) ← decode_simp_arg_list_with_symm hs,
    s      ← if not at_star ∧ all_hyps then do
               ctx ← collect_ctx_simps,
               let ctx := ctx.filter (λ h, h.local_uniq_name ∉ hex), -- remove local exceptions
-              s.append (ctx.map (λ h, (h, ff)))
+              s.append ctx
             else return s,
    -- add equational lemmas, if any
    gex ← gex.mmap (λ n, list.cons n <$> get_eqn_lemmas_for tt n),

--- a/library/init/meta/interactive.lean
+++ b/library/init/meta/interactive.lean
@@ -1203,7 +1203,7 @@ The `simp` tactic uses lemmas and hypotheses to simplify the main goal target or
 
 `simp` simplifies the main goal target using lemmas tagged with the attribute `[simp]`.
 
-`simp [h₁ h₂ ... hₙ]` simplifies the main goal target using the lemmas tagged with the attribute `[simp]` and the given `hᵢ`'s, where the `hᵢ`'s are expressions. If an `hᵢ` is a defined constant `f`, then the equational lemmas associated with `f` are used. This provides a convenient way to unfold `f`.
+`simp [h₁ h₂ ... hₙ]` simplifies the main goal target using the lemmas tagged with the attribute `[simp]` and the given `hᵢ`'s, where the `hᵢ`'s are expressions. If `hᵢ` is preceded by left arrow (`←` or `<-`), the simplification is performed in the reverse direction. If an `hᵢ` is a defined constant `f`, then the equational lemmas associated with `f` are used. This provides a convenient way to unfold `f`.
 
 `simp [*]` simplifies the main goal target using the lemmas tagged with the attribute `[simp]` and all hypotheses.
 

--- a/library/init/meta/interactive.lean
+++ b/library/init/meta/interactive.lean
@@ -1096,16 +1096,16 @@ private meta def resolve_exception_ids (all_hyps : bool) : list name → list na
 -/
 meta def decode_simp_arg_list (hs : list simp_arg_type) : tactic $ list pexpr × list name × list name × bool :=
 do
-  (hs, ex, all) ← hs.foldl
-    (λ (r : tactic (list pexpr × list name × bool)) h, do
-      (es, ex, all) ← r,
+  (hs, ex, all) ← hs.mfoldl
+    (λ (r : (list pexpr × list name × bool)) h, do
+      let (es, ex, all) := r,
       match h with
       | simp_arg_type.all_hyps    := pure (es, ex, tt)
       | simp_arg_type.except id   := pure (es, id::ex, all)
       | simp_arg_type.expr e      := pure (e::es, ex, all)
       | simp_arg_type.symm_expr _ := fail "arguments of the form '←...' are not supported"
       end)
-    (pure ([], [], ff) ),
+    ([], [], ff),
   (gex, hex) ← resolve_exception_ids all ex [] [],
   return (hs.reverse, gex, hex, all)
 

--- a/library/init/meta/interactive.lean
+++ b/library/init/meta/interactive.lean
@@ -1058,6 +1058,14 @@ meta inductive simp_arg_type : Type
 | expr      : pexpr → simp_arg_type
 | symm_expr : pexpr → simp_arg_type
 
+meta instance simp_arg_type_to_tactic_format : has_to_tactic_format simp_arg_type :=
+⟨λ a, match a with
+| simp_arg_type.all_hyps := pure "*"
+| (simp_arg_type.except n) := pure format!"-{n}"
+| (simp_arg_type.expr e) := i_to_expr_no_subgoals e >>= pp
+| (simp_arg_type.symm_expr e) := ((++) "←") <$> (i_to_expr_no_subgoals e >>= pp)
+end⟩
+
 meta def simp_arg : parser simp_arg_type :=
 (tk "*" *> return simp_arg_type.all_hyps) <|>
 (tk "-" *> simp_arg_type.except <$> ident) <|>

--- a/library/init/meta/interactive.lean
+++ b/library/init/meta/interactive.lean
@@ -1060,7 +1060,7 @@ meta inductive simp_arg_type : Type
 meta def simp_arg : parser simp_arg_type :=
 (tk "*" *> return simp_arg_type.all_hyps) <|>
 (tk "-" *> simp_arg_type.except <$> ident) <|>
-(tk "!" *> simp_arg_type.expr tt <$> texpr) <|> -- TODO: why doesn't "←" get parsed?
+(tk "<-" *> simp_arg_type.expr tt <$> texpr) <|>
 (simp_arg_type.expr ff <$> texpr)
 
 meta def simp_arg_list : parser (list simp_arg_type) :=

--- a/library/init/meta/simp_tactic.lean
+++ b/library/init/meta/simp_tactic.lean
@@ -358,7 +358,7 @@ meta def simp_intros_aux (cfg : simp_config) (use_hyps : bool) (to_unfold : list
       assertv_core h_d.local_pp_name new_d h_new_d,
       clear h_d,
       h_new   ← intro1,
-      new_S ← if use_hyps then mcond (is_prop new_d) (S.add h_new false) (return S)
+      new_S ← if use_hyps then mcond (is_prop new_d) (S.add h_new ff) (return S)
               else return S,
       simp_intros_aux new_S use_ns ns.tail
     }

--- a/library/init/meta/simp_tactic.lean
+++ b/library/init/meta/simp_tactic.lean
@@ -43,9 +43,9 @@ If your lemma is not being added, you can see the reasons by setting `set_option
 - `LHS` should not occur within a hypothesis `hᵢ`.
 
  -/
-meta constant simp_lemmas.add : simp_lemmas → expr → bool → tactic simp_lemmas
+meta constant simp_lemmas.add (s : simp_lemmas) (e : expr) (symm : bool := false) : tactic simp_lemmas
 /-- Add a simplification lemma by it's declaration name. See `simp_lemmas.add` for more information.-/
-meta constant simp_lemmas.add_simp : simp_lemmas → name → bool → tactic simp_lemmas
+meta constant simp_lemmas.add_simp (s : simp_lemmas) (id : name) (symm : bool := false) : tactic simp_lemmas
 /-- Adds a congruence simp lemma to simp_lemmas.
 A congruence simp lemma is a lemma that breaks the simplification down into separate problems.
 For example, to simplify `a ∧ b` to `c ∧ d`, we should try to simp `a` to `c` and `b` to `d`.

--- a/library/init/meta/simp_tactic.lean
+++ b/library/init/meta/simp_tactic.lean
@@ -43,9 +43,9 @@ If your lemma is not being added, you can see the reasons by setting `set_option
 - `LHS` should not occur within a hypothesis `hᵢ`.
 
  -/
-meta constant simp_lemmas.add : simp_lemmas → expr → tactic simp_lemmas
+meta constant simp_lemmas.add : simp_lemmas → expr → bool → tactic simp_lemmas
 /-- Add a simplification lemma by it's declaration name. See `simp_lemmas.add` for more information.-/
-meta constant simp_lemmas.add_simp : simp_lemmas → name → tactic simp_lemmas
+meta constant simp_lemmas.add_simp : simp_lemmas → name → bool → tactic simp_lemmas
 /-- Adds a congruence simp lemma to simp_lemmas.
 A congruence simp lemma is a lemma that breaks the simplification down into separate problems.
 For example, to simplify `a ∧ b` to `c ∧ d`, we should try to simp `a` to `c` and `b` to `d`.
@@ -58,8 +58,8 @@ lemma and_congr (h₁ : a ↔ c) (h₂ : b ↔ d) : (a ∧ b) ↔ (c ∧ d) := .
 -/
 meta constant simp_lemmas.add_congr : simp_lemmas → name → tactic simp_lemmas
 
-meta def simp_lemmas.append (s : simp_lemmas) (hs : list expr) : tactic simp_lemmas :=
-hs.mfoldl simp_lemmas.add s
+meta def simp_lemmas.append (s : simp_lemmas) (hs : list (expr × bool)) : tactic simp_lemmas :=
+hs.mfoldl (λ s h, simp_lemmas.add s h.fst h.snd) s
 
 /-- `simp_lemmas.rewrite s e prove R` apply a simplification lemma from 's'
 
@@ -358,7 +358,7 @@ meta def simp_intros_aux (cfg : simp_config) (use_hyps : bool) (to_unfold : list
       assertv_core h_d.local_pp_name new_d h_new_d,
       clear h_d,
       h_new   ← intro1,
-      new_S ← if use_hyps then mcond (is_prop new_d) (S.add h_new) (return S)
+      new_S ← if use_hyps then mcond (is_prop new_d) (S.add h_new false) (return S)
               else return S,
       simp_intros_aux new_S use_ns ns.tail
     }
@@ -391,7 +391,7 @@ do (lhs, rhs)     ← target >>= match_eq,
 
 meta def to_simp_lemmas : simp_lemmas → list name → tactic simp_lemmas
 | S []      := return S
-| S (n::ns) := do S' ← S.add_simp n, to_simp_lemmas S' ns
+| S (n::ns) := do S' ← S.add_simp n ff, to_simp_lemmas S' ns
 
 meta def mk_simp_attr (attr_name : name) (attr_deps : list name := []) : command :=
 do let t := `(user_attribute simp_lemmas),
@@ -494,7 +494,7 @@ meta structure simp_all_entry :=
 (s        : simp_lemmas) -- simplification lemmas for simplifying new_type
 
 private meta def update_simp_lemmas (es : list simp_all_entry) (h : expr) : tactic (list simp_all_entry) :=
-es.mmap $ λ e, do new_s ← e.s.add h, return {s := new_s, ..e}
+es.mmap $ λ e, do new_s ← e.s.add h ff, return {s := new_s, ..e} -- TODO: add symmetry here?
 
 /- Helper tactic for `init`.
    Remark: the following tactic is quadratic on the length of list expr (the list of non dependent propositions).
@@ -503,7 +503,7 @@ private meta def init_aux : list expr → simp_lemmas → list simp_all_entry �
 | []      s r := return (s, r)
 | (h::hs) s r := do
   new_r  ← update_simp_lemmas r h,
-  new_s  ← s.add h,
+  new_s  ← s.add h ff, -- TODO: add symmetry here?
   h_type ← infer_type h,
   init_aux hs new_s (⟨h, h_type, none, s⟩::new_r)
 
@@ -551,7 +551,7 @@ private meta def loop (cfg : simp_config) (discharger : tactic unit) (to_unfold 
        new_es      ← update_simp_lemmas es new_fact_pr,
        new_r       ← update_simp_lemmas r new_fact_pr,
        let new_r := {new_type := new_h_type, pr := new_pr, ..e} :: new_r,
-       new_s       ← s.add new_fact_pr,
+       new_s       ← s.add new_fact_pr ff, -- TODO: add symmetry here?
        loop new_es new_r new_s tt
 
 meta def simp_all (s : simp_lemmas) (to_unfold : list name) (cfg : simp_config := {}) (discharger : tactic unit := failed) : tactic unit :=

--- a/library/init/meta/simp_tactic.lean
+++ b/library/init/meta/simp_tactic.lean
@@ -58,8 +58,21 @@ lemma and_congr (h₁ : a ↔ c) (h₂ : b ↔ d) : (a ∧ b) ↔ (c ∧ d) := .
 -/
 meta constant simp_lemmas.add_congr : simp_lemmas → name → tactic simp_lemmas
 
-meta def simp_lemmas.append (s : simp_lemmas) (hs : list (expr × bool)) : tactic simp_lemmas :=
+/-- Add expressions to a set of simp lemmas using `simp_lemmas.add`.
+
+  This is the new version of `simp_lemmas.append`,
+  which also allows you to set the `symm` flag.
+-/
+meta def simp_lemmas.append_with_symm (s : simp_lemmas) (hs : list (expr × bool)) :
+  tactic simp_lemmas :=
 hs.mfoldl (λ s h, simp_lemmas.add s h.fst h.snd) s
+/-- Add expressions to a set of simp lemmas using `simp_lemmas.add`.
+
+  This is the backwards-compatibility version of `simp_lemmas.append_with_symm`,
+  and sets all `symm` flags to `ff`.
+-/
+meta def simp_lemmas.append (s : simp_lemmas) (hs : list expr) : tactic simp_lemmas :=
+hs.mfoldl (λ s h, simp_lemmas.add s h ff) s
 
 /-- `simp_lemmas.rewrite s e prove R` apply a simplification lemma from 's'
 

--- a/library/init/meta/simp_tactic.lean
+++ b/library/init/meta/simp_tactic.lean
@@ -494,7 +494,7 @@ meta structure simp_all_entry :=
 (s        : simp_lemmas) -- simplification lemmas for simplifying new_type
 
 private meta def update_simp_lemmas (es : list simp_all_entry) (h : expr) : tactic (list simp_all_entry) :=
-es.mmap $ λ e, do new_s ← e.s.add h ff, return {s := new_s, ..e} -- TODO: add symmetry here?
+es.mmap $ λ e, do new_s ← e.s.add h ff, return {s := new_s, ..e}
 
 /- Helper tactic for `init`.
    Remark: the following tactic is quadratic on the length of list expr (the list of non dependent propositions).
@@ -503,7 +503,7 @@ private meta def init_aux : list expr → simp_lemmas → list simp_all_entry �
 | []      s r := return (s, r)
 | (h::hs) s r := do
   new_r  ← update_simp_lemmas r h,
-  new_s  ← s.add h ff, -- TODO: add symmetry here?
+  new_s  ← s.add h ff,
   h_type ← infer_type h,
   init_aux hs new_s (⟨h, h_type, none, s⟩::new_r)
 
@@ -551,7 +551,7 @@ private meta def loop (cfg : simp_config) (discharger : tactic unit) (to_unfold 
        new_es      ← update_simp_lemmas es new_fact_pr,
        new_r       ← update_simp_lemmas r new_fact_pr,
        let new_r := {new_type := new_h_type, pr := new_pr, ..e} :: new_r,
-       new_s       ← s.add new_fact_pr ff, -- TODO: add symmetry here?
+       new_s       ← s.add new_fact_pr ff,
        loop new_es new_r new_s tt
 
 meta def simp_all (s : simp_lemmas) (to_unfold : list name) (cfg : simp_config := {}) (discharger : tactic unit := failed) : tactic unit :=

--- a/library/init/meta/well_founded_tactics.lean
+++ b/library/init/meta/well_founded_tactics.lean
@@ -59,9 +59,10 @@ meta def process_lex : tactic unit → tactic unit
 private meta def unfold_sizeof_measure : tactic unit :=
 dunfold_target [``sizeof_measure, ``measure, ``inv_image] {fail_if_unchanged := ff}
 
+-- TODO: why not re-use `add_simps` used by `simp` itself?
 private meta def add_simps : simp_lemmas → list name → tactic simp_lemmas
 | s []      := return s
-| s (n::ns) := do s' ← s.add_simp n, add_simps s' ns
+| s (n::ns) := do s' ← s.add_simp n ff, add_simps s' ns
 
 private meta def collect_sizeof_lemmas (e : expr) : tactic simp_lemmas :=
 e.mfold simp_lemmas.mk $ λ c d s,

--- a/library/init/meta/well_founded_tactics.lean
+++ b/library/init/meta/well_founded_tactics.lean
@@ -59,7 +59,6 @@ meta def process_lex : tactic unit → tactic unit
 private meta def unfold_sizeof_measure : tactic unit :=
 dunfold_target [``sizeof_measure, ``measure, ``inv_image] {fail_if_unchanged := ff}
 
--- TODO: why not re-use `add_simps` used by `simp` itself?
 private meta def add_simps : simp_lemmas → list name → tactic simp_lemmas
 | s []      := return s
 | s (n::ns) := do s' ← s.add_simp n ff, add_simps s' ns

--- a/src/library/inductive_compiler/nested.cpp
+++ b/src/library/inductive_compiler/nested.cpp
@@ -904,7 +904,7 @@ class add_nested_inductive_decl_fn {
                 m_env = add_protected(m_env, sizeof_spec_name);
                 m_tctx.set_env(m_env);
 
-                m_nested_decl.set_sizeof_lemmas(add(m_tctx, m_nested_decl.get_sizeof_lemmas(), sizeof_spec_name, LEAN_DEFAULT_PRIORITY));
+                m_nested_decl.set_sizeof_lemmas(add(m_tctx, m_nested_decl.get_sizeof_lemmas(), sizeof_spec_name, false, LEAN_DEFAULT_PRIORITY));
             }
         }
     }
@@ -1243,7 +1243,7 @@ class add_nested_inductive_decl_fn {
             expr ty = Pi(m_nested_decl.get_params(), Pi(slemma.m_to_abstract, mk_eq(m_tctx, slemma.m_lhs, slemma.m_rhs)));
             expr pf = Fun(m_nested_decl.get_params(), Fun(slemma.m_to_abstract, mk_eq_refl(m_tctx, slemma.m_lhs)));
             define_theorem(n, ty, pf);
-            m_lemmas = add(m_tctx, m_lemmas, n, LEAN_DEFAULT_PRIORITY);
+            m_lemmas = add(m_tctx, m_lemmas, n, false, LEAN_DEFAULT_PRIORITY);
         }
 
         prove_nested_pack_unpack(start, end, c_nested_pack, c_nested_unpack, indices, nest_idx);
@@ -1425,7 +1425,7 @@ class add_nested_inductive_decl_fn {
             expr ty = Pi(m_nested_decl.get_params(), Pi(slemma.m_to_abstract, mk_eq(m_tctx, slemma.m_lhs, slemma.m_rhs)));
             expr pf = Fun(m_nested_decl.get_params(), Fun(slemma.m_to_abstract, force_recursors(slemma.m_lhs)));
             define_theorem(n, ty, pf);
-            m_lemmas = add(m_tctx, m_lemmas, n, LEAN_DEFAULT_PRIORITY);
+            m_lemmas = add(m_tctx, m_lemmas, n, false, LEAN_DEFAULT_PRIORITY);
         }
 
         prove_primitive_pack_unpack(indices);
@@ -1568,7 +1568,7 @@ class add_nested_inductive_decl_fn {
         simp_lemmas all_lemmas = use_sizeof ? join(m_lemmas, m_nested_decl.get_sizeof_lemmas()) : m_lemmas;
         for (expr const & H : Hs) {
             expr H_type = tctx_whnf.infer(H);
-            all_lemmas = add(tctx_whnf, all_lemmas, mlocal_name(H), H_type, H, LEAN_DEFAULT_PRIORITY);
+            all_lemmas = add(tctx_whnf, all_lemmas, mlocal_name(H), H_type, H, false, LEAN_DEFAULT_PRIORITY);
         }
         lean_trace(name({"inductive_compiler", "nested", "simp", "start"}), tout() << thm << "\n";);
         simp_config cfg = get_simp_config();
@@ -1627,7 +1627,7 @@ class add_nested_inductive_decl_fn {
         expr primitive_pack_unpack_type = Pi(m_nested_decl.get_params(), Pi(index_locals, Pi(x_packed, goal)));
         expr primitive_pack_unpack_val = prove_by_induction_simp(rec_name, primitive_pack_unpack_type, false);
         define_theorem(n, primitive_pack_unpack_type, primitive_pack_unpack_val);
-        m_lemmas = add(m_tctx, m_lemmas, n, LEAN_DEFAULT_PRIORITY);
+        m_lemmas = add(m_tctx, m_lemmas, n, false, LEAN_DEFAULT_PRIORITY);
     }
 
     void prove_primitive_unpack_pack(buffer<expr> const & index_locals) {
@@ -1639,7 +1639,7 @@ class add_nested_inductive_decl_fn {
         expr primitive_unpack_pack_type = Pi(m_nested_decl.get_params(), Pi(index_locals, Pi(x_unpacked, goal)));
         expr primitive_unpack_pack_val = prove_by_induction_simp(rec_name, primitive_unpack_pack_type, false);
         define_theorem(n, primitive_unpack_pack_type, primitive_unpack_pack_val);
-        m_lemmas = add(m_tctx, m_lemmas, n, LEAN_DEFAULT_PRIORITY);
+        m_lemmas = add(m_tctx, m_lemmas, n, false, LEAN_DEFAULT_PRIORITY);
     }
 
     void prove_primitive_pack_sizeof(buffer<expr> const & index_locals) {
@@ -1655,7 +1655,7 @@ class add_nested_inductive_decl_fn {
         expr primitive_sizeof_pack_val = prove_by_induction_simp(rec_name, primitive_sizeof_pack_type, true);
         define_theorem(n, primitive_sizeof_pack_type, primitive_sizeof_pack_val);
         tctx_synth.set_env(m_env);
-        m_lemmas = add(tctx_synth, m_lemmas, n, LEAN_DEFAULT_PRIORITY);
+        m_lemmas = add(tctx_synth, m_lemmas, n, false, LEAN_DEFAULT_PRIORITY);
     }
 
     void prove_primitive_pack_injective() {
@@ -1669,7 +1669,7 @@ class add_nested_inductive_decl_fn {
         expr proof = prove_pack_injective(lemma_name, goal, mk_primitive_name(fn_type::UNPACK), mk_primitive_name(fn_type::UNPACK_PACK));
         m_env = module::add(m_env, check(m_env, mk_definition_inferring_trusted(m_env, lemma_name, to_list(m_nested_decl.get_lp_names()), goal, proof, true)));
         m_tctx.set_env(m_env);
-        m_inj_lemmas = add(m_tctx, m_inj_lemmas, lemma_name, LEAN_DEFAULT_PRIORITY);
+        m_inj_lemmas = add(m_tctx, m_inj_lemmas, lemma_name, false, LEAN_DEFAULT_PRIORITY);
     }
 
     void prove_nested_pack_unpack(expr const & start, expr const & end, expr const & nested_pack, expr const & nested_unpack, buffer<expr> const & index_locals, unsigned nest_idx) {
@@ -1681,7 +1681,7 @@ class add_nested_inductive_decl_fn {
         expr nested_pack_unpack_type = Pi(m_nested_decl.get_params(), Pi(index_locals, Pi(x_packed, goal)));
         expr nested_pack_unpack_val = prove_by_induction_simp(rec_name, nested_pack_unpack_type, false);
         define_theorem(n, nested_pack_unpack_type, nested_pack_unpack_val);
-        m_lemmas = add(m_tctx, m_lemmas, n, LEAN_DEFAULT_PRIORITY);
+        m_lemmas = add(m_tctx, m_lemmas, n, false, LEAN_DEFAULT_PRIORITY);
     }
 
     void prove_nested_unpack_pack(expr const & start, expr const & /* end */, expr const & nested_pack, expr const & nested_unpack, buffer<expr> const & index_locals, unsigned nest_idx) {
@@ -1693,7 +1693,7 @@ class add_nested_inductive_decl_fn {
         expr nested_unpack_pack_type = Pi(m_nested_decl.get_params(), Pi(index_locals, Pi(x_unpacked, goal)));
         expr nested_unpack_pack_val = prove_by_induction_simp(rec_name, nested_unpack_pack_type, false);
         define_theorem(n, nested_unpack_pack_type, nested_unpack_pack_val);
-        m_lemmas = add(m_tctx, m_lemmas, n, LEAN_DEFAULT_PRIORITY);
+        m_lemmas = add(m_tctx, m_lemmas, n, false, LEAN_DEFAULT_PRIORITY);
     }
 
     void prove_nested_pack_sizeof(expr const & start, expr const & /* end */, expr const & nested_pack, buffer<expr> const & index_locals, unsigned nest_idx) {
@@ -1709,7 +1709,7 @@ class add_nested_inductive_decl_fn {
         expr nested_sizeof_pack_val = prove_by_induction_simp(rec_name, nested_sizeof_pack_type, true);
         define_theorem(n, nested_sizeof_pack_type, nested_sizeof_pack_val);
         tctx_synth.set_env(m_env);
-        m_lemmas = add(tctx_synth, m_lemmas, n, LEAN_DEFAULT_PRIORITY);
+        m_lemmas = add(tctx_synth, m_lemmas, n, false, LEAN_DEFAULT_PRIORITY);
     }
 
     void prove_nested_pack_injective(unsigned nest_idx) {
@@ -1723,7 +1723,7 @@ class add_nested_inductive_decl_fn {
         expr proof = prove_pack_injective(lemma_name, goal, mk_nested_name(fn_type::UNPACK, nest_idx), mk_nested_name(fn_type::UNPACK_PACK, nest_idx));
         m_env = module::add(m_env, check(m_env, mk_definition_inferring_trusted(m_env, lemma_name, to_list(m_nested_decl.get_lp_names()), goal, proof, true)));
         m_tctx.set_env(m_env);
-        m_inj_lemmas = add(m_tctx, m_inj_lemmas, lemma_name, LEAN_DEFAULT_PRIORITY);
+        m_inj_lemmas = add(m_tctx, m_inj_lemmas, lemma_name, false, LEAN_DEFAULT_PRIORITY);
     }
 
     expr prove_by_funext(expr const & goal, expr const & fn1, expr const & fn2) {
@@ -1805,7 +1805,7 @@ class add_nested_inductive_decl_fn {
         }
         define_theorem(n, pi_unpack_pack_type, pi_unpack_pack_val);
         m_env = set_simp_sizeof(m_env, n);
-        m_nested_decl.set_sizeof_lemmas(add(m_tctx, m_nested_decl.get_sizeof_lemmas(), n, LEAN_DEFAULT_PRIORITY));
+        m_nested_decl.set_sizeof_lemmas(add(m_tctx, m_nested_decl.get_sizeof_lemmas(), n, false, LEAN_DEFAULT_PRIORITY));
         m_tctx.set_env(m_env);
     }
 
@@ -1820,7 +1820,7 @@ class add_nested_inductive_decl_fn {
         expr proof = prove_pack_injective(lemma_name, goal, mk_pi_name(fn_type::UNPACK), mk_pi_name(fn_type::UNPACK_PACK));
         m_env = module::add(m_env, check(m_env, mk_definition_inferring_trusted(m_env, lemma_name, to_list(m_nested_decl.get_lp_names()), goal, proof, true)));
         m_tctx.set_env(m_env);
-        m_inj_lemmas = add(m_tctx, m_inj_lemmas, lemma_name, LEAN_DEFAULT_PRIORITY);
+        m_inj_lemmas = add(m_tctx, m_inj_lemmas, lemma_name, false, LEAN_DEFAULT_PRIORITY);
     }
 
     ////////////////////////////////////////////
@@ -2201,7 +2201,7 @@ class add_nested_inductive_decl_fn {
                 simp_config cfg = get_simp_config();
                 defeq_can_state dcs;
                 simp_lemmas slss;
-                slss = add(tctx, slss, hyp_decl.get_name(), hyp_decl.get_type(), hyp_decl.mk_ref(), LEAN_DEFAULT_PRIORITY);
+                slss = add(tctx, slss, hyp_decl.get_name(), hyp_decl.get_type(), hyp_decl.mk_ref(), false, LEAN_DEFAULT_PRIORITY);
                 simp_result r = finalize(tctx, get_eq_name(), simplify_fn(tctx, dcs, slss, list<name>(), cfg)(get_eq_name(), s.get_main_goal_decl()->get_type()));
                 lean_verify(is_eq(r.get_new(), lhs, rhs));
                 lean_assert(tctx.is_def_eq(lhs, rhs));
@@ -2213,7 +2213,7 @@ class add_nested_inductive_decl_fn {
                     local_decl H_unpack_decl = tctx.lctx().get_local_decl(new_hyps.back());
 
                     slss = simp_lemmas();
-                    slss = add(tctx, slss, unpack_pack_name, LEAN_DEFAULT_PRIORITY);
+                    slss = add(tctx, slss, unpack_pack_name, false, LEAN_DEFAULT_PRIORITY);
                     r = finalize(tctx, get_eq_name(), simplify_fn(tctx, dcs, slss, list<name>(), cfg)(get_eq_name(), H_unpack_decl.get_type()));
                     s = *apply(tctx, false, false, mk_eq_mp(tctx, r.get_proof(), H_unpack_decl.mk_ref()), s);
                     return s;
@@ -2243,7 +2243,7 @@ class add_nested_inductive_decl_fn {
             simp_config cfg = get_simp_config();
             defeq_can_state dcs;
             simp_lemmas slss;
-            slss = add(tctx, slss, hyp_decl.get_name(), hyp_decl.get_type(), hyp_decl.mk_ref(), LEAN_DEFAULT_PRIORITY);
+            slss = add(tctx, slss, hyp_decl.get_name(), hyp_decl.get_type(), hyp_decl.mk_ref(), false, LEAN_DEFAULT_PRIORITY);
             simp_result r = finalize(tctx, get_eq_name(), simplify_fn(tctx, dcs, slss, list<name>(), cfg)(get_eq_name(), goal_type));
             expr pf;
 

--- a/src/library/tactic/eqn_lemmas.cpp
+++ b/src/library/tactic/eqn_lemmas.cpp
@@ -41,7 +41,7 @@ static environment update(environment const & env, eqn_lemmas_ext const & ext) {
 
 environment add_eqn_lemma_core(environment const & env, name const & eqn_lemma) {
     type_context_old ctx(env, transparency_mode::None);
-    simp_lemmas lemmas = add(ctx, simp_lemmas(), eqn_lemma, LEAN_DEFAULT_PRIORITY);
+    simp_lemmas lemmas = add(ctx, simp_lemmas(), eqn_lemma, false, LEAN_DEFAULT_PRIORITY);
     optional<simp_lemma> new_lemma;
     lemmas.for_each([&](name const & r, simp_lemma const & sl) {
             if (r != get_eq_name())

--- a/src/library/tactic/simp_lemmas.cpp
+++ b/src/library/tactic/simp_lemmas.cpp
@@ -730,7 +730,7 @@ static simp_lemmas add_core(type_context_old & ctx, simp_lemmas const & s, name 
         expr rel, lhs, rhs;
         if (is_simp_relation(env, rule, rel, lhs, rhs) && is_constant(rel)) {
             if (symm) {
-              proof = mk_symm(ctx, get_eq_name(), proof);
+              proof = mk_symm(ctx, const_name(rel), proof);
               std::swap(lhs, rhs);
             }
             if (is_refl_app(proof)) {
@@ -805,7 +805,7 @@ static simp_lemmas add_core(type_context_old & ctx, simp_lemmas const & s, name 
         expr lhs, rhs;
         lean_verify(is_eq(type, lhs, rhs));
         if (symm) {
-            proof = mk_symm(ctx, get_eq_name(), proof);
+            proof = mk_eq_symm(ctx, proof);
             std::swap(lhs, rhs);
         }
         simp_lemmas new_s = s;

--- a/src/library/tactic/simp_lemmas.cpp
+++ b/src/library/tactic/simp_lemmas.cpp
@@ -1015,7 +1015,7 @@ static simp_lemmas add_congr_core(type_context_old & ctx, simp_lemmas const & s,
 }
 
 simp_lemmas add(type_context_old & ctx, simp_lemmas const & s, name const & id, bool symm, unsigned priority) {
-  return ext_add_core(ctx, s, id, symm, priority);
+    return ext_add_core(ctx, s, id, symm, priority);
 }
 
 simp_lemmas add(type_context_old & ctx, simp_lemmas const & s, name const & id, expr const & e, expr const & h, bool symm, unsigned priority) {
@@ -1025,6 +1025,14 @@ simp_lemmas add(type_context_old & ctx, simp_lemmas const & s, name const & id, 
         report_failure(sstream() << "invalid simplification lemma '" << id << "': " << e);
     }
     return r;
+}
+
+simp_lemmas add(type_context_old & ctx, simp_lemmas const & s, name const & id, unsigned priority) {
+    return add(ctx, s, id, false, priority);
+}
+
+simp_lemmas add(type_context_old & ctx, simp_lemmas const & s, name const & id, expr const & e, expr const & h, unsigned priority) {
+    return add(ctx, s, id, e, h, false, priority);
 }
 
 simp_lemmas add_congr(type_context_old & ctx, simp_lemmas const & s, name const & id, unsigned priority) {

--- a/src/library/tactic/simp_lemmas.cpp
+++ b/src/library/tactic/simp_lemmas.cpp
@@ -701,7 +701,7 @@ static bool is_refl_app(expr const & pr) {
 
 static simp_lemmas add_core(type_context_old & ctx, simp_lemmas const & s, name const & id,
                             levels const & univ_metas, buffer<expr> const & _emetas,
-                            expr const & e, expr const & h, unsigned priority) {
+                            expr const & e, expr const & h, bool symm, unsigned priority) {
     lean_assert(ctx.in_tmp_mode());
     list<expr_pair> ceqvs   = to_ceqvs(ctx, id, e, h);
     environment const & env = ctx.env();
@@ -727,6 +727,9 @@ static simp_lemmas add_core(type_context_old & ctx, simp_lemmas const & s, name 
             rule = instantiate(binding_body(rule), mvar);
             proof = mk_app(proof, mvar);
         }
+        if (symm) {
+          proof = mk_symm(ctx, get_eq_name(), proof);
+        }
         expr rel, lhs, rhs;
         if (is_simp_relation(env, rule, rel, lhs, rhs) && is_constant(rel)) {
             if (is_refl_app(proof)) {
@@ -746,14 +749,14 @@ static simp_lemmas add_core(type_context_old & ctx, simp_lemmas const & s, name 
 
 static simp_lemmas add_core(type_context_old & ctx, simp_lemmas const & s, name const & id,
                             buffer<level> const & univ_metas, buffer<expr> const & emetas,
-                            expr const & e, expr const & h, unsigned priority) {
-    return add_core(ctx, s, id, to_list(univ_metas), emetas, e, h, priority);
+                            expr const & e, expr const & h, bool symm, unsigned priority) {
+    return add_core(ctx, s, id, to_list(univ_metas), emetas, e, h, symm, priority);
 }
 
 static simp_lemmas add_core(type_context_old & ctx, simp_lemmas const & s, name const & id, levels const & univ_metas,
-                            expr const & e, expr const & h, unsigned priority) {
+                            expr const & e, expr const & h, bool symm, unsigned priority) {
     buffer<expr> emetas;
-    return add_core(ctx, s, id, univ_metas, emetas, e, h, priority);
+    return add_core(ctx, s, id, univ_metas, emetas, e, h, symm, priority);
 }
 
 bool is_rfl_lemma(expr type, expr pf) {
@@ -781,7 +784,7 @@ static levels mk_tmp_levels_for(type_context_old & ctx, declaration const & d) {
     return to_list(us);
 }
 
-static simp_lemmas add_core(type_context_old & ctx, simp_lemmas const & s, name const & cname, unsigned priority) {
+static simp_lemmas add_core(type_context_old & ctx, simp_lemmas const & s, name const & cname, bool symm, unsigned priority) {
     environment const & env = ctx.env();
     type_context_old::tmp_mode_scope scope(ctx);
     declaration const & d = env.get(cname);
@@ -800,18 +803,23 @@ static simp_lemmas add_core(type_context_old & ctx, simp_lemmas const & s, name 
         }
         expr lhs, rhs;
         lean_verify(is_eq(type, lhs, rhs));
+        if (symm) {
+            printf("foo\n");
+            proof = mk_symm(ctx, get_eq_name(), proof);
+            std::swap(lhs, rhs);
+        }
         simp_lemmas new_s = s;
         new_s.insert(get_eq_name(), mk_rfl_lemma(cname, ls, to_list(emetas), to_list(instances),
                                                  lhs, rhs, proof, priority));
         return new_s;
     } else {
-        return add_core(ctx, s, cname, ls, type, proof, priority);
+        return add_core(ctx, s, cname, ls, type, proof, symm, priority);
     }
 }
 
 /* Extended version. If cname is a definition with equational lemmas associated to it, then
    add the equational lemmas. */
-static simp_lemmas ext_add_core(type_context_old & ctx, simp_lemmas const & s, name const & cname, unsigned priority) {
+static simp_lemmas ext_add_core(type_context_old & ctx, simp_lemmas const & s, name const & cname, bool symm, unsigned priority) {
     simp_lemmas r = s;
 
     // Note: for relations that are not in Prop, the definition will be both
@@ -822,10 +830,10 @@ static simp_lemmas ext_add_core(type_context_old & ctx, simp_lemmas const & s, n
     buffer<name> eqn_lemmas;
     get_ext_eqn_lemmas_for(ctx.env(), cname, eqn_lemmas);
     for (name const & eqn_lemma : eqn_lemmas)
-        r = add_core(ctx, r, eqn_lemma, priority);
+        r = add_core(ctx, r, eqn_lemma, false, priority);
 
     // the definition itself
-    r = add_core(ctx, r, cname, priority);
+    r = add_core(ctx, r, cname, symm, priority);
 
     if (is_eqp(r, s)) {
         report_failure(sstream() << "invalid simplification lemma '" << cname << "'");
@@ -1006,13 +1014,13 @@ static simp_lemmas add_congr_core(type_context_old & ctx, simp_lemmas const & s,
     return new_s;
 }
 
-simp_lemmas add(type_context_old & ctx, simp_lemmas const & s, name const & id, unsigned priority) {
-    return ext_add_core(ctx, s, id, priority);
+simp_lemmas add(type_context_old & ctx, simp_lemmas const & s, name const & id, bool symm, unsigned priority) {
+  return ext_add_core(ctx, s, id, symm, priority);
 }
 
-simp_lemmas add(type_context_old & ctx, simp_lemmas const & s, name const & id, expr const & e, expr const & h, unsigned priority) {
+simp_lemmas add(type_context_old & ctx, simp_lemmas const & s, name const & id, expr const & e, expr const & h, bool symm, unsigned priority) {
     type_context_old::tmp_mode_scope scope(ctx);
-    auto r = add_core(ctx, s, id, list<level>(), e, h, priority);
+    auto r = add_core(ctx, s, id, list<level>(), e, h, symm, priority);
     if (is_eqp(r, s)) {
         report_failure(sstream() << "invalid simplification lemma '" << id << "': " << e);
     }
@@ -1049,7 +1057,7 @@ static void on_add_simp_lemma(environment const & env, name const & c, bool) {
     type_context_old ctx(env);
     simp_lemmas s;
     flet<bool> set_ex(g_throw_ex, true);
-    ext_add_core(ctx, s, c, LEAN_DEFAULT_PRIORITY);
+    ext_add_core(ctx, s, c, false, LEAN_DEFAULT_PRIORITY);
 }
 
 static void on_add_congr_lemma(environment const & env, name const & c, bool) {
@@ -1067,7 +1075,7 @@ static simp_lemmas get_simp_lemmas_from_attribute(type_context_old & ctx, name c
     while (i > 0) {
         i--;
         name const & id = simp_lemmas[i];
-        result = ext_add_core(ctx, result, id, attr.get_prio(ctx.env(), id));
+        result = ext_add_core(ctx, result, id, false, attr.get_prio(ctx.env(), id));
     }
     return result;
 }
@@ -1332,7 +1340,7 @@ vm_obj simp_lemmas_mk_default(vm_obj const & s) {
     LEAN_TACTIC_CATCH(tactic::to_state(s));
 }
 
-vm_obj simp_lemmas_add(vm_obj const & lemmas, vm_obj const & lemma, vm_obj const & s0) {
+vm_obj simp_lemmas_add(vm_obj const & lemmas, vm_obj const & lemma, vm_obj const & symm, vm_obj const & s0) {
     tactic_state s = tactic::to_state(s0);
     LEAN_TACTIC_TRY;
     tactic_state_context_cache cache(s);
@@ -1353,17 +1361,17 @@ vm_obj simp_lemmas_add(vm_obj const & lemmas, vm_obj const & lemma, vm_obj const
     type_context_old::tmp_mode_scope scope(ctx, umetas.size(), emetas.size());
     expr e_type = ctx.infer(e);
     simp_lemmas new_lemmas = add_core(ctx, to_simp_lemmas(lemmas), id, umetas, emetas,
-                                      e_type, e, LEAN_DEFAULT_PRIORITY);
+                                      e_type, e, to_bool(symm), LEAN_DEFAULT_PRIORITY);
     return tactic::mk_success(to_obj(new_lemmas), s);
     LEAN_TACTIC_CATCH(s);
 }
 
-vm_obj simp_lemmas_add_simp(vm_obj const & lemmas, vm_obj const & lemma_name, vm_obj const & s0) {
+vm_obj simp_lemmas_add_simp(vm_obj const & lemmas, vm_obj const & lemma_name, vm_obj const & symm, vm_obj const & s0) {
     tactic_state s = tactic::to_state(s0);
     LEAN_TACTIC_TRY;
     tactic_state_context_cache cache(s);
     type_context_old ctx = cache.mk_type_context();
-    simp_lemmas new_lemmas = add(ctx, to_simp_lemmas(lemmas), to_name(lemma_name), LEAN_DEFAULT_PRIORITY);
+    simp_lemmas new_lemmas = add(ctx, to_simp_lemmas(lemmas), to_name(lemma_name), to_bool(symm), LEAN_DEFAULT_PRIORITY);
     return tactic::mk_success(to_obj(new_lemmas), s);
     LEAN_TACTIC_CATCH(s);
 }

--- a/src/library/tactic/simp_lemmas.cpp
+++ b/src/library/tactic/simp_lemmas.cpp
@@ -727,11 +727,12 @@ static simp_lemmas add_core(type_context_old & ctx, simp_lemmas const & s, name 
             rule = instantiate(binding_body(rule), mvar);
             proof = mk_app(proof, mvar);
         }
-        if (symm) {
-          proof = mk_symm(ctx, get_eq_name(), proof);
-        }
         expr rel, lhs, rhs;
         if (is_simp_relation(env, rule, rel, lhs, rhs) && is_constant(rel)) {
+            if (symm) {
+              proof = mk_symm(ctx, get_eq_name(), proof);
+              std::swap(lhs, rhs);
+            }
             if (is_refl_app(proof)) {
                 // This case is for zeta-reduction, regular rfl-lemmas are already handled in add_core(name, ...)
                 new_s.insert(const_name(rel), mk_rfl_lemma(id, univ_metas, reverse_to_list(emetas),
@@ -804,7 +805,6 @@ static simp_lemmas add_core(type_context_old & ctx, simp_lemmas const & s, name 
         expr lhs, rhs;
         lean_verify(is_eq(type, lhs, rhs));
         if (symm) {
-            printf("foo\n");
             proof = mk_symm(ctx, get_eq_name(), proof);
             std::swap(lhs, rhs);
         }

--- a/src/library/tactic/simp_lemmas.h
+++ b/src/library/tactic/simp_lemmas.h
@@ -137,8 +137,8 @@ simp_lemmas get_simp_lemmas(environment const & env, simp_lemmas_token tk);
 simp_lemmas get_default_simp_lemmas(environment const & env);
 simp_lemmas get_simp_lemmas(environment const & env, name const & tk_name);
 
-simp_lemmas add(type_context_old & ctx, simp_lemmas const & s, name const & id, unsigned priority);
-simp_lemmas add(type_context_old & ctx, simp_lemmas const & s, name const & id, expr const & e, expr const & h, unsigned priority);
+simp_lemmas add(type_context_old & ctx, simp_lemmas const & s, name const & id, bool symm, unsigned priority);
+simp_lemmas add(type_context_old & ctx, simp_lemmas const & s, name const & id, expr const & e, expr const & h, bool symm, unsigned priority);
 simp_lemmas add_congr(type_context_old & ctx, simp_lemmas const & s, name const & id, unsigned priority);
 simp_lemmas join(simp_lemmas const & s1, simp_lemmas const & s2);
 

--- a/src/library/tactic/simp_lemmas.h
+++ b/src/library/tactic/simp_lemmas.h
@@ -139,6 +139,8 @@ simp_lemmas get_simp_lemmas(environment const & env, name const & tk_name);
 
 simp_lemmas add(type_context_old & ctx, simp_lemmas const & s, name const & id, bool symm, unsigned priority);
 simp_lemmas add(type_context_old & ctx, simp_lemmas const & s, name const & id, expr const & e, expr const & h, bool symm, unsigned priority);
+simp_lemmas add(type_context_old & ctx, simp_lemmas const & s, name const & id, unsigned priority);
+simp_lemmas add(type_context_old & ctx, simp_lemmas const & s, name const & id, expr const & e, expr const & h, unsigned priority);
 simp_lemmas add_congr(type_context_old & ctx, simp_lemmas const & s, name const & id, unsigned priority);
 simp_lemmas join(simp_lemmas const & s1, simp_lemmas const & s2);
 

--- a/src/library/tactic/simplify.cpp
+++ b/src/library/tactic/simplify.cpp
@@ -149,7 +149,7 @@ simp_lemmas simplify_core_fn::add_to_slss(simp_lemmas const & _slss, buffer<expr
     for (unsigned i = 0; i < ls.size(); i++) {
         expr const & l = ls[i];
         try {
-            slss = add(m_ctx, slss, mlocal_name(l), m_ctx.infer(l), l, LEAN_DEFAULT_PRIORITY);
+            slss = add(m_ctx, slss, mlocal_name(l), m_ctx.infer(l), l, false, LEAN_DEFAULT_PRIORITY);
             lean_simp_trace(m_ctx, name({"simplify", "context"}),
                             tout() << mlocal_name(l) << " : " << m_ctx.infer(l) << "\n";);
         } catch (exception & e) {}

--- a/tests/lean/run/pathsimp.lean
+++ b/tests/lean/run/pathsimp.lean
@@ -36,7 +36,7 @@ let sls := simp_lemmas.mk,
 sls ← sls.add_congr ``path.congr,
 -- nat_zero_add can be used as a simplification lemma even though it has
 -- associated equational lemmas
-sls ← sls.add_simp ``nat_zero_add,
+sls ← sls.add_simp ``nat_zero_add ff,
 trace sls,
 path_simp_target sls, reflexivity
 

--- a/tests/lean/simp_symm.lean
+++ b/tests/lean/simp_symm.lean
@@ -1,6 +1,6 @@
 constants f g : nat → nat
 
--- Test `simp` with symmetric argument
+-- Test `simp` with lemmas in reverse direction
 axiom f_id : ∀ x, f x = x
 axiom f_g : ∀ x, f x = g x
 example (a : nat) : g a = a :=
@@ -17,3 +17,9 @@ axiom fu_id : ∀ (x : α), fu x = id x
 axiom fu_gu : ∀ (x : α), fu x = gu x
 example (a : nat) : gu a = a :=
 by simp [←fu_gu, fu_id] -- works
+
+-- Reverse direction also works for `↔`
+constants p q : α → Prop
+axiom pq : ∀ (x : α), p x ↔ q x
+example (a : nat) (h : p a) : q a :=
+by { simp [←pq], assumption }

--- a/tests/lean/simp_symm.lean
+++ b/tests/lean/simp_symm.lean
@@ -1,0 +1,19 @@
+constants f g : nat → nat
+
+-- Test `simp` with symmetric argument
+axiom f_id : ∀ x, f x = x
+axiom f_g : ∀ x, f x = g x
+example (a : nat) : g a = a :=
+by simp [←f_g, f_id] -- works
+-- Alternate syntax:
+example (a : nat) : g a = a :=
+by simp [<-f_g, f_id] -- works
+
+-- Universe polymorphic lemmas work:
+universe u
+variable {α : Type u}
+constants fu gu : α → α
+axiom fu_id : ∀ (x : α), fu x = id x
+axiom fu_gu : ∀ (x : α), fu x = gu x
+example (a : nat) : gu a = a :=
+by simp [←fu_gu, fu_id] -- works

--- a/tests/lean/simp_symm.lean
+++ b/tests/lean/simp_symm.lean
@@ -23,3 +23,23 @@ constants p q : α → Prop
 axiom pq : ∀ (x : α), p x ↔ q x
 example (a : nat) (h : p a) : q a :=
 by { simp [←pq], assumption }
+
+section reverse_conflict
+open interactive
+open tactic.interactive
+open tactic.simp_arg_type
+
+def op : nat → nat → nat := sorry
+@[simp] lemma op_assoc (a b c : nat) : op (op a b) c = op a (op b c) := sorry
+
+-- Passing an existing `@[simp]` lemma in reverse direction works:
+-- The failure case is that the existing lemma isn't deleted from the set,
+-- so the simplifier goes in an infinite loop.
+-- We prevent that with the `try_for` call.
+example (a b c : nat) (h : p (op (op a b) c)) : p (op a (op b c)) :=
+by λ s, match try_for 1000 (simp none ff [symm_expr ``(op_assoc)] [] (loc.ns [none]) {} s) with
+        | none := result.exception (some (λ _, format!"timeout in try_for")) none s
+        | (some (result.success _ s')) := assumption s'
+        | (some exception) := exception
+        end
+end reverse_conflict

--- a/tests/lean/simp_symm.lean.expected.out
+++ b/tests/lean/simp_symm.lean.expected.out
@@ -1,0 +1,2 @@
+simp_symm.lean:32:0: warning: declaration 'op' uses sorry
+simp_symm.lean:33:8: warning: declaration 'op_assoc' uses sorry


### PR DESCRIPTION
# Pull Request Description

Allow the `simp` tactic to apply reverse direction, analogously to `rw`: if `h : a = b`, then `simp [<-h]` will replace all instances of `b` in the goal with `a`.

This implementation is inspired by `rewrite`: we store a flag for each `expr` lemma passed to `simp`, indicating whether to reverse it. When all parameters to the lemma have been instantiated (so that the lemma has the form `h _ ... _ : R _ _`, `mk_symm` is applied to it to get the reverse relation.