### PR TITLE
feat(module): hash source code instead of tracking timestamps

### DIFF
--- a/src/api/module.cpp
+++ b/src/api/module.cpp
@@ -35,7 +35,7 @@ lean_bool lean_env_import(lean_env env, lean_ios ios, lean_list_name modules, le
 lean_bool lean_env_export(lean_env env, char const * fname, lean_exception * ex) {
     LEAN_TRY;
     check_nonnull(env);
-    auto lm = export_module(to_env_ref(env), fname);
+    auto lm = export_module(to_env_ref(env), fname, 0, 0);
     std::ofstream out(fname, std::ofstream::binary);
     write_module(lm, out);
     LEAN_CATCH;

--- a/src/library/module.cpp
+++ b/src/library/module.cpp
@@ -251,7 +251,7 @@ void write_module(loaded_module const & mod, std::ostream & out) {
     }
 
     std::string r = out1.str();
-    unsigned blob_hash    = hash_data(r);
+    unsigned blob_hash = hash_data(r);
 
     bool uses_sorry = get(mod.m_uses_sorry);
 

--- a/src/library/module.cpp
+++ b/src/library/module.cpp
@@ -235,10 +235,6 @@ deserializer & operator>>(deserializer & d, module_name & r) {
     return d;
 }
 
-static unsigned olean_hash(std::string const & data) {
-    return hash(data.size(), [&] (unsigned i) { return static_cast<unsigned char>(data[i]); });
-}
-
 void write_module(loaded_module const & mod, std::ostream & out) {
     std::ostringstream out1(std::ios_base::binary);
     serializer s1(out1);
@@ -255,13 +251,15 @@ void write_module(loaded_module const & mod, std::ostream & out) {
     }
 
     std::string r = out1.str();
-    unsigned h    = olean_hash(r);
+    unsigned blob_hash    = hash_data(r);
 
     bool uses_sorry = get(mod.m_uses_sorry);
 
     serializer s2(out);
     s2 << g_olean_header << get_version_string();
-    s2 << h;
+    s2 << mod.m_src_hash;
+    s2 << mod.m_trans_hash;
+    s2 << blob_hash;
     s2 << uses_sorry;
     // store imported files
     s2 << static_cast<unsigned>(mod.m_imports.size());
@@ -277,7 +275,7 @@ static task<bool> has_sorry(modification_list const & mods) {
     return any(introduced_exprs, [] (expr const & e) { return has_sorry(e); });
 }
 
-loaded_module export_module(environment const & env, std::string const & mod_name) {
+loaded_module export_module(environment const & env, std::string const & mod_name, unsigned src_hash, unsigned trans_hash) {
     loaded_module out;
     out.m_module_name = mod_name;
 
@@ -290,6 +288,9 @@ loaded_module export_module(environment const & env, std::string const & mod_nam
     std::reverse(out.m_modifications.begin(), out.m_modifications.end());
 
     out.m_uses_sorry = has_sorry(out.m_modifications);
+
+    out.m_src_hash = src_hash;
+    out.m_trans_hash = trans_hash;
 
     return out;
 }
@@ -579,7 +580,7 @@ optional<declaration> is_decl_modification(modification const & mod) {
 
 } // end of namespace module
 
-bool is_candidate_olean_file(std::string const & file_name) {
+bool is_candidate_olean_file(std::string const & file_name, unsigned src_hash) {
     std::ifstream in(file_name);
     deserializer d1(in, optional<std::string>(file_name));
     std::string header, version;
@@ -591,6 +592,10 @@ bool is_candidate_olean_file(std::string const & file_name) {
     if (version != get_version_string())
         return false;
 #endif
+    unsigned olean_src_hash;
+    d1 >> olean_src_hash;
+    if (olean_src_hash != src_hash)
+        return false;
     return true;
 }
 
@@ -600,11 +605,11 @@ olean_data parse_olean(std::istream & in, std::string const & file_name, bool ch
 
     deserializer d1(in, optional<std::string>(file_name));
     std::string header, version;
-    unsigned claimed_hash;
+    unsigned src_hash, trans_hash, claimed_blob_hash;
     d1 >> header;
     if (header != g_olean_header)
         throw exception(sstream() << "file '" << file_name << "' does not seem to be a valid object Lean file, invalid header");
-    d1 >> version >> claimed_hash;
+    d1 >> version >> src_hash >> trans_hash >> claimed_blob_hash;
     // version has already been checked in `is_candidate_olean_file`
 
     d1 >> uses_sorry;
@@ -624,12 +629,12 @@ olean_data parse_olean(std::istream & in, std::string const & file_name, bool ch
 
 //    if (m_senv.env().trust_lvl() <= LEAN_BELIEVER_TRUST_LEVEL) {
     if (check_hash) {
-        unsigned computed_hash = olean_hash(code);
-        if (claimed_hash != computed_hash)
+        unsigned computed_hash = hash_data(code);
+        if (claimed_blob_hash != computed_hash)
             throw exception(sstream() << "file '" << file_name << "' has been corrupted, checksum mismatch");
     }
 
-    return { imports, code, uses_sorry };
+    return { imports, code, src_hash, trans_hash, uses_sorry };
 }
 
 static void import_module(environment & env, std::string const & module_file_name, module_name const & ref,
@@ -762,8 +767,8 @@ module_loader mk_olean_loader(std::vector<std::string> const & path) {
         auto parsed = parse_olean(in, fn, check_hash);
         auto modifs = parse_olean_modifications(parsed.m_serialized_modifications, fn);
         return std::make_shared<loaded_module>(
-                loaded_module { fn, parsed.m_imports, modifs,
-                                mk_pure_task<bool>(parsed.m_uses_sorry), {} });
+                loaded_module { fn, parsed.m_imports, parsed.m_src_hash, parsed.m_trans_hash,
+                                modifs, mk_pure_task<bool>(parsed.m_uses_sorry), {} });
     };
 }
 

--- a/src/library/module.h
+++ b/src/library/module.h
@@ -37,6 +37,7 @@ using modification_list = std::vector<std::shared_ptr<modification const>>;
 struct loaded_module {
     std::string m_module_name;
     std::vector<module_name> m_imports;
+    unsigned m_src_hash, m_trans_hash;
     modification_list m_modifications;
     task<bool> m_uses_sorry;
 
@@ -86,19 +87,21 @@ optional<pos_info> get_decl_pos_info(environment const & env, name const & decl_
 environment add_transient_decl_pos_info(environment const & env, name const & decl_name, pos_info const & pos);
 
 /** \brief Store/Export module using \c env. */
-loaded_module export_module(environment const & env, std::string const & mod_name);
+loaded_module export_module(environment const & env, std::string const & mod_name, unsigned src_hash, unsigned trans_hash);
 void write_module(loaded_module const & mod, std::ostream & out);
 
 std::shared_ptr<loaded_module const> cache_preimported_env(
         loaded_module &&, environment const & initial_env,
         std::function<module_loader()> const & mk_mod_ldr);
 
-/** \brief Check whether we should try to load the given .olean file according to its header and Lean version. */
-bool is_candidate_olean_file(std::string const & file_name);
+/** \brief Check whether we should try to load the given .olean file according to its header and Lean version,
+ * as well as the hash (after normalizing line endings) of the Lean source to which it should correspond. */
+bool is_candidate_olean_file(std::string const & file_name, unsigned src_hash);
 
 struct olean_data {
     std::vector<module_name> m_imports;
     std::string m_serialized_modifications;
+    unsigned m_src_hash, m_trans_hash;
     bool m_uses_sorry;
 };
 olean_data parse_olean(std::istream & in, std::string const & file_name, bool check_hash = true);

--- a/src/library/module_mgr.cpp
+++ b/src/library/module_mgr.cpp
@@ -188,7 +188,7 @@ void module_mgr::build_module(module_id const & id, bool can_use_olean, name_set
 
                 auto & d_mod = m_modules[d_id];
                 mod->m_deps.push_back({ d_id, d, d_mod });
-                actual_trans_hash ^= d_mod->m_trans_hash;
+                actual_trans_hash = hash(actual_trans_hash, d_mod->m_trans_hash);
             }
 
             // If anything in the reflexive-transitive closure of this module under the import relation
@@ -242,7 +242,7 @@ void module_mgr::build_lean(std::shared_ptr<module_info> const & mod, name_set c
             d_id = resolve(d, id);
             build_module(d_id, true, module_stack);
             d_mod = m_modules[d_id];
-            mod->m_trans_hash ^= d_mod->m_trans_hash;
+            mod->m_trans_hash = hash(mod->m_trans_hash, d_mod->m_trans_hash);
         } catch (throwable & ex) {
             message_builder(m_initial_env, m_ios, id, {1, 0}, ERROR).set_exception(ex).report();
         }

--- a/src/library/module_mgr.cpp
+++ b/src/library/module_mgr.cpp
@@ -188,7 +188,7 @@ void module_mgr::build_module(module_id const & id, bool can_use_olean, name_set
 
                 auto & d_mod = m_modules[d_id];
                 mod->m_deps.push_back({ d_id, d, d_mod });
-                actual_trans_hash ^= d_mod->m_trans_hash;
+                actual_trans_hash = combine_hashes(actual_trans_hash, d_mod->m_trans_hash);
             }
 
             // If anything in the reflexive-transitive closure of this module under the import relation
@@ -242,7 +242,7 @@ void module_mgr::build_lean(std::shared_ptr<module_info> const & mod, name_set c
             d_id = resolve(d, id);
             build_module(d_id, true, module_stack);
             d_mod = m_modules[d_id];
-            mod->m_trans_hash ^= d_mod->m_trans_hash;
+            mod->m_trans_hash = combine_hashes(mod->m_trans_hash, d_mod->m_trans_hash);
         } catch (throwable & ex) {
             message_builder(m_initial_env, m_ios, id, {1, 0}, ERROR).set_exception(ex).report();
         }

--- a/src/library/module_mgr.cpp
+++ b/src/library/module_mgr.cpp
@@ -188,7 +188,7 @@ void module_mgr::build_module(module_id const & id, bool can_use_olean, name_set
 
                 auto & d_mod = m_modules[d_id];
                 mod->m_deps.push_back({ d_id, d, d_mod });
-                actual_trans_hash = combine_hashes(actual_trans_hash, d_mod->m_trans_hash);
+                actual_trans_hash ^= d_mod->m_trans_hash;
             }
 
             // If anything in the reflexive-transitive closure of this module under the import relation
@@ -242,7 +242,7 @@ void module_mgr::build_lean(std::shared_ptr<module_info> const & mod, name_set c
             d_id = resolve(d, id);
             build_module(d_id, true, module_stack);
             d_mod = m_modules[d_id];
-            mod->m_trans_hash = combine_hashes(mod->m_trans_hash, d_mod->m_trans_hash);
+            mod->m_trans_hash ^= d_mod->m_trans_hash;
         } catch (throwable & ex) {
             message_builder(m_initial_env, m_ios, id, {1, 0}, ERROR).set_exception(ex).report();
         }

--- a/src/library/module_mgr.cpp
+++ b/src/library/module_mgr.cpp
@@ -188,7 +188,6 @@ void module_mgr::build_module(module_id const & id, bool can_use_olean, name_set
 
                 auto & d_mod = m_modules[d_id];
                 mod->m_deps.push_back({ d_id, d, d_mod });
-                // TODO(Vtec234): better way to mix hashes
                 actual_trans_hash ^= d_mod->m_trans_hash;
             }
 
@@ -243,7 +242,6 @@ void module_mgr::build_lean(std::shared_ptr<module_info> const & mod, name_set c
             d_id = resolve(d, id);
             build_module(d_id, true, module_stack);
             d_mod = m_modules[d_id];
-            // TODO(Vtec234): better mix
             mod->m_trans_hash ^= d_mod->m_trans_hash;
         } catch (throwable & ex) {
             message_builder(m_initial_env, m_ios, id, {1, 0}, ERROR).set_exception(ex).report();

--- a/src/library/module_mgr.h
+++ b/src/library/module_mgr.h
@@ -33,7 +33,7 @@ struct module_info {
     module_id m_id;
     std::string m_contents;
     // Hash of the Lean source (after normalizing line endings) yielding this module:
-    // - if m_source == LEAN, hash(remove_cr(m_contents))
+    // - if m_source == LEAN, hash_data(remove_cr(m_contents))
     // - if m_source == OLEAN, value loaded from the .olean
     unsigned m_src_hash;
     // Transitive hash of all source code this module was built from,

--- a/src/library/module_mgr.h
+++ b/src/library/module_mgr.h
@@ -32,8 +32,14 @@ struct module_info {
 
     module_id m_id;
     std::string m_contents;
+    // Hash of the Lean source (after normalizing line endings) yielding this module:
+    // - if m_source == LEAN, hash(remove_cr(m_contents))
+    // - if m_source == OLEAN, value loaded from the .olean
+    unsigned m_src_hash;
+    // Transitive hash of all source code this module was built from,
+    // i.e. m_src_hash mixed with the m_trans_hash of each imported module
+    unsigned m_trans_hash;
     module_src m_source = module_src::LEAN;
-    time_t m_mtime = -1, m_trans_mtime = -1;
 
     struct dependency {
         module_id m_id;
@@ -63,10 +69,13 @@ struct module_info {
 
     module_info() {}
 
-    module_info(module_id const & id, std::string const & contents, module_src src, time_t mtime)
-            : m_id(id), m_contents(contents), m_source(src), m_mtime(mtime) {}
+    module_info(module_id const & id, std::string const & contents, unsigned src_hash, unsigned trans_hash, module_src src)
+            : m_id(id), m_contents(contents), m_src_hash(src_hash), m_trans_hash(trans_hash), m_source(src) {}
 };
 
+/* A virtual interface for loading Lean modules by name. It has two instantiations:
+- `fs_module_vs` for loading modules from disk
+- `server` for loading modules open in an editor */
 class module_vfs {
 public:
     virtual ~module_vfs() {}

--- a/src/shell/CMakeLists.txt
+++ b/src/shell/CMakeLists.txt
@@ -212,6 +212,11 @@ FOREACH(T ${LEANPKGTESTS})
 ENDFOREACH(T)
 endif()
 
+# LEAN IMPORTING TEST
+add_test(NAME "leantest_importing"
+         WORKING_DIRECTORY "${LEAN_SOURCE_DIR}/../tests/lean/importing/"
+         COMMAND bash "./test_importing.sh" "${LEAN_SOURCE_DIR}/../bin/lean")
+
 # LEAN TESTS using --trust=0
 file(GLOB LEANT0TESTS "${LEAN_SOURCE_DIR}/../tests/lean/trust0/*.lean")
 FOREACH(T ${LEANT0TESTS})

--- a/src/shell/server.cpp
+++ b/src/shell/server.cpp
@@ -488,8 +488,8 @@ server::cmd_res server::handle_sync(server::cmd_req const & req) {
         new_content = load_module(new_file_name, /* can_use_olean */ false)->m_contents;
     }
 
-    // TODO(Vtec234): by how much is hashing on sync going to slow the server down?
-    // The hash should be super-fast -- maybe xxHash?
+    // NOTE(Vtec234): as of 2020-03-05, hashing all of mathlib takes about .1s on
+    // a 2.7GHz cpu, so this should not have observable performance impact.
     unsigned new_hash = hash_data(remove_cr(new_content));
 
     bool needs_invalidation = true;

--- a/src/shell/server.h
+++ b/src/shell/server.h
@@ -60,8 +60,8 @@ class server : public module_vfs {
     io_state m_ios;
 
     struct editor_file {
-        time_t m_mtime;
         std::string m_content;
+        unsigned m_src_hash;
     };
     std::unordered_map<std::string, editor_file> m_open_files;
 

--- a/src/util/CMakeLists.txt
+++ b/src/util/CMakeLists.txt
@@ -3,7 +3,7 @@ add_library(util OBJECT debug.cpp name.cpp name_set.cpp fresh_name.cpp
   safe_arith.cpp ascii.cpp memory.cpp shared_mutex.cpp path.cpp
   stackinfo.cpp lean_path.cpp serializer.cpp lbool.cpp
   bitap_fuzzy_search.cpp init_module.cpp thread.cpp memory_pool.cpp
-  utf8.cpp name_map.cpp list_fn.cpp file_lock.cpp
+  utf8.cpp name_map.cpp line_endings.cpp list_fn.cpp file_lock.cpp
   timeit.cpp timer.cpp task.cpp task_builder.cpp cancellable.cpp
   log_tree.cpp small_object_allocator.cpp subscripted_name_set.cpp
   parser_exception.cpp name_generator.cpp)

--- a/src/util/hash.cpp
+++ b/src/util/hash.cpp
@@ -67,11 +67,4 @@ unsigned hash_data(std::string const & data) {
     return hash(data.size(), [&] (unsigned i) { return static_cast<unsigned char>(data.data()[i]); });
 }
 
-unsigned combine_hashes(unsigned h1, unsigned h2) {
-    // https://stackoverflow.com/a/1646913
-    unsigned ret = 17;
-    ret = ret * 31 + h1;
-    return ret * 31 + h2;
-}
-
 }

--- a/src/util/hash.cpp
+++ b/src/util/hash.cpp
@@ -67,4 +67,11 @@ unsigned hash_data(std::string const & data) {
     return hash(data.size(), [&] (unsigned i) { return static_cast<unsigned char>(data.data()[i]); });
 }
 
+unsigned combine_hashes(unsigned h1, unsigned h2) {
+    // https://stackoverflow.com/a/1646913
+    unsigned ret = 17;
+    ret = ret * 31 + h1;
+    return ret * 31 + h2;
+}
+
 }

--- a/src/util/hash.cpp
+++ b/src/util/hash.cpp
@@ -4,6 +4,8 @@ Released under Apache 2.0 license as described in the file LICENSE.
 
 Author: Leonardo de Moura
 */
+#include "hash.h"
+
 namespace lean {
 
 void mix(unsigned & a, unsigned & b, unsigned & c) {
@@ -58,6 +60,10 @@ unsigned hash_str(unsigned length, char const * str, unsigned init_value) {
     mix(a, b, c);
     /*-------------------------------------------- report the result */
     return c;
+}
+
+unsigned hash_data(std::string const & data) {
+    return hash(data.size(), [&] (unsigned i) { return static_cast<unsigned char>(data.data()[i]); });
 }
 
 }

--- a/src/util/hash.cpp
+++ b/src/util/hash.cpp
@@ -4,7 +4,8 @@ Released under Apache 2.0 license as described in the file LICENSE.
 
 Author: Leonardo de Moura
 */
-#include "hash.h"
+#include "util/hash.h"
+#include <string>
 
 namespace lean {
 

--- a/src/util/hash.h
+++ b/src/util/hash.h
@@ -5,6 +5,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Author: Leonardo de Moura
 */
 #pragma once
+#include <string>
 #include "util/debug.h"
 #include "util/int64.h"
 
@@ -13,6 +14,8 @@ namespace lean {
 void mix(unsigned & a, unsigned & b, unsigned & c);
 
 unsigned hash_str(unsigned len, char const * str, unsigned init_value);
+
+unsigned hash_data(std::string const & data);
 
 inline unsigned hash(unsigned h1, unsigned h2) {
     h2 -= h1; h2 ^= (h1 << 8);

--- a/src/util/hash.h
+++ b/src/util/hash.h
@@ -17,6 +17,8 @@ unsigned hash_str(unsigned len, char const * str, unsigned init_value);
 
 unsigned hash_data(std::string const & data);
 
+unsigned combine_hashes(unsigned h1, unsigned h2);
+
 inline unsigned hash(unsigned h1, unsigned h2) {
     h2 -= h1; h2 ^= (h1 << 8);
     h1 -= h2; h2 ^= (h1 << 16);

--- a/src/util/hash.h
+++ b/src/util/hash.h
@@ -17,8 +17,6 @@ unsigned hash_str(unsigned len, char const * str, unsigned init_value);
 
 unsigned hash_data(std::string const & data);
 
-unsigned combine_hashes(unsigned h1, unsigned h2);
-
 inline unsigned hash(unsigned h1, unsigned h2) {
     h2 -= h1; h2 ^= (h1 << 8);
     h1 -= h2; h2 ^= (h1 << 16);

--- a/src/util/line_endings.cpp
+++ b/src/util/line_endings.cpp
@@ -1,0 +1,23 @@
+/*
+Copyright (c) 2016-2020 Microsoft Corporation. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+
+Authors: Gabriel Ebner, Wojciech Nawrocki
+*/
+#include "util/line_endings.h"
+#include <string>
+#include <algorithm>
+
+namespace lean {
+
+std::string remove_cr(std::string const & str) {
+    std::string ret = str;
+    ret.erase(std::remove(ret.begin(), ret.end(), '\r'), ret.end());
+    return ret;
+}
+
+bool equal_upto_cr(std::string const & a, std::string const & b) {
+    return remove_cr(a) == remove_cr(b);
+}
+
+}

--- a/src/util/line_endings.h
+++ b/src/util/line_endings.h
@@ -1,0 +1,19 @@
+/*
+Copyright (c) 2016 Microsoft Corporation. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+
+Author: Gabriel Ebner
+*/
+#pragma once
+#include <string>
+#include <algorithm>
+
+static void remove_cr(std::string & str) {
+    str.erase(std::remove(str.begin(), str.end(), '\r'), str.end());
+}
+
+static bool equal_upto_cr(std::string a, std::string b) {
+    remove_cr(a);
+    remove_cr(b);
+    return a == b;
+}

--- a/src/util/line_endings.h
+++ b/src/util/line_endings.h
@@ -1,19 +1,14 @@
 /*
-Copyright (c) 2016 Microsoft Corporation. All rights reserved.
+Copyright (c) 2016-2020 Microsoft Corporation. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 
-Author: Gabriel Ebner
+Author: Gabriel Ebner, Wojciech Nawrocki
 */
 #pragma once
 #include <string>
-#include <algorithm>
 
-static void remove_cr(std::string & str) {
-    str.erase(std::remove(str.begin(), str.end(), '\r'), str.end());
-}
+namespace lean {
+std::string remove_cr(std::string const & str);
 
-static bool equal_upto_cr(std::string a, std::string b) {
-    remove_cr(a);
-    remove_cr(b);
-    return a == b;
+bool equal_upto_cr(std::string const & a, std::string const & b);
 }

--- a/src/util/path.cpp
+++ b/src/util/path.cpp
@@ -173,11 +173,11 @@ std::string read_file(std::string const & fname, std::ios_base::openmode mode) {
     return buf.str();
 }
 
-time_t get_mtime(std::string const &fname) {
+bool file_exists(std::string const &fname) {
     struct stat st;
     if (stat(fname.c_str(), &st) != 0)
-        return -1;
-    return st.st_mtime;
+        return false;
+    return true;
 }
 
 optional<bool> is_dir(std::string const & fn) {

--- a/src/util/path.h
+++ b/src/util/path.h
@@ -41,7 +41,7 @@ bool is_directory(std::string const & fn);
 optional<bool> is_dir(std::string const & fn);
 std::vector<std::string> read_dir(std::string const & dirname);
 
-time_t get_mtime(std::string const & fname);
+bool file_exists(std::string const & fname);
 
 std::string lrealpath(std::string const & fname);
 }

--- a/tests/lean/importing/test_importing.sh
+++ b/tests/lean/importing/test_importing.sh
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+if [ $# -ne 1 ]; then
+    echo "Usage: test_importing.sh [lean-executable-path]"
+    exit 1
+fi
+ulimit -s 8192
+LEAN=$1
+export LEAN_PATH=../../../library:.
+
+cat <<EOF > foo.lean
+run_cmd tactic.trace "foo"
+EOF
+rm -f foo.olean
+
+out=$($LEAN --make ./foo.lean 2>&1)
+if [[ $out != "foo" ]]; then
+    echo "-- Lean isn't building foo: got $out , expected foo"
+    exit 1
+fi
+
+touch foo.lean
+out=$($LEAN --make ./foo.lean 2>&1)
+if [[ $out != "" ]]; then
+    echo "-- Lean rebuilds foo on timestamp change: got $out , expected no output"
+    exit 1
+fi
+
+cat <<EOF > x.lean
+def x := 0
+run_cmd tactic.trace "x"
+EOF
+cat <<EOF > y.lean
+import x
+def y := x
+run_cmd tactic.trace "y"
+EOF
+cat <<EOF > z.lean
+import y
+def z := y
+run_cmd tactic.trace "z"
+EOF
+rm -f x.olean y.olean z.olean
+
+out=$($LEAN --make z.lean 2>&1 | tr -d '\n')
+if [[ "$out" != "xyz" ]]; then
+    echo "-- Wrong modules built: got $out , expected xyz"
+    exit 1
+fi
+
+cat <<EOF > y.lean
+def y := 1
+run_cmd tactic.trace "y"
+EOF
+
+out=$($LEAN --make z.lean 2>&1 | tr -d '\n')
+if [[ "$out" != "yz" ]]; then
+    echo "-- Wrong modules built: got $out , expected yz"
+    exit 1
+fi
+
+cat <<EOF > y.lean
+import x
+def y := x
+run_cmd tactic.trace "y"
+EOF
+
+out=$($LEAN --make z.lean 2>&1 | tr -d '\n')
+if [[ "$out" != "yz" ]]; then
+    echo "-- Wrong modules built: got $out , expected yz"
+    exit 1
+fi
+
+touch x.lean
+out=$($LEAN --make z.lean 2>&1 | tr -d '\n')
+if [[ "$out" != "" ]]; then
+    echo "-- Wrong modules built: got $out , expected no output"
+    exit 1
+fi
+
+rm -f foo.lean foo.olean x.lean x.olean y.lean y.olean z.lean z.olean

--- a/tests/lean/importing/test_importing.sh
+++ b/tests/lean/importing/test_importing.sh
@@ -4,7 +4,7 @@ if [ $# -ne 1 ]; then
     exit 1
 fi
 ulimit -s 8192
-LEAN=$1
+LEAN_MAKE="$1 -j0 --make"
 export LEAN_PATH=../../../library:.
 
 cat <<EOF > foo.lean
@@ -12,14 +12,14 @@ run_cmd tactic.trace "foo"
 EOF
 rm -f foo.olean
 
-out=$($LEAN --make ./foo.lean 2>&1)
+out=$($LEAN_MAKE ./foo.lean 2>&1)
 if [[ $out != "foo" ]]; then
     echo "-- Lean isn't building foo: got $out , expected foo"
     exit 1
 fi
 
 touch foo.lean
-out=$($LEAN --make ./foo.lean 2>&1)
+out=$($LEAN_MAKE ./foo.lean 2>&1)
 if [[ $out != "" ]]; then
     echo "-- Lean rebuilds foo on timestamp change: got $out , expected no output"
     exit 1
@@ -41,7 +41,7 @@ run_cmd tactic.trace "z"
 EOF
 rm -f x.olean y.olean z.olean
 
-out=$($LEAN --make z.lean 2>&1 | tr -d '\n')
+out=$($LEAN_MAKE z.lean 2>&1 | tr -d '\n')
 if [[ "$out" != "xyz" ]]; then
     echo "-- Wrong modules built: got $out , expected xyz"
     exit 1
@@ -52,7 +52,7 @@ def y := 1
 run_cmd tactic.trace "y"
 EOF
 
-out=$($LEAN --make z.lean 2>&1 | tr -d '\n')
+out=$($LEAN_MAKE z.lean 2>&1 | tr -d '\n')
 if [[ "$out" != "yz" ]]; then
     echo "-- Wrong modules built: got $out , expected yz"
     exit 1
@@ -64,14 +64,14 @@ def y := x
 run_cmd tactic.trace "y"
 EOF
 
-out=$($LEAN --make z.lean 2>&1 | tr -d '\n')
+out=$($LEAN_MAKE z.lean 2>&1 | tr -d '\n')
 if [[ "$out" != "yz" ]]; then
     echo "-- Wrong modules built: got $out , expected yz"
     exit 1
 fi
 
 touch x.lean
-out=$($LEAN --make z.lean 2>&1 | tr -d '\n')
+out=$($LEAN_MAKE z.lean 2>&1 | tr -d '\n')
 if [[ "$out" != "" ]]; then
     echo "-- Wrong modules built: got $out , expected no output"
     exit 1

--- a/tests/lean/importing/test_importing.sh
+++ b/tests/lean/importing/test_importing.sh
@@ -41,7 +41,7 @@ run_cmd tactic.trace "z"
 EOF
 rm -f x.olean y.olean z.olean
 
-out=$($LEAN_MAKE z.lean 2>&1 | tr -d '\n')
+out=$($LEAN_MAKE z.lean 2>&1 | tr -d '\r\n')
 if [[ "$out" != "xyz" ]]; then
     echo "-- Wrong modules built: got $out , expected xyz"
     exit 1
@@ -52,7 +52,7 @@ def y := 1
 run_cmd tactic.trace "y"
 EOF
 
-out=$($LEAN_MAKE z.lean 2>&1 | tr -d '\n')
+out=$($LEAN_MAKE z.lean 2>&1 | tr -d '\r\n')
 if [[ "$out" != "yz" ]]; then
     echo "-- Wrong modules built: got $out , expected yz"
     exit 1
@@ -64,14 +64,14 @@ def y := x
 run_cmd tactic.trace "y"
 EOF
 
-out=$($LEAN_MAKE z.lean 2>&1 | tr -d '\n')
+out=$($LEAN_MAKE z.lean 2>&1 | tr -d '\r\n')
 if [[ "$out" != "yz" ]]; then
     echo "-- Wrong modules built: got $out , expected yz"
     exit 1
 fi
 
 touch x.lean
-out=$($LEAN_MAKE z.lean 2>&1 | tr -d '\n')
+out=$($LEAN_MAKE z.lean 2>&1 | tr -d '\r\n')
 if [[ "$out" != "" ]]; then
     echo "-- Wrong modules built: got $out , expected no output"
     exit 1


### PR DESCRIPTION
This should resolve the timestamp problem (#112) -- with this change, timestamps are irrelevant and Lean only recompiles .oleans if the source code has changed. This PR replaces `m_mtime` and `m_trans_mtime` in the module manager with `m_src_hash` and `m_trans_hash` which are stored in .olean files and defined as follows:
```cpp
    // Hash of the Lean source (after normalizing line endings) yielding this module:
    // - if m_source == LEAN, hash(remove_cr(m_contents))
    // - if m_source == OLEAN, value loaded from the .olean
    unsigned m_src_hash;
    // Transitive hash of all source code this module was built from,
    // i.e. m_src_hash mixed with the m_trans_hash of each imported module
    unsigned m_trans_hash;
```
If `foo.lean` changes, the `m_src_hash` in `foo.olean` no longer matches while if any of the transitively imported sources change, `m_trans_hash` will no longer match.

It seems to work (`touch` doesn't cause recompilation and changing an `x.lean` correctly recompiles `z.lean` if `x -> y -> z` is an import chain), but I can't say I fully understand the module manager, so a review from @gebner would be appreciated. ~There are some TODOs left and I should also add some dynamic tests that change files and see if they recompile.~

2020-03-06: I added a janky test of when imports are rebuilt, the PR should now be ready to go.