### PR TITLE
fix(src/library): allow `simp` to rewrite subsingletons

### DIFF
--- a/library/init/meta/congr_tactic.lean
+++ b/library/init/meta/congr_tactic.lean
@@ -33,9 +33,10 @@ meta def congr_core : tactic unit :=
 do tgt ← target,
    apply_eq_congr_core tgt
    <|> apply_heq_congr_core
-   <|> fail "congr tactic failed"
+   <|> fail "congr tactic failed",
+   all_goals (try (applyc `subsingleton.elim))
 
 meta def congr : tactic unit :=
-do focus1 (try assumption >> congr_core >> all_goals (try reflexivity >> try (applyc `subsingleton.elim) >> try congr))
+do focus1 (try assumption >> congr_core >> all_goals (try reflexivity >> try congr))
 
 end tactic

--- a/library/init/meta/congr_tactic.lean
+++ b/library/init/meta/congr_tactic.lean
@@ -33,8 +33,7 @@ meta def congr_core : tactic unit :=
 do tgt ← target,
    apply_eq_congr_core tgt
    <|> apply_heq_congr_core
-   <|> fail "congr tactic failed",
-   all_goals (try (applyc `subsingleton.elim))
+   <|> fail "congr tactic failed"
 
 meta def congr : tactic unit :=
 do focus1 (try assumption >> congr_core >> all_goals (try reflexivity >> try congr))

--- a/library/init/meta/congr_tactic.lean
+++ b/library/init/meta/congr_tactic.lean
@@ -36,6 +36,6 @@ do tgt ← target,
    <|> fail "congr tactic failed"
 
 meta def congr : tactic unit :=
-do focus1 (try assumption >> congr_core >> all_goals (try reflexivity >> try congr))
+do focus1 (try assumption >> congr_core >> all_goals (try reflexivity >> try (applyc `subsingleton.elim) >> try congr))
 
 end tactic

--- a/src/library/congr_lemma.cpp
+++ b/src/library/congr_lemma.cpp
@@ -382,9 +382,7 @@ struct congr_lemma_manager {
                 } else if (pinfos[i].has_fwd_deps()) {
                     // If something depends on `i`, it should be Fixed.
                     kinds[i] = congr_arg_kind::Fixed;
-                }
-                else
-                {
+                } else {
                     // It's not a Prop and it has no forwards dependencies.
                     // If there are backwards dependencies on Eq arguments, then
                     // we will use subsingleton elimination to prove this

--- a/tests/lean/simp_subsingleton.lean
+++ b/tests/lean/simp_subsingleton.lean
@@ -1,0 +1,37 @@
+inductive some_subsingleton : Type | canonical
+open some_subsingleton
+instance : subsingleton some_subsingleton := ⟨λ a b, by cases a; cases b; refl⟩
+-- Note that ⟨λ a b, refl a⟩ does not work as a valid instance:
+-- the type is a subsingleton, but not definitionally!
+
+def some_function : some_subsingleton → some_subsingleton := λ x, x
+
+@[simp] lemma some_function_lemma {a : some_subsingleton} :
+  some_function a = canonical := by cases a; refl
+
+-- Motivating example:
+-- example (a : some_subsingleton) : some_function a = canonical := by simp only [some_function_lemma]
+
+example (a : some_subsingleton) : some_function a = canonical :=
+by {(do
+  t <- tactic.target,
+  c <- tactic.mk_specialized_congr_lemma_simp t,
+  tactic.trace c.arg_kinds), simp }
+
+example : cond (to_bool (2 = 2)) 0 1 = 0 :=
+by {(do
+  `((cond %%t %%i %%e) = _) <- tactic.target,
+  c <- tactic.mk_specialized_congr_lemma_simp t,
+  tactic.trace c.arg_kinds), simp }
+
+constants (γ : Type) (f : Π (α : Type*) (β : Sort*), α → β → γ)
+          (X : Type) (X_ss : subsingleton X)
+          (Y : Prop)
+
+attribute [instance] X_ss
+
+example (x₁ x₂ : X) (y₁ y₂ : Y) : f X Y x₁ y₁ = f X Y x₂ y₂ :=
+by { (do
+  `(%%t = _) <- tactic.target,
+  cs <- tactic.mk_specialized_congr_lemma_simp t,
+  tactic.trace cs.arg_kinds), congr }

--- a/tests/lean/simp_subsingleton.lean.expected.out
+++ b/tests/lean/simp_subsingleton.lean.expected.out
@@ -1,0 +1,3 @@
+[fixed_no_param, eq, eq]
+[eq, cast]
+[fixed_no_param, eq, eq, cast]


### PR DESCRIPTION
# Pull Request Description

The `simp` tactic uses `mk_congr_simp` to find rewritable subterms. If a subterm has a type which is an instance of `subsingleton`, then `mk_congr_simp` did not include this in the rewritable subterms (i.e. those with `congr_arg_kind::Eq`). This results in `simp` failing on goals of the form `(x : some_subsingleton) = (y : some_subsingleton)`. This is rather counterintuitive, especially since `rewrite` has no problems with such goals.

This PR tries to solve this issue by allowing subsingleton terms to have `congr_arg_kind::Eq` if that gives no conflict, i.e. no subterms with `congr_arg_kind::Eq` that have a dependency on the subsingleton term or vice versa. As a result, whether `simp` can rewrite a term should not depend (too much) on whether there is a `subsingleton` instance floating around.

The drawback to this approach is that the `congr` tactic produces more proof obligations, since `subsingleton.elim` no longer gets applied whenever possible (because `mk_congr` calls `mk_congr_simp`, which doesn't seem correct AFAIUI). The fix for `congr` in this PR is to try applying `subsingleton.elim` on any goals created by the `congr_core` tactic.

The command to check whether Lean gives no (additional) errors on the `lean36` branch of mathlib is still running on my machine, but has given no errors yet.