### PR TITLE
fix(library/type_context): `?m_1` and `(λ x, ?m_1) y` are definitionally equal

### DIFF
--- a/src/library/type_context.cpp
+++ b/src/library/type_context.cpp
@@ -2782,7 +2782,7 @@ lbool type_context_old::quick_is_def_eq(expr const & e1, expr const & e2) {
                 return l_false;
             }
         } else {
-            return l_false;
+            return l_undef;
         }
     }
 
@@ -2797,7 +2797,7 @@ lbool type_context_old::quick_is_def_eq(expr const & e1, expr const & e2) {
             /* We need to swap `m_update_left` and `m_update_right` because `process_assignment` uses `is_def_eq` */
             return to_lbool(process_assignment(e2, e1));
         } else {
-            return l_false;
+            return l_undef;
         }
     }
 

--- a/tests/lean/run/mvar_beta_isdefeq.lean
+++ b/tests/lean/run/mvar_beta_isdefeq.lean
@@ -1,0 +1,30 @@
+open tactic expr
+
+set_option pp.all true
+set_option trace.check true
+
+-- ?m_1  =?=  (λ x, ?m_1) unit.star
+#eval do
+m ← mk_meta_var `(Type),
+let e :=
+  (lam `x binder_info.default (const ``unit []) m)
+    (const ``unit.star []),
+is_def_eq m e
+
+
+/-- similar to `mk_local_pis` but make meta variables instead of
+    local constants -/
+meta def mk_meta_pis : expr → tactic (list expr × expr)
+| (expr.pi n bi d b) := do
+  p ← mk_meta_var d,
+  (ps, r) ← mk_meta_pis (expr.instantiate_var b p),
+  return ((p :: ps), r)
+| e := return ([], e)
+
+
+-- The issue also occurs when instantiating some lemmas with metavariables
+#eval do
+c ← mk_const ``psigma.rev_lex_accessible.equations._eqn_1,
+t ← infer_type c,
+(ms, t') ← mk_meta_pis t,
+type_check t'


### PR DESCRIPTION
Currently, `quick_is_def_eq` incorrectly returns false (i.e., not defeq) for these expressions.