### PR TITLE
fix(module): open .oleans in binary mode on Windows

### DIFF
--- a/doc/changes.md
+++ b/doc/changes.md
@@ -1,3 +1,9 @@
+v3.7.2c (20 Mar 2020)
+---------------------
+
+Bug fix:
+  - Open .oleans in binary mode on Windows (#155)
+
 v3.7.1c (16 Mar 2020)
 ---------------------
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -5,7 +5,7 @@ endif()
 project(LEAN CXX C)
 set(LEAN_VERSION_MAJOR 3)
 set(LEAN_VERSION_MINOR 7)
-set(LEAN_VERSION_PATCH 1)
+set(LEAN_VERSION_PATCH 2)
 set(LEAN_VERSION_IS_RELEASE 0)  # This number is 1 in the release revision, and 0 otherwise.
 set(LEAN_SPECIAL_VERSION_DESC "" CACHE STRING "Additional version description like 'nightly-2018-03-11'")
 set(LEAN_VERSION_STRING "${LEAN_VERSION_MAJOR}.${LEAN_VERSION_MINOR}.${LEAN_VERSION_PATCH}")

--- a/src/library/module.cpp
+++ b/src/library/module.cpp
@@ -581,7 +581,7 @@ optional<declaration> is_decl_modification(modification const & mod) {
 } // end of namespace module
 
 optional<unsigned> src_hash_if_is_candidate_olean(std::string const & file_name) {
-    std::ifstream in(file_name);
+    std::ifstream in(file_name, std::ios_base::binary);
     deserializer d1(in, optional<std::string>(file_name));
     std::string header, version;
     d1 >> header;


### PR DESCRIPTION
This wasn't caught by the [importing test](https://github.com/leanprover-community/lean/blob/master/tests/lean/importing/test_importing.sh) because it only fails for a small percentage of .oleans which happen to contain something like `\r\n` in the header.