### PR TITLE
feat(scanner): allow nested comment blocks in docstrings

### DIFF
--- a/library/init/meta/expr.lean
+++ b/library/init/meta/expr.lean
@@ -186,7 +186,7 @@ meta constant expr.instantiate_var         : expr → expr → expr
 /-- ``instantiate_vars `(#0 #1 #2) [x,y,z] = `(%%x %%y %%z)`` -/
 meta constant expr.instantiate_vars        : expr → list expr → expr
 
-/-- Perform beta-reduction if the left expression is a lambda. Ie: ``expr.subst | `(λ x, %%Y) Z := Y[x/Z] | X Z := X``-/
+/-- Perform beta-reduction if the left expression is a lambda. Ie: ``expr.subst | `(λ x, %%Y) Z := Y[x/Z] | X Z := X`` -/
 protected meta constant expr.subst : expr elab → expr elab → expr elab
 
 /-- `get_free_var_range e` returns one plus the maximum de-Bruijn value in `e`. Eg `get_free_var_range `(#1 #0)` yields `2` -/

--- a/library/init/meta/tactic.lean
+++ b/library/init/meta/tactic.lean
@@ -550,15 +550,15 @@ where l_i's and a_j's are the collected dependencies.
 -/
 meta constant add_aux_decl (c : name) (type : expr) (val : expr) (is_lemma : bool) : tactic expr
 
-/-- Returns a list of all top-level (`/-!`) docstrings in the active module and imported ones.
+/-- Returns a list of all top-level (`/-! ... -/`) docstrings in the active module and imported ones.
 The returned object is a list of modules, indexed by `(some filename)` for imported modules
 and `none` for the active one, where each module in the list is paired with a list
 of `(position_in_file, docstring)` pairs. -/
 meta constant olean_doc_strings : tactic (list (option string × (list (pos × string))))
 
 /-- Returns a list of docstrings in the active module. An entry in the list can be either:
-- a top-level (`/-!`) docstring, represented as `(none, docstring)`
-- a declaration-specific (`/--`) docstring, represented as `(some decl_name, docstring)` -/
+- a top-level (`/-! ... -/`) docstring, represented as `(none, docstring)`
+- a declaration-specific (`/-- ... -/`) docstring, represented as `(some decl_name, docstring)` -/
 meta def module_doc_strings : tactic (list (option name × string)) :=
   do
     /- Obtain a list of top-level docs in current module. -/

--- a/src/frontends/lean/scanner.cpp
+++ b/src/frontends/lean/scanner.cpp
@@ -357,7 +357,12 @@ void scanner::read_doc_block_core() {
         check_not_eof("unexpected end of documentation block");
         uchar c = curr();
         next();
-        if (c == '-') {
+        if (c == '/') {
+            if (curr() == '-') {
+                next();
+                read_comment_block();
+            }
+        } else if (c == '-') {
             if (curr() == '/') {
                 next();
                 return;

--- a/src/frontends/lean/scanner.cpp
+++ b/src/frontends/lean/scanner.cpp
@@ -357,12 +357,7 @@ void scanner::read_doc_block_core() {
         check_not_eof("unexpected end of documentation block");
         uchar c = curr();
         next();
-        if (c == '`') {
-            if (curr() == '/' || curr() == '-') {
-                m_buffer += c;
-                next();
-            }
-        } else if (c == '/') {
+        if (c == '/') {
             if (curr() == '-') {
                 m_buffer += c;
                 next();

--- a/src/frontends/lean/scanner.cpp
+++ b/src/frontends/lean/scanner.cpp
@@ -357,10 +357,16 @@ void scanner::read_doc_block_core() {
         check_not_eof("unexpected end of documentation block");
         uchar c = curr();
         next();
-        if (c == '/') {
-            if (curr() == '-') {
+        if (c == '`') {
+            if (curr() == '/' || curr() == '-') {
+                m_buffer += c;
                 next();
-                read_comment_block();
+            }
+        } else if (c == '/') {
+            if (curr() == '-') {
+                m_buffer += c;
+                next();
+                read_comment_block_doc();
             }
         } else if (c == '-') {
             if (curr() == '/') {
@@ -401,6 +407,31 @@ void scanner::read_comment_block() {
                     return;
             }
         }
+    }
+}
+
+void scanner::read_comment_block_doc() {
+    unsigned nesting = 1;
+    while (true) {
+        uchar c = curr();
+        check_not_eof("unexpected end of comment block");
+        next();
+        if (c == '/') {
+            if (curr() == '-') {
+                m_buffer += c;
+                next();
+                nesting++;
+            }
+        } else if (c == '-') {
+            if (curr() == '/') {
+                m_buffer += c;
+                next();
+                nesting--;
+                if (nesting == 0)
+                    return;
+            }
+        }
+        m_buffer += c;
     }
 }
 

--- a/src/frontends/lean/scanner.h
+++ b/src/frontends/lean/scanner.h
@@ -65,6 +65,7 @@ protected:
     void move_back(unsigned offset, unsigned u_offset);
     void read_single_line_comment();
     void read_comment_block();
+    void read_comment_block_doc();
     void read_until(uchar const * end_str, char const * error_msg);
     unsigned get_utf8_size(uchar c);
     void next_utf_core(uchar c, buffer<uchar> & cs);

--- a/tests/lean/run/comment.lean
+++ b/tests/lean/run/comment.lean
@@ -1,1 +1,5 @@
 /- tests -/
+/- /- /- nested comment blocks -/ -/ -/
+/-- /- /- nested comment blocks in a docstring -/ -/ -/
+example : true := trivial
+/-! /- /- nested comment blocks in a module block-/ -/ -/


### PR DESCRIPTION
This allows nested comment blocks to be placed in docstrings and module docs. This will make it possible to write comments in Lean code examples in docstrings.

See https://github.com/leanprover-community/mathlib/pull/1963#issuecomment-585889606 and https://leanprover-community.github.io/archive/113488general/42453nestedcommentblocks.html

Question: if we want to merge this, where should it be documented?