### PR TITLE
feat(format): soft line breaks that lets to formatter decide where to split lines

### DIFF
--- a/library/init/meta/format.lean
+++ b/library/init/meta/format.lean
@@ -19,9 +19,10 @@ meta constant format.line            : format
 meta constant format.space           : format
 /-- = `""` -/
 meta constant format.nil             : format
+meta constant format.soft_break      : format
 /-- Concatenate the given formats. -/
 meta constant format.compose         : format → format → format
-/-- `format.nest n f` tells the formatter that `f` is nested inside something with length `n` 
+/-- `format.nest n f` tells the formatter that `f` is nested inside something with length `n`
 so that it is pretty-printed with the correct tabs on a line break.
 For example, in `list.to_format` we have:
 
@@ -55,7 +56,7 @@ meta instance : has_append format :=
 meta instance : has_to_string format :=
 ⟨λ f, f.to_string options.mk⟩
 
-/-- Use this instead of `has_to_string` to enable prettier formatting. 
+/-- Use this instead of `has_to_string` to enable prettier formatting.
 See docstring for `format` for more on the differences between `format` and `string`.
 Note that `format` is `meta` while `string` is not. -/
 meta class has_to_format (α : Type u) :=

--- a/src/library/vm/vm_format.cpp
+++ b/src/library/vm/vm_format.cpp
@@ -44,6 +44,10 @@ vm_obj format_line() {
     return to_obj(line());
 }
 
+vm_obj format_soft_break() {
+    return to_obj(soft_break());
+}
+
 vm_obj format_space() {
     return to_obj(space());
 }
@@ -181,6 +185,7 @@ void initialize_vm_format() {
     DECLARE_VM_BUILTIN(name({"format", "line"}),             format_line);
     DECLARE_VM_BUILTIN(name({"format", "space"}),            format_space);
     DECLARE_VM_BUILTIN(name({"format", "nil"}),              format_nil);
+    DECLARE_VM_BUILTIN(name({"format", "soft_break"}),       format_soft_break);
     DECLARE_VM_BUILTIN(name({"format", "compose"}),          format_compose);
     DECLARE_VM_BUILTIN(name({"format", "nest"}),             format_nest);
     DECLARE_VM_BUILTIN(name({"format", "highlight"}),        format_highlight);

--- a/src/util/sexpr/format.cpp
+++ b/src/util/sexpr/format.cpp
@@ -91,6 +91,7 @@ format mk_line() {
 
 static format * g_line = nullptr;
 static format * g_space = nullptr;
+static format * g_soft_break = nullptr;
 static format * g_lp = nullptr;
 static format * g_rp = nullptr;
 static format * g_lsb = nullptr;
@@ -175,6 +176,10 @@ format paren(format const & x) {
 // wrap x y = x <> (text " " :<|> line) <> y
 format wrap(format const & f1, format const & f2) {
     return f1 + choice(format(" "), line()) + f2;
+}
+
+format const & soft_break() {
+    return *g_soft_break;
 }
 
 struct format::separate_tokens_fn {
@@ -518,6 +523,7 @@ void initialize_format() {
     register_unsigned_option(*g_pp_width, LEAN_DEFAULT_PP_WIDTH, "(pretty printer) line width");
     g_line = new format(mk_line());
     g_space = new format(" ");
+    g_soft_break = new format(choice(*g_space, line()));
     g_lp = new format("(");
     g_rp = new format(")");
     g_lsb = new format("[");
@@ -534,6 +540,7 @@ void finalize_format() {
     delete g_sexpr_space;
     delete g_line;
     delete g_space;
+    delete g_soft_break;
     delete g_lp;
     delete g_rp;
     delete g_lsb;

--- a/src/util/sexpr/format.h
+++ b/src/util/sexpr/format.h
@@ -218,6 +218,7 @@ format highlight_keyword(format const & f);
 format highlight_builtin(format const & f);
 format highlight_command(format const & f);
 format const & line();
+format const & soft_break();
 format const & space();
 format const & lp();
 format const & rp();


### PR DESCRIPTION
# Pull Request Description

It allows the following behavior:

```lean
"two" ++ format.soft_break ++ "words"
```

will be formatted on one line whereas

```lean
"very long string with many many words" ++ format.soft_break ++ "other very long string with many many words"
```

may be formatted on two lines.

Ensure you have read the contribution guide before filling in a description of the
pull request, regardless of whether it is complete or a work in progress.
All Pull Requests should include test case(s) which demonstrates the intended
behavior of a feature, or a regression test demonstrating that the fix resolves
the issue.
