### PR TITLE
refactor(library/init/core): replace insert definition by export

### DIFF
--- a/library/init/core.lean
+++ b/library/init/core.lean
@@ -398,12 +398,11 @@ def bit1 {α : Type u} [s₁ : has_one α] [s₂ : has_add α] (a : α) : α := 
 
 attribute [pattern] has_zero.zero has_one.one bit0 bit1 has_add.add has_neg.neg
 
-def insert {α : Type u} {γ : Type v} [has_insert α γ] : α → γ → γ :=
-has_insert.insert
+export has_insert (insert)
 
 /-- The singleton collection -/
 def singleton {α : Type u} {γ : Type v} [has_emptyc γ] [has_insert α γ] (a : α) : γ :=
-has_insert.insert a ∅
+insert a ∅
 
 /- nat basic instances -/
 


### PR DESCRIPTION
Currently we have both `has_insert.insert` and `insert`, which do exactly the same thing.  This causes a bit of headache since built-in set notation uses `has_insert.insert` but you typically write `insert`.  We have a simp lemma in mathlib that replaces `has_insert.insert` by `insert`, but then you can't use built-in set notation such as `{a}` in simp lemmas...