### PR TITLE
refactor(algebra/*): rename ordered groups/monoids to ordered add_ groups/monoids

### DIFF
--- a/library/init/algebra/functions.lean
+++ b/library/init/algebra/functions.lean
@@ -10,7 +10,7 @@ universe u
 
 definition min {α : Type u} [decidable_linear_order α] (a b : α) : α := if a ≤ b then a else b
 definition max {α : Type u} [decidable_linear_order α] (a b : α) : α := if a ≤ b then b else a
-definition abs {α : Type u} [decidable_linear_ordered_comm_group α] (a : α) : α := max a (-a)
+definition abs {α : Type u} [decidable_linear_ordered_add_comm_group α] (a : α) : α := max a (-a)
 
 section
 open decidable tactic
@@ -131,7 +131,7 @@ end
 
 
 section
-variables {α : Type u} [decidable_linear_ordered_cancel_comm_monoid α]
+variables {α : Type u} [decidable_linear_ordered_cancel_add_comm_monoid α]
 
 lemma min_add_add_left (a b c : α) : min (a + b) (a + c) = a + min b c :=
 eq.symm (eq_min
@@ -163,7 +163,7 @@ begin rw [add_comm a c, add_comm b c, add_comm _ c], apply max_add_add_left end
 end
 
 section
-variables {α : Type u} [decidable_linear_ordered_comm_group α]
+variables {α : Type u} [decidable_linear_ordered_add_comm_group α]
 
 lemma max_neg_neg (a b : α) : max (-a) (-b) = - min a b  :=
 eq.symm (eq_max
@@ -186,8 +186,8 @@ lemma max_eq_neg_min_neg_neg (a b : α) : max a b = - min (-a) (-b) :=
 by rw [min_neg_neg, neg_neg]
 end
 
-section decidable_linear_ordered_comm_group
-variables {α : Type u} [decidable_linear_ordered_comm_group α]
+section decidable_linear_ordered_add_comm_group
+variables {α : Type u} [decidable_linear_ordered_add_comm_group α]
 
 lemma abs_of_nonneg {a : α} (h : a ≥ 0) : abs a = a :=
 have h' : -a ≤ a, from le_trans (neg_nonpos_of_nonneg h) h,
@@ -365,7 +365,7 @@ begin
   apply hal
 end
 
-end decidable_linear_ordered_comm_group
+end decidable_linear_ordered_add_comm_group
 
 
 section decidable_linear_ordered_comm_ring

--- a/library/init/algebra/ordered_group.lean
+++ b/library/init/algebra/ordered_group.lean
@@ -14,26 +14,26 @@ set_option old_structure_cmd true
 
 universe u
 
-class ordered_cancel_comm_monoid (α : Type u)
+class ordered_cancel_add_comm_monoid (α : Type u)
       extends add_comm_monoid α, add_left_cancel_semigroup α,
               add_right_cancel_semigroup α, partial_order α :=
 (add_le_add_left       : ∀ a b : α, a ≤ b → ∀ c : α, c + a ≤ c + b)
 (le_of_add_le_add_left : ∀ a b c : α, a + b ≤ a + c → b ≤ c)
 
-section ordered_cancel_comm_monoid
+section ordered_cancel_add_comm_monoid
 variable {α : Type u}
-variable [s : ordered_cancel_comm_monoid α]
+variable [s : ordered_cancel_add_comm_monoid α]
 
 lemma add_le_add_left {a b : α} (h : a ≤ b) (c : α) : c + a ≤ c + b :=
-@ordered_cancel_comm_monoid.add_le_add_left α s a b h c
+@ordered_cancel_add_comm_monoid.add_le_add_left α s a b h c
 
 lemma le_of_add_le_add_left {a b c : α} (h : a + b ≤ a + c) : b ≤ c :=
-@ordered_cancel_comm_monoid.le_of_add_le_add_left α s a b c h
-end ordered_cancel_comm_monoid
+@ordered_cancel_add_comm_monoid.le_of_add_le_add_left α s a b c h
+end ordered_cancel_add_comm_monoid
 
-section ordered_cancel_comm_monoid
+section ordered_cancel_add_comm_monoid
 variable {α : Type u}
-variable [ordered_cancel_comm_monoid α]
+variable [ordered_cancel_add_comm_monoid α]
 
 lemma add_lt_add_left {a b : α} (h : a < b) (c : α) : c + a < c + b :=
 lt_of_le_not_le (add_le_add_left (le_of_lt h) _) $
@@ -181,43 +181,43 @@ zero_add c ▸ add_lt_add ha hbc
 lemma add_lt_of_lt_of_neg {a b c : α} (hbc : b < c) (ha : a < 0) : b + a < c :=
 add_zero c ▸ add_lt_add hbc ha
 
-end ordered_cancel_comm_monoid
+end ordered_cancel_add_comm_monoid
 
-class ordered_comm_group (α : Type u) extends add_comm_group α, partial_order α :=
+class ordered_add_comm_group (α : Type u) extends add_comm_group α, partial_order α :=
 (add_le_add_left : ∀ a b : α, a ≤ b → ∀ c : α, c + a ≤ c + b)
 
-section ordered_comm_group
+section ordered_add_comm_group
 variable {α : Type u}
-variable [ordered_comm_group α]
+variable [ordered_add_comm_group α]
 
-lemma ordered_comm_group.add_lt_add_left (a b : α) (h : a < b) (c : α) : c + a < c + b :=
+lemma ordered_add_comm_group.add_lt_add_left (a b : α) (h : a < b) (c : α) : c + a < c + b :=
 begin
   rw lt_iff_le_not_le at h ⊢,
   split,
-  { apply ordered_comm_group.add_le_add_left _ _ h.1 },
+  { apply ordered_add_comm_group.add_le_add_left _ _ h.1 },
   { intro w,
-    have w : -c + (c + b) ≤ -c + (c + a) := ordered_comm_group.add_le_add_left _ _ w _,
+    have w : -c + (c + b) ≤ -c + (c + a) := ordered_add_comm_group.add_le_add_left _ _ w _,
     simp only [add_zero, add_comm, add_left_neg, add_left_comm] at w,
     exact h.2 w },
 end
 
-lemma ordered_comm_group.le_of_add_le_add_left {a b c : α} (h : a + b ≤ a + c) : b ≤ c :=
-have -a + (a + b) ≤ -a + (a + c), from ordered_comm_group.add_le_add_left _ _ h _,
+lemma ordered_add_comm_group.le_of_add_le_add_left {a b c : α} (h : a + b ≤ a + c) : b ≤ c :=
+have -a + (a + b) ≤ -a + (a + c), from ordered_add_comm_group.add_le_add_left _ _ h _,
 begin simp [neg_add_cancel_left] at this, assumption end
 
-lemma ordered_comm_group.lt_of_add_lt_add_left {a b c : α} (h : a + b < a + c) : b < c :=
-have -a + (a + b) < -a + (a + c), from ordered_comm_group.add_lt_add_left _ _ h _,
+lemma ordered_add_comm_group.lt_of_add_lt_add_left {a b c : α} (h : a + b < a + c) : b < c :=
+have -a + (a + b) < -a + (a + c), from ordered_add_comm_group.add_lt_add_left _ _ h _,
 begin simp [neg_add_cancel_left] at this, assumption end
-end ordered_comm_group
+end ordered_add_comm_group
 
-instance ordered_comm_group.to_ordered_cancel_comm_monoid (α : Type u) [s : ordered_comm_group α] : ordered_cancel_comm_monoid α :=
+instance ordered_add_comm_group.to_ordered_cancel_add_comm_monoid (α : Type u) [s : ordered_add_comm_group α] : ordered_cancel_add_comm_monoid α :=
 { add_left_cancel       := @add_left_cancel α _,
   add_right_cancel      := @add_right_cancel α _,
-  le_of_add_le_add_left := @ordered_comm_group.le_of_add_le_add_left α _,
+  le_of_add_le_add_left := @ordered_add_comm_group.le_of_add_le_add_left α _,
   ..s }
 
-section ordered_comm_group
-variables {α : Type u} [ordered_comm_group α]
+section ordered_add_comm_group
+variables {α : Type u} [ordered_add_comm_group α]
 
 lemma neg_le_neg {a b : α} (h : a ≤ b) : -b ≤ -a :=
 have 0 ≤ -a + b,           from add_left_neg a ▸ add_le_add_left h (-a),
@@ -615,20 +615,20 @@ begin
   apply le_refl
 end
 
-end ordered_comm_group
+end ordered_add_comm_group
 
-class decidable_linear_ordered_comm_group (α : Type u)
+class decidable_linear_ordered_add_comm_group (α : Type u)
     extends add_comm_group α, decidable_linear_order α :=
 (add_le_add_left : ∀ a b : α, a ≤ b → ∀ c : α, c + a ≤ c + b)
 
-instance decidable_linear_ordered_comm_group.to_ordered_comm_group (α : Type u)
-  [s : decidable_linear_ordered_comm_group α] : ordered_comm_group α :=
+instance decidable_linear_ordered_comm_group.to_ordered_add_comm_group (α : Type u)
+  [s : decidable_linear_ordered_add_comm_group α] : ordered_add_comm_group α :=
 { add := s.add, ..s }
 
-class decidable_linear_ordered_cancel_comm_monoid (α : Type u)
-      extends ordered_cancel_comm_monoid α, decidable_linear_order α
+class decidable_linear_ordered_cancel_add_comm_monoid (α : Type u)
+      extends ordered_cancel_add_comm_monoid α, decidable_linear_order α
 
-lemma decidable_linear_ordered_comm_group.add_lt_add_left {α} [decidable_linear_ordered_comm_group α]
+lemma decidable_linear_ordered_add_comm_group.add_lt_add_left {α} [decidable_linear_ordered_add_comm_group α]
   (a b : α) (h : a < b) (c : α) : c + a < c + b :=
-  ordered_comm_group.add_lt_add_left a b h c
+  ordered_add_comm_group.add_lt_add_left a b h c
   

--- a/library/init/algebra/ordered_ring.lean
+++ b/library/init/algebra/ordered_ring.lean
@@ -15,7 +15,7 @@ set_option old_structure_cmd true
 universe u
 
 class ordered_semiring (α : Type u)
-  extends semiring α, ordered_cancel_comm_monoid α :=
+  extends semiring α, ordered_cancel_add_comm_monoid α :=
 (mul_lt_mul_of_pos_left:     ∀ a b c : α, a < b → 0 < c → c * a < c * b)
 (mul_lt_mul_of_pos_right:    ∀ a b c : α, a < b → 0 < c → a * c < b * c)
 
@@ -196,7 +196,7 @@ end linear_ordered_semiring
 
 class decidable_linear_ordered_semiring (α : Type u) extends linear_ordered_semiring α, decidable_linear_order α
 
-class ordered_ring (α : Type u) extends ring α, ordered_comm_group α, zero_ne_one_class α :=
+class ordered_ring (α : Type u) extends ring α, ordered_add_comm_group α, zero_ne_one_class α :=
 (mul_pos    : ∀ a b : α, 0 < a → 0 < b → 0 < a * b)
 
 lemma ordered_ring.mul_nonneg {α} [s : ordered_ring α] (a b : α) (h₁ : 0 ≤ a) (h₂ : 0 ≤ b) : 0 ≤ a * b :=
@@ -397,7 +397,7 @@ instance linear_ordered_comm_ring.to_integral_domain [s: linear_ordered_comm_rin
   ..s }
 
 class decidable_linear_ordered_comm_ring (α : Type u) extends linear_ordered_comm_ring α,
-    decidable_linear_ordered_comm_group α
+    decidable_linear_ordered_add_comm_group α
 
 instance decidable_linear_ordered_comm_ring.to_decidable_linear_ordered_semiring [d : decidable_linear_ordered_comm_ring α] :
    decidable_linear_ordered_semiring α :=

--- a/library/init/data/int/order.lean
+++ b/library/init/data/int/order.lean
@@ -203,7 +203,7 @@ instance : decidable_linear_ordered_comm_ring int :=
   decidable_lt    := int.decidable_lt,
   ..int.comm_ring }
 
-instance : decidable_linear_ordered_comm_group int :=
+instance : decidable_linear_ordered_add_comm_group int :=
 by apply_instance
 
 lemma eq_nat_abs_of_zero_le {a : ℤ} (h : 0 ≤ a) : a = nat_abs a :=

--- a/library/init/data/nat/lemmas.lean
+++ b/library/init/data/nat/lemmas.lean
@@ -320,7 +320,7 @@ instance : decidable_linear_ordered_semiring nat :=
   ..nat.comm_semiring }
 
 -- all the fields are already included in the decidable_linear_ordered_semiring instance
-instance : decidable_linear_ordered_cancel_comm_monoid ℕ :=
+instance : decidable_linear_ordered_cancel_add_comm_monoid ℕ :=
 { add_left_cancel := @nat.add_left_cancel,
   ..nat.decidable_linear_ordered_semiring }
 


### PR DESCRIPTION
This PR renames ordered groups and monoids to make name space for their multiplicative counterparts.