### PR TITLE
perf(library/init/data/array/basic): speed up array.map

### DIFF
--- a/library/init/data/array/basic.lean
+++ b/library/init/data/array/basic.lean
@@ -147,26 +147,33 @@ variables {n : nat} {α : Type u} {β : Type v}
 def nil {α} : array 0 α :=
 d_array.nil
 
+@[inline]
 def read (a : array n α) (i : fin n) : α :=
 d_array.read a i
 
+@[inline]
 def write (a : array n α) (i : fin n) (v : α) : array n α :=
 d_array.write a i v
 
 /-- Fold array starting from 0, folder function includes an index argument. -/
+@[inline]
 def iterate (a : array n α) (b : β) (f : fin n → α → β → β) : β :=
 d_array.iterate a b f
 
 /-- Map each element of the given array with an index argument. -/
+@[inline]
 def foreach (a : array n α) (f : fin n → α → α) : array n α :=
-iterate a a (λ i v a', a'.write i (f i v))
+d_array.foreach a f
 
+@[inline]
 def map (f : α → α) (a : array n α) : array n α :=
 foreach a (λ _, f)
 
+@[inline]
 def map₂ (f : α → α → α) (a b : array n α) : array n α :=
 foreach b (λ i, f (a.read i))
 
+@[inline]
 def foldl (a : array n α) (b : β) (f : α → β → β) : β :=
 iterate a b (λ _, f)
 


### PR DESCRIPTION
`array.map` was 50x slower than a naive implementation using `d_array.mk`.  Now it is twice as fast as the naive implementation.

```lean
import data.buffer

universes u v

def array.mmap_core {m n} {α β : Type u} [monad m] (as : array n α) (f : α → m β) : ∀ i ≤ n, m (array i β)
| 0 _ := pure array.nil
| (i+1) h := do
    bs ← array.mmap_core i (le_of_lt h),
    b ← f (as.read ⟨i, h⟩),
    pure $ bs.push_back b

def array.mmap {m n α β} [monad m] (as : array n α) (f : α → m β) : m (array n β) :=
as.mmap_core f _ (le_refl _)

def d_array.map' {n : ℕ} {α : fin n → Type u} {β : fin n → Type v} (f : Π (i : fin n), α i → β i) (x : d_array n α) :
  d_array n β :=
d_array.mk $ λ i, f i $ x.read i

def array.map' {n : ℕ} {α : Type u} {β : Type v} (f : α → β) (x : array n α) :
  array n β :=
x.map' $ λ _, f

def black_hole {α β} : α → β → opt_param unit () → β
| a b () := b

set_option profiler true
-- set_option trace.compiler.optimize_bytecode true
#eval ((mk_array 10000 1).mmap (pure ∘ nat.succ) : tactic (array _ ℕ))
#eval black_hole ((mk_array 10000 1).map' nat.succ) 0
#eval black_hole ((mk_array 10000 1).map nat.succ) 0
#eval black_hole (d_array.map (λ _, nat.succ) (mk_array 10000 1)) 0
```