### PR TITLE
refactor(data/nat/basic): get rid of nat.pow

### DIFF
--- a/library/init/data/nat/basic.lean
+++ b/library/init/data/nat/basic.lean
@@ -195,17 +195,4 @@ protected lemma bit1_ne_zero (n : ℕ) : bit1 n ≠ 0 :=
 show succ (n + n) ≠ 0, from
 λ h, nat.no_confusion h
 
-/- Exponentiation -/
-
-protected def pow (b : ℕ) : ℕ → ℕ
-| 0        := 1
-| (succ n) := pow n * b
-
-instance : has_pow nat nat :=
-⟨nat.pow⟩
-
-lemma pow_succ (b n : ℕ) : b^(succ n) = b^n * b := rfl
-
-@[simp] lemma pow_zero (b : ℕ) : b^0 = 1 := rfl
-
 end nat

--- a/library/init/data/nat/lemmas.lean
+++ b/library/init/data/nat/lemmas.lean
@@ -1275,79 +1275,7 @@ dvd.elim H (λl H1, by rw mul_assoc at H1; exact ⟨_, eq_of_mul_eq_mul_left kpo
 theorem dvd_of_mul_dvd_mul_right {m n k : ℕ} (kpos : k > 0) (H : m * k ∣ n * k) : m ∣ n :=
 by rw [mul_comm m k, mul_comm n k] at H; exact dvd_of_mul_dvd_mul_left kpos H
 
-/- pow -/
-
-@[simp] theorem pow_one (b : ℕ) : b^1 = b := by simp [pow_succ]
-
-theorem pow_le_pow_of_le_left {x y : ℕ} (H : x ≤ y) : ∀ i : ℕ, x^i ≤ y^i
-| 0 := le_refl _
-| (succ i) := mul_le_mul (pow_le_pow_of_le_left i) H (zero_le _) (zero_le _)
-
-theorem pow_le_pow_of_le_right {x : ℕ} (H : x > 0) {i : ℕ} : ∀ {j}, i ≤ j → x^i ≤ x^j
-| 0        h := by rw eq_zero_of_le_zero h; apply le_refl
-| (succ j) h := (lt_or_eq_of_le h).elim
-  (λhl, by rw [pow_succ, ← mul_one (x^i)]; exact
-    mul_le_mul (pow_le_pow_of_le_right $ le_of_lt_succ hl) H (zero_le _) (zero_le _))
-  (λe, by rw e; refl)
-
-theorem pos_pow_of_pos {b : ℕ} (n : ℕ) (h : 0 < b) : 0 < b^n :=
-pow_le_pow_of_le_right h (zero_le _)
-
-theorem zero_pow {n : ℕ} (h : 0 < n) : 0^n = 0 :=
-by rw [← succ_pred_eq_of_pos h, pow_succ, mul_zero]
-
-theorem pow_lt_pow_of_lt_left {x y : ℕ} (H : x < y) {i} (h : i > 0) : x^i < y^i :=
-begin
-  cases i with i, { exact absurd h (not_lt_zero _) },
-  rw [pow_succ, pow_succ],
-  exact mul_lt_mul' (pow_le_pow_of_le_left (le_of_lt H) _) H (zero_le _)
-    (pos_pow_of_pos _ $ lt_of_le_of_lt (zero_le _) H)
-end
-
-theorem pow_lt_pow_of_lt_right {x : ℕ} (H : x > 1) {i j : ℕ} (h : i < j) : x^i < x^j :=
-begin
-  have xpos := lt_of_succ_lt H,
-  refine lt_of_lt_of_le _ (pow_le_pow_of_le_right xpos h),
-  rw [← mul_one (x^i), pow_succ],
-  exact nat.mul_lt_mul_of_pos_left H (pos_pow_of_pos _ xpos)
-end
-
-/- mod / div / pow -/
-
 local attribute [simp] mul_comm
-
-theorem mod_pow_succ {b : ℕ} (b_pos : b > 0) (w m : ℕ)
-: m % (b^succ w) = b * (m/b % b^w) + m % b :=
-begin
-  apply nat.strong_induction_on m,
-  clear m,
-  intros p IH,
-  cases lt_or_ge p (b^succ w) with h₁ h₁,
-  -- base case: p < b^succ w
-  { have h₂ : p / b < b^w,
-    { rw [div_lt_iff_lt_mul p _ b_pos],
-      simp [pow_succ] at h₁,
-      simp [h₁] },
-    rw [mod_eq_of_lt h₁, mod_eq_of_lt h₂],
-    simp [mod_add_div, add_comm] },
-  -- step: p ≥ b^succ w
-  { -- Generate condiition for induction principal
-    have h₂ : p - b^succ w < p,
-    { apply sub_lt_of_pos_le _ _ (pos_pow_of_pos _ b_pos) h₁ },
-
-    -- Apply induction
-    rw [mod_eq_sub_mod h₁, IH _ h₂],
-    -- Normalize goal and h1
-    simp [pow_succ],
-    simp [ge, pow_succ] at h₁,
-    -- Pull subtraction outside mod and div
-    rw [sub_mul_mod _ _ _ h₁, sub_mul_div _ _ _ h₁],
-    -- Cancel subtraction inside mod b^w
-    have p_b_ge :  b^w ≤ p / b,
-    { rw [le_div_iff_mul_le _ _ b_pos],
-      simp [h₁] },
-    rw [eq.symm (mod_eq_sub_mod p_b_ge)] }
-end
 
 lemma div_lt_self {n m : nat} : n > 0 → m > 1 → n / m < n :=
 begin


### PR DESCRIPTION
This gets rid of the `has_pow nat nat` instance which should be replaced by `monoid.pow`.
I deleted one lemma which should be moved to mathlib. The other deleted lemmas are not specific to natural numbers and should already be proved for `monoid.pow`

# Pull Request Description

Ensure you have read the contribution guide before filling in a description of the
pull request, regardless of whether it is complete or a work in progress.
All Pull Requests should include test case(s) which demonstrates the intended
behavior of a feature, or a regression test demonstrating that the fix resolves
the issue.
