### PR TITLE
feat(native.float): add `float.of_string` and change `ceil`, `floor`, `round`, `trunc` to return ints

### DIFF
--- a/library/init/meta/float.lean
+++ b/library/init/meta/float.lean
@@ -117,13 +117,13 @@ meta constant atanh : float → float
 
 meta constant abs : float → float
 /-- Nearest integer not less than the given value. -/
-meta constant ceil : float → float
+meta constant ceil : float → int
 /-- Nearest integer not greater than the given value. -/
-meta constant floor : float → float
+meta constant floor : float → int
 /-- Nearest integer not greater in magnitude than the given value. -/
-meta constant trunc : float → float
+meta constant trunc : float → int
 /-- Round to the nearest integer, rounding away from zero in halfway cases. -/
-meta constant round : float → float
+meta constant round : float → int
 
 meta constant lt : float → float → bool
 meta instance : has_lt float := ⟨λ x y, lt x y⟩
@@ -145,6 +145,8 @@ meta constant to_repr : float → string
 meta instance : has_repr float := ⟨to_repr⟩
 meta instance : has_to_string float := ⟨to_repr⟩
 meta instance : has_to_format float := ⟨format.of_string ∘ to_string⟩
+
+meta constant of_string : string → option float
 
 meta instance has_nat_pow : has_pow float nat :=
 ⟨λ a b, native.float.pow a (float.of_nat b)⟩

--- a/src/library/vm/vm_float.cpp
+++ b/src/library/vm/vm_float.cpp
@@ -52,6 +52,14 @@ vm_obj float_repr(vm_obj const & a) {
     return to_obj(out.str());
 }
 
+vm_obj float_of_string(vm_obj const & s) {
+    try {
+        return mk_vm_some(mk_vm_float(std::stof(to_string(s))));
+    } catch (std::invalid_argument const & e) {
+        return mk_vm_none();
+    }
+}
+
 void initialize_vm_float() {
     DECLARE_VM_BUILTIN(name({"native", "float", "specification", "radix"}),     []() { return mk_vm_nat(std::numeric_limits<float>::radix); });
     DECLARE_VM_BUILTIN(name({"native", "float", "specification", "precision"}), []() { return mk_vm_nat(std::numeric_limits<float>::digits);});
@@ -100,10 +108,10 @@ void initialize_vm_float() {
     DECLARE_VM_BUILTIN(name({"native", "float", "sqrt"}),  [](vm_obj const & a) {return mk_vm_float(std::sqrt(to_float(a)));});
     DECLARE_VM_BUILTIN(name({"native", "float", "cbrt"}),  [](vm_obj const & a) {return mk_vm_float(std::cbrt(to_float(a)));});
     DECLARE_VM_BUILTIN(name({"native", "float", "abs"}),   [](vm_obj const & a) {return mk_vm_float(std::abs(to_float(a)));});
-    DECLARE_VM_BUILTIN(name({"native", "float", "ceil"}),  [](vm_obj const & a) {return mk_vm_float(std::ceil(to_float(a)));});
-    DECLARE_VM_BUILTIN(name({"native", "float", "floor"}), [](vm_obj const & a) {return mk_vm_float(std::floor(to_float(a)));});
-    DECLARE_VM_BUILTIN(name({"native", "float", "trunc"}), [](vm_obj const & a) {return mk_vm_float(std::trunc(to_float(a)));});
-    DECLARE_VM_BUILTIN(name({"native", "float", "round"}), [](vm_obj const & a) {return mk_vm_float(std::round(to_float(a)));});
+    DECLARE_VM_BUILTIN(name({"native", "float", "ceil"}),  [](vm_obj const & a) {return mk_vm_int(std::ceil(to_float(a)));});
+    DECLARE_VM_BUILTIN(name({"native", "float", "floor"}), [](vm_obj const & a) {return mk_vm_int(std::floor(to_float(a)));});
+    DECLARE_VM_BUILTIN(name({"native", "float", "trunc"}), [](vm_obj const & a) {return mk_vm_int(std::trunc(to_float(a)));});
+    DECLARE_VM_BUILTIN(name({"native", "float", "round"}), [](vm_obj const & a) {return mk_vm_int(std::round(to_float(a)));});
     DECLARE_VM_BUILTIN(name({"native", "float", "exp"}),   [](vm_obj const & a) {return mk_vm_float(std::exp(to_float(a)));});
     DECLARE_VM_BUILTIN(name({"native", "float", "exp2"}),  [](vm_obj const & a) {return mk_vm_float(std::exp2(to_float(a)));});
     DECLARE_VM_BUILTIN(name({"native", "float", "log"}),   [](vm_obj const & a) {return mk_vm_float(std::log(to_float(a)));});
@@ -130,6 +138,7 @@ void initialize_vm_float() {
     DECLARE_VM_BUILTIN(name({"native", "float", "of_nat"}),  float_of_nat);
     DECLARE_VM_BUILTIN(name({"native", "float", "of_int"}),  float_of_int);
     DECLARE_VM_BUILTIN(name({"native", "float", "to_repr"}), float_repr);
+    DECLARE_VM_BUILTIN(name({"native", "float", "of_string"}), float_of_string);
 }
 void finalize_vm_float() {
 }

--- a/tests/lean/float.lean
+++ b/tests/lean/float.lean
@@ -96,3 +96,18 @@ list.foldl band tt $ floats.map (λ ⟨x,y⟩, prop x y)
 #eval tan pi ≃ 0
 
 #eval (of_int (-12341234))
+
+#eval to_bool $ float.floor (2.5)  =  2
+#eval to_bool $ float.floor (-2.5) = -3
+#eval to_bool $ float.ceil  (2.5)  =  3
+#eval to_bool $ float.ceil  (-2.5) = -2
+#eval to_bool $ float.trunc (2.5)  =  2
+#eval to_bool $ float.trunc (-2.5) = -2
+#eval to_bool $ float.round (2.5)  =  3
+#eval to_bool $ float.round (-2.5) = -3
+
+#eval (of_string "hello")
+#eval (of_string "0.123E4")
+#eval (of_string "-123.123")
+#eval (of_string "-123.0000000000000000000000000001")
+#eval (of_string "-2.28773e+07")

--- a/tests/lean/float.lean.expected.out
+++ b/tests/lean/float.lean.expected.out
@@ -71,3 +71,16 @@ tt
 -1
 tt
 -1.23412e+07
+tt
+tt
+tt
+tt
+tt
+tt
+tt
+tt
+none
+(some 1230)
+(some -123.123)
+(some -123)
+(some -2.28773e+07)


### PR DESCRIPTION
I was doing some coding with floats and I realised that we don't have a way of parsing floats from strings or casting floats to integers. 

This PR adds 

- `native.float.of_string : string -> option float`, which under the hood uses `std::stof`
- `native.float.ceil`, `floor`, `round` and `trunc` now have `int` as their return type instead of float. 

Since the float feature is quite new and ints coerce to floats I think that it is unlikely that changing `floor : float -> float` to `float -> int` is going to significantly break any dependent code and it seems less cluttered to simply change the type signature rather than make a whole new set of constants for the integer versions. 
