### PR TITLE
fix(init/meta/interactive,tactic): docstring fix

### DIFF
--- a/library/init/meta/interactive.lean
+++ b/library/init/meta/interactive.lean
@@ -1527,7 +1527,7 @@ tactic.match_target t m >> skip
 /--
 `by_cases (h :)? p` splits the main goal into two cases, assuming `h : p` in the first branch, and `h : ¬ p` in the second branch.
 
-This tactic requires that `p` is decidable. To ensure that all propositions are decidable via classical reasoning, use  `local attribute classical.prop_decidable [instance]`.
+This tactic requires that `p` is decidable. To ensure that all propositions are decidable via classical reasoning, use  `local attribute [instance] classical.prop_decidable`.
 -/
 meta def by_cases : parse cases_arg_p → tactic unit
 | (n, q) := concat_tags $ do
@@ -1551,7 +1551,7 @@ meta def funext : parse ident_* → tactic unit
 /--
 If the target of the main goal is a proposition `p`, `by_contradiction h` reduces the goal to proving `false` using the additional hypothesis `h : ¬ p`. If `h` is omitted, a name is generated automatically.
 
-This tactic requires that `p` is decidable. To ensure that all propositions are decidable via classical reasoning, use  `local attribute classical.prop_decidable [instance]`.
+This tactic requires that `p` is decidable. To ensure that all propositions are decidable via classical reasoning, use  `local attribute [instance] classical.prop_decidable`.
 -/
 meta def by_contradiction (n : parse ident?) : tactic unit :=
 tactic.by_contradiction n >> return ()

--- a/library/init/meta/tactic.lean
+++ b/library/init/meta/tactic.lean
@@ -1210,7 +1210,7 @@ do tgt : expr ← target,
    <|>
    (mk_mapp `decidable.by_contradiction [some tgt, none] >>= eapply >> skip)
    <|>
-   fail "tactic by_contradiction failed, target is not a negation nor a decidable proposition (remark: when 'local attribute classical.prop_decidable [instance]' is used all propositions are decidable)",
+   fail "tactic by_contradiction failed, target is not a negation nor a decidable proposition (remark: when 'local attribute [instance] classical.prop_decidable' is used, all propositions are decidable)",
    match H with
    | some n := intro n
    | none   := intro1

--- a/tests/lean/by_contradiction.lean.expected.out
+++ b/tests/lean/by_contradiction.lean.expected.out
@@ -8,7 +8,7 @@ a_1 : ¬¬a = b,
 H : ¬a = b
 ⊢ false
 -------
-by_contradiction.lean:22:3: error: tactic by_contradiction failed, target is not a negation nor a decidable proposition (remark: when 'local attribute classical.prop_decidable [instance]' is used all propositions are decidable)
+by_contradiction.lean:22:3: error: tactic by_contradiction failed, target is not a negation nor a decidable proposition (remark: when 'local attribute [instance] classical.prop_decidable' is used, all propositions are decidable)
 state:
 p q : Prop,
 a : ¬¬p


### PR DESCRIPTION
The docstrings for by_cases, by_contra, by_contradiction had
`local attribute classical.prop_decidable [instance]`
instead of
`local attribute [instance] classical.prop_decidable`.
