### PR TITLE
chore(travis.yml): simplify travis config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,12 +2,7 @@ language: cpp
 sudo: true
 cache:
   apt: true
-  ccache: true
 dist: trusty
-branches:
-  only:
-    - master
-    - /^v3\.[0-9]+\..*$/
 group: deprecated-2017Q3
 addons:
   apt:
@@ -173,20 +168,11 @@ before_install:
       brew update &&
       (brew install gcc || brew link --overwrite gcc) &&
       brew install gmp &&
-      brew install ccache &&
       # workaround for https://github.com/travis-ci/travis-ci/issues/6307
       command curl -sSL https://rvm.io/mpapis.asc | gpg --import -
       command curl -sSL https://rvm.io/pkuczynski.asc | gpg --import -
       rvm get head || true
     fi
-
-install:
-  - export CXX_FAMILY=`echo $CMAKE_CXX_COMPILER | sed -n "s/\([^\+]*++\).*/\1/p"`
-     # CXX_FAMILY is either `clang++` or `g++`
-  - mkdir -p ~/bin/
-  - chmod +x script/ccache-$CXX_FAMILY
-  - cp script/ccache-$CXX_FAMILY ~/bin/
-  - export PATH="~/bin/:$PATH"
 
 script:
   - mkdir -p build
@@ -205,7 +191,7 @@ script:
       . ../script/setup_nightly.sh
     fi
   - cmake -DCMAKE_BUILD_TYPE=$CMAKE_BUILD_TYPE
-          -DCMAKE_CXX_COMPILER=ccache-$CXX_FAMILY
+          -DCMAKE_CXX_COMPILER=$CMAKE_CXX_COMPILER
           -DTESTCOV=$TESTCOV
           -DTCMALLOC=$TCMALLOC
           -DMULTI_THREAD=$MULTI_THREAD


### PR DESCRIPTION
This should hopefully fix the ccache errors (by simply removing the ccache support).
