### PR TITLE
fix(builtin_cmds): force tactic type in run_cmd

### DIFF
--- a/src/frontends/lean/builtin_cmds.cpp
+++ b/src/frontends/lean/builtin_cmds.cpp
@@ -564,6 +564,7 @@ static environment run_command_cmd(parser & p) {
     expr tactic          = p.parse_expr();
     expr try_triv        = mk_app(mk_constant(get_tactic_try_name()), mk_constant(get_tactic_triv_name()));
     tactic               = mk_app(mk_constant(get_has_bind_and_then_name()), tactic, try_triv);
+    tactic               = mk_typed_expr(mk_tactic_unit(), tactic);
     expr val             = mk_typed_expr(mk_true(), mk_by(tactic));
     bool check_unassigned = false;
     bool recover_from_errors = true;

--- a/tests/lean/run_cmd_type.lean
+++ b/tests/lean/run_cmd_type.lean
@@ -1,0 +1,5 @@
+meta def foo: lean.parser unit :=
+do
+    return ()
+
+run_cmd foo

--- a/tests/lean/run_cmd_type.lean.expected.out
+++ b/tests/lean/run_cmd_type.lean.expected.out
@@ -1,0 +1,8 @@
+run_cmd_type.lean:5:8: error: type mismatch at application
+  has_bind.and_then foo
+term
+  foo
+has type
+  lean.parser unit
+but is expected to have type
+  tactic unit


### PR DESCRIPTION
Fixes #101. Internally, `run_cmd foo` expands to something like `((by (foo >> tactic.try tactic.triv)): true)` but in a different way than it would interactively, so the term passed to `by` can end up having type `lean.parser unit` since there is a coercion from `tactic` to `lean.parser`:
```lean
#check (foo >> tactic.try tactic.triv)
-- foo >> ↑(tactic.try tactic.triv) : lean.parser unit
```
This change forces it to have type `tactic unit`.