### PR TITLE
fix(init/core): make type argument in has_one/has_zero implicit

### DIFF
--- a/library/init/core.lean
+++ b/library/init/core.lean
@@ -318,8 +318,8 @@ structure unification_hint :=
 
 /- Declare builtin and reserved notation -/
 
-class has_zero     (α : Type u) := (zero : α)
-class has_one      (α : Type u) := (one : α)
+class has_zero     (α : Type u) := mk {} :: (zero : α)
+class has_one      (α : Type u) := mk {} :: (one : α)
 class has_add      (α : Type u) := (add : α → α → α)
 class has_mul      (α : Type u) := (mul : α → α → α)
 class has_inv      (α : Type u) := (inv : α → α)

--- a/tests/lean/pp_zero_bug.lean.expected.out
+++ b/tests/lean/pp_zero_bug.lean.expected.out
@@ -1,2 +1,2 @@
-has_zero.zero : Π (α : Type u_1) [c : has_zero α], α
-has_zero.zero ℕ : Π [c : has_zero ℕ], ℕ
+has_zero.zero : Π {α : Type u_1} [c : has_zero α], α
+has_zero.zero : Π [c : has_zero ℕ], ℕ

--- a/tests/lean/run/1562.lean
+++ b/tests/lean/run/1562.lean
@@ -10,5 +10,5 @@ meta instance tactic_to_smt2_m (α : Type) : has_coe (tactic α) (smt2_m α) :=
 ⟨ fun tc, ⟨fun s, do res ← tc, return (res, s)⟩ ⟩
 
 meta def reflect_arith_formula : expr → smt2_m term
-| `(has_zero.zero) := smt2.builder.int_const <$> tactic.eval_expr int `(has_zero.zero int)
+| `(has_zero.zero) := smt2.builder.int_const <$> tactic.eval_expr int `(@has_zero.zero int)
 | a := tactic.fail "foo"


### PR DESCRIPTION
See discussion at https://leanprover.zulipchat.com/#narrow/stream/113488-general/topic/unbearable.20unhappiness.20of.20.60simp.60.20not.20working

## Required updates to mathlib
Search for `has_zero.zero _` and remove the underscore in a few places! (Being careful not to change `@has_zero.zero _`.)

We'll also be able to reverse the clunky changes from #2290! (I checked that the `example`s I added to verify correct behaviour in that PR still work when you remove the `reducible` attributes on the `has_coe_to_sort`s.)
