### PR TITLE
refactor(init/meta/expr): better corner-case for expr.subst

### DIFF
--- a/doc/changes.md
+++ b/doc/changes.md
@@ -11,6 +11,7 @@ Bug fixes:
   - Assertion violation in `simp_inductive` (#173)
 
 Changes:
+  - `expr.subst` constructs an application if the left expression is not a lambda (#180)
   - `if_simp_congr` is removed, simp now produces the correct decidability instance when simplifying if-then-else (#159)
   - `float.{ceil,floor,trunc,round}` now return integers (#176)
   - `default` is now an export (#161)

--- a/library/init/meta/expr.lean
+++ b/library/init/meta/expr.lean
@@ -186,7 +186,9 @@ meta constant expr.instantiate_var         : expr → expr → expr
 /-- ``instantiate_vars `(#0 #1 #2) [x,y,z] = `(%%x %%y %%z)`` -/
 meta constant expr.instantiate_vars        : expr → list expr → expr
 
-/-- Perform beta-reduction if the left expression is a lambda. Ie: ``expr.subst | `(λ x, %%Y) Z := Y[x/Z] | X Z := X`` -/
+/-- Perform beta-reduction if the left expression is a lambda, or construct an application otherwise.
+That is: ``expr.subst `(λ x, %%Y) Z = Y[x/Z]``, and
+``expr.subst X Z = X.app Z`` otherwise -/
 protected meta constant expr.subst : expr elab → expr elab → expr elab
 
 /-- `get_free_var_range e` returns one plus the maximum de-Bruijn value in `e`. Eg `get_free_var_range `(#1 #0)` yields `2` -/
@@ -255,10 +257,7 @@ id
 
 @[inline] meta def reflected.subst {α : Sort v} {β : α → Sort u} {f : Π a : α, β a} {a : α} :
   reflected f → reflected a → reflected (f a) :=
-λ ef ea, match ef with
-| (expr.lam _ _ _ _) := expr.subst ef ea
-| _                  := expr.app   ef ea
-end
+expr.subst
 
 attribute [irreducible] reflected reflected.subst reflected.to_expr
 

--- a/src/library/vm/vm_expr.cpp
+++ b/src/library/vm/vm_expr.cpp
@@ -459,7 +459,7 @@ vm_obj expr_subst(vm_obj const &, vm_obj const & _e1, vm_obj const & _e2) {
     if (is_lambda(e1)) {
         return to_obj(instantiate(binding_body(e1), e2));
     } else {
-        return to_obj(e1);
+        return to_obj(mk_app(e1, e2));
     }
 }
 


### PR DESCRIPTION
The `prod.has_reflect` instance uses the `reflect.subst` function four times.  This function is inlined (because it must be inlined to forget the unused argument), and the match is expanded into an expression recursor.  The resulting term and VM program is huge, causing significant slowdown in tactic parsing.

This PR speeds up the `foo` tactic by a factor of 5: https://leanprover.zulipchat.com/#narrow/stream/113488-general/topic/set.20is.20slow/near/193433744 