### PR TITLE
fix(module): load standalone .oleans

### DIFF
--- a/doc/changes.md
+++ b/doc/changes.md
@@ -1,8 +1,8 @@
 v3.7.1c (?? Mar 2020)
 ---------------------
 
-Bug fixes:
-    - Allow loading standalone .olean files (#150)
+Bug fix:
+  - Allow loading standalone .olean files (#150)
 
 v3.7.0c (13 Mar 2020)
 ---------------------
@@ -23,6 +23,12 @@ Changes:
   - Type class resolution solves instance arguments from right-to-left (#139)
   - Type class resolution skips assigned metavariables (#135)
   - Signature of `has_attribute` and `copy_attribute` has changed (#66)
+  
+v3.6.1c (2 Mar 2020)
+--------------------
+
+Bug fix:
+  - Correctly reference the community fork of Lean in `leanpkg.toml` (#131)
 
 v3.6.0c (26 Feb 2020)
 ---------------------

--- a/doc/changes.md
+++ b/doc/changes.md
@@ -1,5 +1,11 @@
-v3.7.0c (?? Mar 2020)
---------------------
+v3.7.1c (?? Mar 2020)
+---------------------
+
+Bug fixes:
+    - Allow loading standalone .olean files (#150)
+
+v3.7.0c (13 Mar 2020)
+---------------------
 
 Features:
   - `simp` can rewrite subsingletons (#134)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -5,7 +5,7 @@ endif()
 project(LEAN CXX C)
 set(LEAN_VERSION_MAJOR 3)
 set(LEAN_VERSION_MINOR 7)
-set(LEAN_VERSION_PATCH 0)
+set(LEAN_VERSION_PATCH 1)
 set(LEAN_VERSION_IS_RELEASE 0)  # This number is 1 in the release revision, and 0 otherwise.
 set(LEAN_SPECIAL_VERSION_DESC "" CACHE STRING "Additional version description like 'nightly-2018-03-11'")
 set(LEAN_VERSION_STRING "${LEAN_VERSION_MAJOR}.${LEAN_VERSION_MINOR}.${LEAN_VERSION_PATCH}")

--- a/src/library/module.cpp
+++ b/src/library/module.cpp
@@ -580,23 +580,21 @@ optional<declaration> is_decl_modification(modification const & mod) {
 
 } // end of namespace module
 
-bool is_candidate_olean_file(std::string const & file_name, unsigned src_hash) {
+optional<unsigned> src_hash_if_is_candidate_olean(std::string const & file_name) {
     std::ifstream in(file_name);
     deserializer d1(in, optional<std::string>(file_name));
     std::string header, version;
     d1 >> header;
     if (header != g_olean_header)
-        return false;
+        return {};
     d1 >> version;
 #ifndef LEAN_IGNORE_OLEAN_VERSION
     if (version != get_version_string())
-        return false;
+        return {};
 #endif
     unsigned olean_src_hash;
     d1 >> olean_src_hash;
-    if (olean_src_hash != src_hash)
-        return false;
-    return true;
+    return some<unsigned>(olean_src_hash);
 }
 
 olean_data parse_olean(std::istream & in, std::string const & file_name, bool check_hash) {
@@ -610,7 +608,7 @@ olean_data parse_olean(std::istream & in, std::string const & file_name, bool ch
     if (header != g_olean_header)
         throw exception(sstream() << "file '" << file_name << "' does not seem to be a valid object Lean file, invalid header");
     d1 >> version >> src_hash >> trans_hash >> claimed_blob_hash;
-    // version has already been checked in `is_candidate_olean_file`
+    // version has already been checked in `src_hash_if_is_candidate_olean`
 
     d1 >> uses_sorry;
 

--- a/src/library/module.h
+++ b/src/library/module.h
@@ -94,9 +94,10 @@ std::shared_ptr<loaded_module const> cache_preimported_env(
         loaded_module &&, environment const & initial_env,
         std::function<module_loader()> const & mk_mod_ldr);
 
-/** \brief Check whether we should try to load the given .olean file according to its header and Lean version,
- * as well as the hash (after normalizing line endings) of the Lean source to which it should correspond. */
-bool is_candidate_olean_file(std::string const & file_name, unsigned src_hash);
+/** \brief Checks whether we should try to load the given .olean file according to its header and Lean version.
+ * If yes, returns the hash (after normalizing line endings) of the Lean source to which it corresponds,
+ * otherwise returns none. */
+optional<unsigned> src_hash_if_is_candidate_olean(std::string const & file_name);
 
 struct olean_data {
     std::vector<module_name> m_imports;

--- a/src/util/optional.h
+++ b/src/util/optional.h
@@ -48,6 +48,7 @@ public:
     }
 
     explicit operator bool() const { return m_some; }
+    bool has_value() const { return m_some; }
     T const * operator->() const { lean_assert(m_some); return &m_value; }
     T * operator->() { lean_assert(m_some); return &m_value; }
     T const & operator*() const { lean_assert(m_some); return m_value; }


### PR DESCRIPTION
No longer requires .lean sources to exist to load the .oleans, so that binary distributions are possible, e.g. in the Lean web editor. Issue noted in [Zulip](https://leanprover.zulipchat.com/#narrow/stream/113488-general/topic/Lean.203.2E7.2E0.20released!/near/190659957). CC @bryangingechen 