### PR TITLE
fix(leanpkg): Correctly reference the community fork of lean in leanpkg.toml

### DIFF
--- a/leanpkg/leanpkg/lean_version.lean
+++ b/leanpkg/leanpkg/lean_version.lean
@@ -11,7 +11,7 @@ sformat!("{major}.{minor}.{patch}")
 
 def lean_version_string :=
 if lean.is_release then
-    lean_version_string_core
+    "leanprover-community/lean:" ++ lean_version_string_core
 else if lean.special_version_desc ≠ "" then
     lean.special_version_desc
 else

--- a/leanpkg/leanpkg/main.lean
+++ b/leanpkg/leanpkg/main.lean
@@ -12,16 +12,9 @@ h ← io.mk_file_handle fn io.mode.write,
 io.fs.write h cnts.to_char_buffer,
 io.fs.close h
 
-/--
-.toml files that refer to Lean versions hosted externally will use the syntax "community/lean:3.5.0".
-We need to strip the prefix, if it exists, to avoid an incorrect warning from leanpkg.
--/
-def external_lean_version (s : string) : string :=
-list.ilast $ s.split $ λ c, c = ':'
-
 def read_manifest : io manifest := do
 m ← manifest.from_file leanpkg_toml_fn,
-when (external_lean_version m.lean_version ≠ lean_version_string) $
+when (m.lean_version ≠ lean_version_string) $
   io.print_ln $ "\nWARNING: Lean version mismatch: installed version is " ++ lean_version_string
      ++ ", but package requires " ++ m.lean_version ++ "\n",
 return m


### PR DESCRIPTION
This PR contains the first option as discussed in #126.