### PR TITLE
fix(library/vm/interaction_state_imp): remove dangerous functions

### DIFF
--- a/src/library/tactic/vm_type_context.cpp
+++ b/src/library/tactic/vm_type_context.cpp
@@ -46,7 +46,8 @@ vm_obj tco_run (vm_obj const &, vm_obj const & tco, vm_obj const & t, vm_obj con
     if (is_succ(result)) {
         return tactic::mk_success(value(result), set_mctx(s, ctx.mctx()));
     } else {
-        return tactic::mk_exception(value(result), s);
+        auto fmt_thunk = value(result);
+        return tactic::mk_exception_from_format_thunk(fmt_thunk, s);
     }
 }
 vm_obj tco_infer (vm_obj const & e, vm_obj const & tco) {

--- a/src/library/vm/interaction_state.h
+++ b/src/library/vm/interaction_state.h
@@ -47,9 +47,8 @@ struct interaction_monad {
     static vm_obj mk_success(vm_obj const & a, vm_obj const & s);
     static vm_obj mk_success(vm_obj const & a, State const & s);
     static vm_obj mk_success(State const & s);
-    static vm_obj mk_exception(vm_obj const & fn, State const & s);
+    static vm_obj mk_exception_from_format_thunk(vm_obj const & fn, State const & s);
     static vm_obj mk_silent_exception(State const & s);
-    static vm_obj mk_exception(vm_obj const & fn, vm_obj const & pos, State const & s);
     static vm_obj mk_exception(throwable const & ex, State const & s);
     static vm_obj mk_exception(format const & fmt, State const & s);
     static vm_obj mk_exception(char const * msg, State const & s);

--- a/tests/lean/issue136.lean
+++ b/tests/lean/issue136.lean
@@ -1,0 +1,6 @@
+
+meta def tactic.interactive.test (a : interactive.parse
+  (lean.parser.of_tactic (@tactic.fail ℕ _ _ "oh no"))) :=
+tactic.skip
+
+example : true := begin test end -- should be "oh no"

--- a/tests/lean/issue136.lean.expected.out
+++ b/tests/lean/issue136.lean.expected.out
@@ -1,0 +1,2 @@
+issue136.lean:6:29: error: oh no
+issue136.lean:6:0: warning: declaration '[anonymous]' uses sorry


### PR DESCRIPTION
Fixes #136.

The interaction_monad.exception constructor takes an `option (thunk format)` as argument.  The functions in `interaction_state_imp.h` treated this inconsistently: `get_exception_message` returned the option, while the `mk_exception` function wrapped it in a some.