### PR TITLE
fix(library/type_context): inconsistent unification of match-based definitions

### DIFF
--- a/src/library/type_context.cpp
+++ b/src/library/type_context.cpp
@@ -597,13 +597,20 @@ optional<expr> type_context_old::unfold_definition(expr const & e) {
                 return some_expr(r);
             }
         }
-    } else if (auto r = unfold_definition_core(e)) {
-        if (optional<expr> new_r = extract_id_rhs(*r))
-            return new_r;
-        else
-            return r;
     } else {
-        return none_expr();
+        // Block unfolding of constants that are smart unfolding targets,
+        // because they are also blocked if applied to a non-matching term.
+        if (is_constant(e) && m_smart_unfolding && is_smart_unfolding_target(env(), const_name(e))) {
+            return none_expr();
+        }
+        if (auto r = unfold_definition_core(e)) {
+            if (optional<expr> new_r = extract_id_rhs(*r))
+                return new_r;
+            else
+                return r;
+        } else {
+            return none_expr();
+        }
     }
 }
 

--- a/tests/lean/defeq_match.lean
+++ b/tests/lean/defeq_match.lean
@@ -1,0 +1,4 @@
+constants (p : (nat → nat → nat) → Prop) (p_add : p nat.add)
+
+-- The failure case we want to avoid is unfolding `nat.add` and not `λ a b, nat.add a b`
+example : p (λ a b, nat.add a b) := p_add

--- a/tests/lean/match_at_type.lean
+++ b/tests/lean/match_at_type.lean
@@ -9,6 +9,3 @@ sorry
 
 instance I2 : decidable (Foo2 (λ ⟨a, b⟩, a)) :=
 sorry
-
-def test (f : ((Σu:nat, nat) → nat) → nat) : f (λ ⟨a, b⟩, a) = f (λ⟨a, b⟩, a) :=
-eq.refl (f ((λ ⟨a, b⟩, a : (Σu:nat, nat) → nat)))

--- a/tests/lean/run/sigma_match.lean
+++ b/tests/lean/run/sigma_match.lean
@@ -20,10 +20,10 @@ match x with
 end
 
 example (A B : Type) (x : arrow_ob A B) : src1 x = src2 x :=
-rfl
+by { cases x; cases x_snd; refl }
 
 example (A B : Type) (x : arrow_ob A B) : src1 x = src3 x :=
-rfl
+by { cases x; cases x_snd; refl }
 
 example (A B : Type) (x : arrow_ob A B) : src2 x = src3 x :=
-rfl
+by { cases x; cases x_snd; refl }


### PR DESCRIPTION
The issue was that `nat.add` didn't get unified with `λ a b, nat.add a b`, because `nat.add` is defined using matches. If such a definition is applied to a term, only when the term matches one of the match cases the whole is unfolded.  In contrast, if there is no application, the constant `nat.add` is happily unfolded all the way. Thus the elaborator decides unification fails.

There are basically two solutions: unfolding more (i.e. also unfold `nat.add a b`) or unfolding less (i.e. don't unfold `nat.add`). Since unfolding `nat.add` would expose implementation details, namely the `nat.add._main` function, choosing to unfold less is better.

But this leads to another issue: now `λ <a, b>, a` does not unify with `λ <a, b>, a` if they are defined separately. This is not a big issue since `example : let c := 0 in (λ <a, b>, a + c) = (λ <a, b>, a + c) := rfl` didn't work anyway. Hence the changed tests.