### PR TITLE
fix(library/init): remove `if_simp_congr` for more powerful `if` simplification

### DIFF
--- a/library/init/logic.lean
+++ b/library/init/logic.lean
@@ -881,17 +881,6 @@ lemma if_congr {α : Sort u} {b c : Prop} [dec_b : decidable b] [dec_c : decidab
         ite b x y = ite c u v :=
 @if_ctx_congr α b c dec_b dec_c x y u v h_c (λ h, h_t) (λ h, h_e)
 
-lemma if_ctx_simp_congr {α : Sort u} {b c : Prop} [dec_b : decidable b] {x y u v : α}
-                        (h_c : b ↔ c) (h_t : c → x = u) (h_e : ¬c → y = v) :
-        ite b x y = (@ite c (decidable_of_decidable_of_iff dec_b h_c) α u v) :=
-@if_ctx_congr α b c dec_b (decidable_of_decidable_of_iff dec_b h_c) x y u v h_c h_t h_e
-
-@[congr]
-lemma if_simp_congr {α : Sort u} {b c : Prop} [dec_b : decidable b] {x y u v : α}
-                    (h_c : b ↔ c) (h_t : x = u) (h_e : y = v) :
-        ite b x y = (@ite c (decidable_of_decidable_of_iff dec_b h_c) α u v) :=
-@if_ctx_simp_congr α b c dec_b x y u v h_c (λ h, h_t) (λ h, h_e)
-
 @[simp]
 lemma if_true {α : Sort u} {h : decidable true} (t e : α) : (@ite true h α t e) = t :=
 if_pos trivial

--- a/tests/lean/simp_ite.lean
+++ b/tests/lean/simp_ite.lean
@@ -1,0 +1,12 @@
+-- in older versions, this would get stuck on the equality
+-- `decidable_of_decidable_of_iff dec_p p_iff_p' = dec_p'`
+constants (p p' : Prop) (p_iff_p' : p ↔ p')
+attribute [simp] p_iff_p'
+example (a b : ℕ) [dec_p : decidable p] [dec_p' : decidable p'] :
+  (if p then a else b) = (if p' then a else b) :=
+by simp
+
+-- `simp` shouldn't try rewrite `p` to `p'` without the instance, but still rewrite `a` to `a'`
+constants (a a' b : ℕ) (a_eq_a' : a = a')
+attribute [simp] a_eq_a'
+example [decidable p] : (if p then a else b) = (if p then a' else b) := by simp


### PR DESCRIPTION
This PR is based on discussion on [mathlib PR #2223](https://github.com/leanprover-community/mathlib/pull/2223).

The lemma `if_simp_congr` removed in this PR caused `simp` to always use `decidable_of_decidable_iff` to construct a `decidable` instance for the condition of an `if` expression. That meant that `if c then t else e = if c' then t else e` often did not get solved by `simp`, getting stuck on `dec_c = decidable_of_decidable_of_iff ...`. There is another `congr` lemma, `if_congr`, defined just before `if_simp_congr`, which does allow the `decidable` instances to differ. Because of the order of the declarations, `if_simp_congr` takes priority.

It seems that `if_simp_congr` was introduced to allow progress rewriting `if c then t else e` to `if c' then t else e` without requiring a `decidable c'` instance. However, this progress should never be needed to close a goal: either the `if` expression is rewritten by another `simp` lemma carrying its own `decidable` instances, or it is not rewritten, so the `decidable` instance already exists in the goal. The only breakage will be to non-terminal `simp`s, which are an anti-pattern anyway.  The removed lemmas are not used either in another part of the core library or mathlib.

The only errors occuring when compiling mathlib with these changes are goals being closed too soon because `simp` has become more powerful.