### PR TITLE
chore(*): revert removal of unnecessary axioms

### DIFF
--- a/library/init/algebra/field.lean
+++ b/library/init/algebra/field.lean
@@ -16,9 +16,8 @@ set_option default_priority 100
 
 set_option old_structure_cmd true
 
-class division_ring (α : Type u) extends
-  add_group α, semigroup α, has_one α, distrib α, has_inv α, zero_ne_one_class α :=
-(one_mul : ∀ a : α, 1 * a = a)
+class division_ring (α : Type u) extends ring α, has_inv α, zero_ne_one_class α :=
+(mul_inv_cancel : ∀ {a : α}, a ≠ 0 → a * a⁻¹ = 1)
 (inv_mul_cancel : ∀ {a : α}, a ≠ 0 → a⁻¹ * a = 1)
 (inv_zero : (0 : α)⁻¹ = 0)
 
@@ -39,84 +38,38 @@ rfl
 @[simp] lemma inv_zero : 0⁻¹ = (0:α) :=
 division_ring.inv_zero
 
-@[simp]
-lemma inv_mul_cancel {a : α} (h : a ≠ 0) : a⁻¹ * a = 1 :=
-division_ring.inv_mul_cancel h
-
-lemma division_ring.zero_mul (a : α) : 0 * a = 0 :=
-have 0 * a + 0 = 0 * a + 0 * a, from calc
-  0 * a + 0 = (0 + 0) * a   : by simp
-        ... = 0 * a + 0 * a : by rewrite right_distrib,
-show 0 * a = 0, from  (add_left_cancel this).symm
-
-lemma division_ring.mul_zero (a : α) : a * 0 = 0 :=
-have a * 0 + 0 = a * 0 + a * 0, from calc
-     a * 0 + 0 = a * (0 + 0)   : by simp
-           ... = a * 0 + a * 0 : by rw left_distrib,
-show a * 0 = 0, from (add_left_cancel this).symm
-
-lemma inv_ne_zero {a : α} (h : a ≠ 0) : a⁻¹ ≠ 0 :=
-assume : a⁻¹ = 0,
-have 0 = (1 : α), by rw [← inv_mul_cancel h, this, division_ring.zero_mul],
-zero_ne_one this
-
--- note: integral domain has a "mul_ne_zero". α commutative division ring is an integral
--- domain, but let's not define that class for now.
-lemma division_ring.mul_ne_zero {a b : α} (ha : a ≠ 0) (hb : b ≠ 0) : a * b ≠ 0 :=
-assume : a * b = 0,
-have   1 * b = 0, by rw [← inv_mul_cancel ha, mul_assoc, this, division_ring.mul_zero],
-have   b = 0, by rwa division_ring.one_mul at this,
-absurd this hb
-
-@[simp]
-lemma mul_inv_cancel {a : α} (h : a ≠ 0) : a * a⁻¹ = 1 :=
-have a * a⁻¹ ≠ 0, from division_ring.mul_ne_zero h (inv_ne_zero h) ,
-calc a * a⁻¹ = (a * a⁻¹)⁻¹ * (a * a⁻¹) * (a * a⁻¹) :
-  by rw [inv_mul_cancel this, division_ring.one_mul]
-... = (a * a⁻¹)⁻¹ * (a * a⁻¹) :
-  by rw [mul_assoc, mul_assoc, ← mul_assoc (a⁻¹), inv_mul_cancel h, division_ring.one_mul]
-... = 1 : by rw inv_mul_cancel this
-
-lemma division_ring.mul_one (a : α) : a * 1 = a :=
-classical.by_cases
-  (λ ha0 : a = 0, by rw [ha0, division_ring.zero_mul])
-  (λ ha0 : a ≠ 0,
-      by rw [← inv_mul_cancel ha0, ← mul_assoc,
-        mul_inv_cancel ha0, division_ring.one_mul])
-
-instance division_ring.to_ring : ring α :=
-{ mul_one := division_ring.mul_one,
-  ..show division_ring α, by apply_instance }
-
 @[simp] lemma div_zero (a : α) : a / 0 = (0:α) :=
 calc
   a / 0 = (a:α) * 0⁻¹ : by rw division_def
     ... = a * 0       : by rw inv_zero
-    ... = (0:α)       : by rw division_ring.mul_zero
+    ... = (0:α)       : by rw mul_zero
+
+@[simp]
+lemma mul_inv_cancel {a : α} (h : a ≠ 0) : a * a⁻¹ = 1 :=
+division_ring.mul_inv_cancel h
+
+@[simp]
+lemma inv_mul_cancel {a : α} (h : a ≠ 0) : a⁻¹ * a = 1 :=
+division_ring.inv_mul_cancel h
 
 @[simp]
 lemma one_div_eq_inv (a : α) : 1 / a = a⁻¹ :=
-division_ring.one_mul a⁻¹
+one_mul a⁻¹
 
 lemma inv_eq_one_div (a : α) : a⁻¹ = 1 / a :=
 by simp
 
-lemma one_div_mul_cancel {a : α} (h : a ≠ 0) : (1 / a) * a = 1 :=
-by simp [h]
-
-lemma one_div_ne_zero {a : α} (h : a ≠ 0) : 1 / a ≠ 0 :=
-assume : 1 / a = 0,
-have 0 = (1:α), by rw [← one_div_mul_cancel h, this, zero_mul],
-absurd this zero_ne_one
-
 local attribute [simp]
 division_def mul_comm mul_assoc
-mul_left_comm inv_mul_cancel
+mul_left_comm mul_inv_cancel inv_mul_cancel
 
 lemma div_eq_mul_one_div (a b : α) : a / b = a * (1 / b) :=
 by simp
 
 lemma mul_one_div_cancel {a : α} (h : a ≠ 0) : a * (1 / a) = 1 :=
+by simp [h]
+
+lemma one_div_mul_cancel {a : α} (h : a ≠ 0) : (1 / a) * a = 1 :=
 by simp [h]
 
 lemma div_self {a : α} (h : a ≠ 0) : a / a = 1 :=
@@ -127,6 +80,22 @@ div_self (ne.symm zero_ne_one)
 
 lemma mul_div_assoc (a b c : α) : (a * b) / c = a * (b / c) :=
 by simp
+
+lemma one_div_ne_zero {a : α} (h : a ≠ 0) : 1 / a ≠ 0 :=
+assume : 1 / a = 0,
+have 0 = (1:α), from eq.symm (by rw [← mul_one_div_cancel h, this, mul_zero]),
+absurd this zero_ne_one
+
+lemma ne_zero_of_one_div_ne_zero {a : α} (h : 1 / a ≠ 0) : a ≠ 0 :=
+assume ha : a = 0, begin rw [ha, div_zero] at h, contradiction end
+
+lemma inv_ne_zero {a : α} (h : a ≠ 0) : a⁻¹ ≠ 0 :=
+by rw inv_eq_one_div; exact one_div_ne_zero h
+
+lemma eq_zero_of_one_div_eq_zero {a : α} (h : 1 / a = 0) : a = 0 :=
+classical.by_cases
+  (assume ha, ha)
+  (assume ha, false.elim ((one_div_ne_zero ha) h))
 
 lemma one_inv_eq : 1⁻¹ = (1:α) :=
 calc 1⁻¹ = 1 * 1⁻¹ : by rw [one_mul]
@@ -139,6 +108,14 @@ by simp
 
 lemma zero_div (a : α) : 0 / a = 0 :=
 by simp
+
+-- note: integral domain has a "mul_ne_zero". a commutative division ring is an integral
+-- domain, but let's not define that class for now.
+lemma division_ring.mul_ne_zero {a b : α} (ha : a ≠ 0) (hb : b ≠ 0) : a * b ≠ 0 :=
+assume : a * b = 0,
+have   a * 1 = 0, by rw [← mul_one_div_cancel hb, ← mul_assoc, this, zero_mul],
+have   a = 0, by rwa mul_one at this,
+absurd this ha
 
 lemma mul_ne_zero_comm {a b : α} (h : a * b ≠ 0) : b * a ≠ 0 :=
 have h₁ : a ≠ 0, from ne_zero_of_mul_ne_zero_right h,
@@ -290,7 +267,7 @@ by rw [← mul_one a, ← mul_inv_cancel h, ← mul_assoc, h2, mul_assoc, mul_in
 end division_ring
 
 class field (α : Type u) extends comm_ring α, has_inv α, zero_ne_one_class α :=
-(inv_mul_cancel : ∀ {a : α}, a ≠ 0 → a⁻¹ * a = 1)
+(mul_inv_cancel : ∀ {a : α}, a ≠ 0 → a * a⁻¹ = 1)
 (inv_zero : (0 : α)⁻¹ = 0)
 
 section field
@@ -298,7 +275,7 @@ section field
 variable [field α]
 
 instance field.to_division_ring : division_ring α :=
-{ ..show ring α, by apply_instance,
+{ inv_mul_cancel := λ _ h, by rw [mul_comm, field.mul_inv_cancel h]
   ..show field α, by apply_instance }
 
 lemma one_div_mul_one_div (a b : α) : (1 / a) * (1 / b) =  1 / (a * b) :=

--- a/library/init/algebra/group.lean
+++ b/library/init/algebra/group.lean
@@ -30,15 +30,9 @@ class right_cancel_semigroup (α : Type u) extends semigroup α :=
 class monoid (α : Type u) extends semigroup α, has_one α :=
 (one_mul : ∀ a : α, 1 * a = a) (mul_one : ∀ a : α, a * 1 = a)
 
-class comm_monoid (α : Type u) extends comm_semigroup α, has_one α :=
-(one_mul : ∀ a : α, 1 * a = a)
+class comm_monoid (α : Type u) extends monoid α, comm_semigroup α
 
-@[reducible] instance comm_monoid.to_monoid (α : Type u) [I : comm_monoid α] : monoid α :=
-{ mul_one := λ a, by rw [comm_monoid.mul_comm, comm_monoid.one_mul]
-  ..I }
-
-class group (α : Type u) extends semigroup α, has_one α, has_inv α :=
-(one_mul : ∀ a : α, 1 * a = a)
+class group (α : Type u) extends monoid α, has_inv α :=
 (mul_left_inv : ∀ a : α, a⁻¹ * a = 1)
 
 class comm_group (α : Type u) extends group α, comm_monoid α
@@ -86,18 +80,6 @@ group.mul_left_inv
 
 def inv_mul_self := @mul_left_inv
 
-@[simp] lemma mul_right_inv [group α] (a : α) : a * a⁻¹ = 1 :=
-calc a * a⁻¹ = (a * a⁻¹)⁻¹ * (a * a⁻¹) * (a * a⁻¹) :
-  by rw [mul_left_inv, group.one_mul]
-... = (a * a⁻¹)⁻¹ * (a * a⁻¹) :
-  by rw [mul_assoc, mul_assoc, ← mul_assoc (a⁻¹), mul_left_inv, group.one_mul]
-... = 1 : by rw mul_left_inv
-
-instance group.to_monoid [I : group α] : monoid α :=
-{ mul_one := λ a,
-    by rw [← group.mul_left_inv a, ← mul_assoc, mul_right_inv, group.one_mul],
-  ..I }
-
 @[simp] lemma inv_mul_cancel_left [group α] (a b : α) : a⁻¹ * (a * b) = b :=
 by rw [← mul_assoc, mul_left_inv, one_mul]
 
@@ -112,6 +94,10 @@ inv_eq_of_mul_eq_one (one_mul 1)
 
 @[simp] lemma inv_inv [group α] (a : α) : (a⁻¹)⁻¹ = a :=
 inv_eq_of_mul_eq_one (mul_left_inv a)
+
+@[simp] lemma mul_right_inv [group α] (a : α) : a * a⁻¹ = 1 :=
+have a⁻¹⁻¹ * a⁻¹ = 1, by rw mul_left_inv,
+by rwa [inv_inv] at this
 
 def mul_inv_self := @mul_right_inv
 
@@ -212,15 +198,10 @@ class add_right_cancel_semigroup (α : Type u) extends add_semigroup α :=
 class add_monoid (α : Type u) extends add_semigroup α, has_zero α :=
 (zero_add : ∀ a : α, 0 + a = a) (add_zero : ∀ a : α, a + 0 = a)
 
-class add_comm_monoid (α : Type u) extends add_semigroup α, has_zero α, add_comm_semigroup α :=
-(zero_add : ∀ a : α, 0 + a = a)
+class add_comm_monoid (α : Type u) extends add_monoid α, add_comm_semigroup α
 
-class add_group (α : Type u) extends add_semigroup α, has_zero α, has_neg α :=
-(zero_add : ∀ a : α, 0 + a = a)
+class add_group (α : Type u) extends add_monoid α, has_neg α :=
 (add_left_neg : ∀ a : α, -a + a = 0)
-
--- instance add_group.to_add_monoid (α : Type u) [I : add_group α] : add_monoid α :=
--- { add_zero := sorry, ..I }
 
 class add_comm_group (α : Type u) extends add_group α, add_comm_monoid α
 
@@ -247,11 +228,7 @@ run_cmd transport_multiplicative_to_additive
    (`has_mul.mul, `has_add.add), (`has_one.one, `has_zero.zero), (`has_inv.inv, `has_neg.neg),
    (`has_mul, `has_add), (`has_one, `has_zero), (`has_inv, `has_neg),
    /- map constructors -/
-   (`has_mul.mk, `has_add.mk), (`has_one.mk, `has_zero.mk), (`has_inv.mk, `has_neg.mk),
-   (`semigroup.mk, `add_semigroup.mk),
-   (`comm_semigroup.mk, `add_comm_semigroup.mk),
-   (`monoid.mk, `add_monoid.mk),
-   (`group.mk, `add_group.mk),
+   (`has_mul.mk, `has_add.mk), (`has_one, `has_zero.mk), (`has_inv, `has_neg.mk),
    /- map structures -/
    (`semigroup, `add_semigroup),
    (`monoid, `add_monoid),
@@ -263,8 +240,6 @@ run_cmd transport_multiplicative_to_additive
    (`right_cancel_semigroup, `add_right_cancel_semigroup),
    (`left_cancel_semigroup.mk, `add_left_cancel_semigroup.mk),
    (`right_cancel_semigroup.mk, `add_right_cancel_semigroup.mk),
-   /- map proofs -/
-   (`comm_monoid.to_monoid._proof_1, `add_comm_monoid.to_add_monoid._proof_1),
    /- map instances -/
    (`semigroup.to_has_mul, `add_semigroup.to_has_add),
    (`monoid.to_has_one, `add_monoid.to_has_zero),
@@ -273,9 +248,7 @@ run_cmd transport_multiplicative_to_additive
    (`monoid.to_semigroup, `add_monoid.to_add_semigroup),
    (`comm_monoid.to_monoid, `add_comm_monoid.to_add_monoid),
    (`comm_monoid.to_comm_semigroup, `add_comm_monoid.to_add_comm_semigroup),
-   (`group.to_has_one, `add_group.to_has_zero),
-   (`group.to_semigroup, `add_group.to_add_semigroup),
-
+   (`group.to_monoid, `add_group.to_add_monoid),
    (`comm_group.to_group, `add_comm_group.to_add_group),
    (`comm_group.to_comm_monoid, `add_comm_group.to_add_comm_monoid),
    (`left_cancel_semigroup.to_semigroup, `add_left_cancel_semigroup.to_add_semigroup),
@@ -290,14 +263,6 @@ run_cmd transport_multiplicative_to_additive
    (`group.mul_left_inv, `add_group.add_left_neg),
    (`group.mul, `add_group.add),
    (`group.mul_assoc, `add_group.add_assoc),
-   (`group.one, `add_group.zero),
-   (`group.one_mul, `add_group.zero_add),
-   (`group.inv, `add_group.neg),
-   (`comm_monoid.mul, `add_comm_monoid.add),
-   (`comm_monoid.mul_assoc, `add_comm_monoid.add_assoc),
-   (`comm_monoid.one, `add_comm_monoid.zero),
-   (`comm_monoid.one_mul, `add_comm_monoid.zero_add),
-   (`comm_monoid.mul_comm, `add_comm_monoid.add_comm),
    /- map lemmas -/
    (`mul_assoc, `add_assoc),
    (`mul_comm, `add_comm),
@@ -306,11 +271,6 @@ run_cmd transport_multiplicative_to_additive
    (`one_mul, `zero_add),
    (`mul_one, `add_zero),
    (`mul_left_inv, `add_left_neg),
-   (`mul_right_inv, `add_right_neg),
-   /- map instances -/
-   (`group.to_monoid._proof_1, `add_group.to_add_monoid._proof_1),
-   (`group.to_monoid, `add_group.to_add_monoid),
-   /- map lemmas -/
    (`mul_left_cancel, `add_left_cancel),
    (`mul_right_cancel, `add_right_cancel),
    (`mul_left_cancel_iff, `add_left_cancel_iff),
@@ -320,6 +280,7 @@ run_cmd transport_multiplicative_to_additive
    (`eq_inv_mul_of_mul_eq, `eq_neg_add_of_add_eq),
    (`inv_eq_of_mul_eq_one, `neg_eq_of_add_eq_zero),
    (`inv_inv, `neg_neg),
+   (`mul_right_inv, `add_right_neg),
    (`mul_inv_cancel_left, `add_neg_cancel_left),
    (`mul_inv_cancel_right, `add_neg_cancel_right),
    (`mul_inv_rev, `neg_add_rev),

--- a/library/init/algebra/group.lean
+++ b/library/init/algebra/group.lean
@@ -212,7 +212,7 @@ class add_right_cancel_semigroup (α : Type u) extends add_semigroup α :=
 class add_monoid (α : Type u) extends add_semigroup α, has_zero α :=
 (zero_add : ∀ a : α, 0 + a = a) (add_zero : ∀ a : α, a + 0 = a)
 
-class add_comm_monoid (α : Type u) extends add_comm_semigroup α, has_zero α :=
+class add_comm_monoid (α : Type u) extends add_semigroup α, has_zero α, add_comm_semigroup α :=
 (zero_add : ∀ a : α, 0 + a = a)
 
 class add_group (α : Type u) extends add_semigroup α, has_zero α, has_neg α :=

--- a/library/init/algebra/ordered_field.lean
+++ b/library/init/algebra/ordered_field.lean
@@ -4,18 +4,16 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Robert Lewis, Leonardo de Moura
 -/
 prelude
-import init.algebra.ordered_ring init.algebra.field
+import init.algebra.ordered_ring .field
 
 set_option old_structure_cmd true
 
 universe u
 
-class linear_ordered_field (α : Type u) extends linear_ordered_comm_ring α, division_ring α
+class linear_ordered_field (α : Type u) extends linear_ordered_ring α, field α
 
 section linear_ordered_field
 variables {α : Type u} [linear_ordered_field α]
-
-instance linear_ordered_field.to_field : field α := { ..show linear_ordered_field α, by apply_instance }
 
 lemma mul_zero_lt_mul_inv_of_pos {a : α} (h : 0 < a) : a * 0 < a * (1 / a) :=
 calc a * 0 = 0           : by rw mul_zero
@@ -64,7 +62,7 @@ lemma le_of_one_le_div (a : α) {b : α} (hb : b > 0) (h : 1 ≤ a / b) : b ≤ 
 have hb'   : b ≠ 0,     from ne.symm (ne_of_lt hb),
 calc
    b   ≤ b * (a / b) : le_mul_of_ge_one_right (le_of_lt hb) h
-   ... = a           : by rw [mul_div_cancel' a hb']
+   ... = a           : by rw [mul_div_cancel' _ hb']
 
 lemma one_lt_div_of_lt (a : α) {b : α} (hb : b > 0) (h : b < a) : 1 < a / b :=
 have hb' : b ≠ 0, from ne.symm (ne_of_lt hb),

--- a/library/init/algebra/ring.lean
+++ b/library/init/algebra/ring.lean
@@ -78,15 +78,7 @@ section semiring
   by simp [right_distrib]
 end semiring
 
-class comm_semiring (α : Type u) extends add_comm_monoid α, comm_monoid α :=
-(left_distrib : ∀ a b c : α, a * (b + c) = (a * b) + (a * c))
-(zero_mul : ∀ a : α, 0 * a = 0)
-
-instance comm_semiring.to_semiring (α : Type u) [I : comm_semiring α] : semiring α :=
-{ right_distrib := λ a b c, by rw [mul_comm, comm_semiring.left_distrib, mul_comm c, mul_comm c]; refl,
-  mul_one := mul_one,
-  mul_zero := λ a, by rw [mul_comm, comm_semiring.zero_mul]; refl,
-  ..I }
+class comm_semiring (α : Type u) extends semiring α, comm_monoid α
 
 section comm_semiring
   variables [comm_semiring α] (a b c : α)
@@ -168,7 +160,7 @@ end comm_semiring
 
 /- ring -/
 
-class ring (α : Type u) extends add_group α, monoid α, distrib α
+class ring (α : Type u) extends add_comm_group α, monoid α, distrib α
 
 local attribute [simp] sub_eq_add_neg
 
@@ -184,20 +176,8 @@ have 0 * a + 0 = 0 * a + 0 * a, from calc
         ... = 0 * a + 0 * a : by rewrite right_distrib,
 show 0 * a = 0, from  (add_left_cancel this).symm
 
-lemma ring.add_comm [ring α] (a b : α) : a + b = b + a :=
-have (a + a) + (b + b) = (a + b) + (a + b),
-  from calc (a + a) + (b + b) = (1 + 1) * (a + b) :
-    by rw [left_distrib, right_distrib, right_distrib]; simp
-  ... = (a + b) + (a + b) :
-    by rw [right_distrib, left_distrib]; simp,
-calc a + b = -a + ((a + a) + (b + b)) - b : by simp [add_assoc]
-... = b + a : by rw this; simp [add_assoc]
-
 instance ring.to_semiring [s : ring α] : semiring α :=
-{ mul_zero := ring.mul_zero, add_comm := ring.add_comm, zero_mul := ring.zero_mul, ..s }
-
-instance ring.to_add_comm_group [s : ring α] : add_comm_group α :=
-{ add_comm := ring.add_comm, ..s}
+{ mul_zero := ring.mul_zero, zero_mul := ring.zero_mul, ..s }
 
 lemma neg_mul_eq_neg_mul [s : ring α] (a b : α) : -(a * b) = -a * b :=
 neg_eq_of_add_eq_zero
@@ -236,27 +216,21 @@ calc
 
 def sub_mul := @mul_sub_right_distrib
 
-class comm_ring (α : Type u) extends add_group α, comm_monoid α :=
-(left_distrib : ∀ a b c : α, a * (b + c) = (a * b) + (a * c))
-
-instance comm_ring.to_ring (α : Type u) [s : comm_ring α] : ring α :=
-{ mul_one := mul_one,
-  right_distrib := λ a b c, by rw [mul_comm, comm_ring.left_distrib, mul_comm c, mul_comm c]; refl,
-  ..s }
+class comm_ring (α : Type u) extends ring α, comm_semigroup α
 
 instance comm_ring.to_comm_semiring [s : comm_ring α] : comm_semiring α :=
-{ zero_mul := zero_mul, add_comm := ring.add_comm, ..s }
+{ mul_zero := mul_zero, zero_mul := zero_mul, ..s }
 
 section comm_ring
   variable [comm_ring α]
 
-  local attribute [simp] add_assoc add_comm add_left_comm mul_comm add_neg_cancel_left
+  local attribute [simp] add_assoc add_comm add_left_comm mul_comm
 
   lemma mul_self_sub_mul_self_eq (a b : α) : a * a - b * b = (a + b) * (a - b) :=
-  begin simp [right_distrib, left_distrib] end
+  begin simp [right_distrib, left_distrib], rw [add_comm (-(a*b)), add_left_comm (a*b)], simp end
 
   lemma mul_self_sub_one_eq (a : α) : a * a - 1 = (a + 1) * (a - 1) :=
-  begin simp [right_distrib, left_distrib] end
+  begin simp [right_distrib, left_distrib], rw [add_left_comm, add_comm (-a), add_left_comm a], simp end
 
   lemma add_mul_self_eq (a b : α) : (a + b) * (a + b) = a*a + 2*a*b + b*b :=
   calc (a + b)*(a + b) = a*a + (1+1)*a*b + b*b : by simp [right_distrib, left_distrib]

--- a/library/init/data/int/basic.lean
+++ b/library/init/data/int/basic.lean
@@ -316,9 +316,12 @@ protected lemma add_comm : ∀ a b : ℤ, a + b = b + a
 | -[1+ n]    (of_nat m) := rfl
 | -[1+ n]    -[1+m]     := by simp [nat.add_comm]
 
-protected lemma zero_add : ∀ a : ℤ, 0 + a = a
-| (of_nat n) := congr_arg of_nat (nat.zero_add n)
+protected lemma add_zero : ∀ a : ℤ, a + 0 = a
+| (of_nat n) := rfl
 | -[1+ n]   := rfl
+
+protected lemma zero_add (a : ℤ) : 0 + a = a :=
+int.add_comm a 0 ▸ int.add_zero a
 
 private lemma sub_nat_nat_sub {m n : ℕ} (h : m ≥ n) (k : ℕ) :
   sub_nat_nat (m - n) k = sub_nat_nat m (k + n) :=
@@ -512,25 +515,32 @@ protected lemma distrib_left : ∀ a b c : ℤ, a * (b + c) = a * b + a * c
 | (of_nat m) -[1+ n]    (of_nat k) := begin simp [neg_of_nat_eq_sub_nat_nat_zero],
                                             rw [int.add_comm, ← sub_nat_nat_add], reflexivity end
 | (of_nat m) -[1+ n]   -[1+ k]     := begin simp, rw [← nat.left_distrib, succ_add] end
-| -[1+ m]    (of_nat n) (of_nat k) := begin simp [mul_comm], rw [← right_distrib, mul_comm] end
+| -[1+ m]    (of_nat n) (of_nat k) := begin simp [mul_comm], rw [← nat.right_distrib, mul_comm] end
 | -[1+ m]    (of_nat n) -[1+ k]    := begin simp [neg_of_nat_eq_sub_nat_nat_zero],
                                             rw [int.add_comm, ← sub_nat_nat_add], reflexivity end
 | -[1+ m]    -[1+ n]    (of_nat k) := begin simp [neg_of_nat_eq_sub_nat_nat_zero],
                                             rw [← sub_nat_nat_add], reflexivity end
 | -[1+ m]    -[1+ n]   -[1+ k]     := begin simp, rw [← nat.left_distrib, succ_add] end
 
+protected lemma distrib_right (a b c : ℤ) : (a + b) * c = a * c + b * c :=
+begin rw [int.mul_comm, int.distrib_left], simp [int.mul_comm] end
+
 instance : comm_ring int :=
 { add            := int.add,
   add_assoc      := int.add_assoc,
   zero           := int.zero,
   zero_add       := int.zero_add,
+  add_zero       := int.add_zero,
   neg            := int.neg,
   add_left_neg   := int.add_left_neg,
+  add_comm       := int.add_comm,
   mul            := int.mul,
   mul_assoc      := int.mul_assoc,
   one            := int.one,
   one_mul        := int.one_mul,
+  mul_one        := int.mul_one,
   left_distrib   := int.distrib_left,
+  right_distrib  := int.distrib_right,
   mul_comm       := int.mul_comm }
 
 /- Extra instances to short-circuit type class resolution -/

--- a/library/init/data/int/order.lean
+++ b/library/init/data/int/order.lean
@@ -187,10 +187,7 @@ simp [int.lt_iff_le_and_ne], split; intro h,
 end
 
 instance : decidable_linear_ordered_comm_ring int :=
-{ mul_one         := mul_one,
-  right_distrib   := right_distrib,
-  add_comm        := add_comm,
-  le              := int.le,
+{ le              := int.le,
   le_refl         := int.le_refl,
   le_trans        := @int.le_trans,
   le_antisymm     := @int.le_antisymm,

--- a/library/init/data/nat/lemmas.lean
+++ b/library/init/data/nat/lemmas.lean
@@ -91,6 +91,11 @@ lemma succ_mul : ∀ (n m : ℕ), (succ n) * m = (n * m) + m
     sort_add
   end
 
+protected lemma right_distrib : ∀ (n m k : ℕ), (n + m) * k = n * k + m * k
+| n m 0        := rfl
+| n m (succ k) :=
+  begin simp [mul_succ, right_distrib n m k], sort_add end
+
 protected lemma left_distrib : ∀ (n m k : ℕ), n * (m + k) = n * m + n * k
 | 0        m k := by simp [nat.zero_mul]
 | (succ n) m k :=
@@ -104,21 +109,27 @@ protected lemma mul_assoc : ∀ (n m k : ℕ), (n * m) * k = n * (m * k)
 | n m 0        := rfl
 | n m (succ k) := by simp [mul_succ, nat.left_distrib, mul_assoc n m k]
 
+protected lemma mul_one : ∀ (n : ℕ), n * 1 = n := nat.zero_add
+
 protected lemma one_mul (n : ℕ) : 1 * n = n :=
-nat.mul_comm n 1 ▸ nat.zero_add n
+by rw [nat.mul_comm, nat.mul_one]
 
 instance : comm_semiring nat :=
 {add            := nat.add,
  add_assoc      := nat.add_assoc,
  zero           := nat.zero,
  zero_add       := nat.zero_add,
+ add_zero       := nat.add_zero,
  add_comm       := nat.add_comm,
  mul            := nat.mul,
  mul_assoc      := nat.mul_assoc,
  one            := nat.succ nat.zero,
  one_mul        := nat.one_mul,
+ mul_one        := nat.mul_one,
  left_distrib   := nat.left_distrib,
+ right_distrib  := nat.right_distrib,
  zero_mul       := nat.zero_mul,
+ mul_zero       := nat.mul_zero,
  mul_comm       := nat.mul_comm}
 
 /- properties of inequality -/
@@ -289,10 +300,7 @@ protected lemma mul_lt_mul_of_pos_right {n m k : ℕ} (h : n < m) (hk : k > 0) :
 mul_comm k m ▸ mul_comm k n ▸ nat.mul_lt_mul_of_pos_left h hk
 
 instance : decidable_linear_ordered_semiring nat :=
-{ mul_one                    := mul_one,
-  right_distrib              := right_distrib,
-  mul_zero                   := mul_zero,
-  add_left_cancel            := @nat.add_left_cancel,
+{ add_left_cancel            := @nat.add_left_cancel,
   add_right_cancel           := @nat.add_right_cancel,
   lt                         := nat.lt,
   le                         := nat.le,

--- a/tests/lean/1952.lean.expected.out
+++ b/tests/lean/1952.lean.expected.out
@@ -7,8 +7,9 @@ but is expected to have type
   ∀ (a : ℕ), ⁇ a = a
 1952.lean:16:38: error: invalid structure value { ... }, field 'mul' was not provided
 1952.lean:16:38: error: invalid structure value { ... }, field 'one' was not provided
-1952.lean:16:38: error: invalid structure value { ... }, field 'inv' was not provided
 1952.lean:16:38: error: invalid structure value { ... }, field 'one_mul' was not provided
+1952.lean:16:38: error: invalid structure value { ... }, field 'mul_one' was not provided
+1952.lean:16:38: error: invalid structure value { ... }, field 'inv' was not provided
 1952.lean:16:38: error: invalid structure value { ... }, field 'mul_left_inv' was not provided
 1952.lean:16:53: error: type mismatch at field 'mul_assoc'
   λ (x y z : α), rfl


### PR DESCRIPTION
This causes way too many issues in mathlib.  In order to revive this, please port mathlib first.  I'm happy to do a special "remove axioms"-release once we have a branch of mathlib that works with this change.

Non-exhaustive list of things that break:
 - For example a group with zero now has more axioms than a division ring.  So you cannot construct a gwz instance from a dr instance, but you need to write an extra `..(by apply_instance : semiring α)`.
 - Unification failures in `dfinsupp`.  (This is the part where I'm giving up.)  Since `add_group` no longer extends `add_monoid`, the unifier cannot compute the `add_monoid` instance.  This is really ugly, because addition requires `add_monoid`.  Hence lemmas such as `add_apply` just don't work anymore.

