### PR TITLE
fix(meta/simp_tactic): call instantiate_mvars on target before simplifying

### DIFF
--- a/library/init/meta/simp_tactic.lean
+++ b/library/init/meta/simp_tactic.lean
@@ -287,7 +287,7 @@ meta constant simplify (s : simp_lemmas) (to_unfold : list name := []) (e : expr
                        (discharger : tactic unit := failed) : tactic (expr × expr)
 
 meta def simp_target (s : simp_lemmas) (to_unfold : list name := []) (cfg : simp_config := {}) (discharger : tactic unit := failed) : tactic unit :=
-do t ← target,
+do t ← target >>= instantiate_mvars,
    (new_t, pr) ← simplify s to_unfold t cfg `eq discharger,
    replace_target new_t pr
 


### PR DESCRIPTION
See discussion at https://leanprover.zulipchat.com/#narrow/stream/113488-general/topic/unbearable.20unhappiness.20of.20.60simp.60.20not.20working