### PR TITLE
feat(frontends/lean/parser): support user commands after imports

### DIFF
--- a/src/frontends/lean/dependencies.cpp
+++ b/src/frontends/lean/dependencies.cpp
@@ -50,6 +50,7 @@ bool display_deps(search_path const & path, environment const & env, std::ostrea
 
     while (true) {
         token_kind t = token_kind::Identifier;
+        pos_info p = s.get_pos_info();
         try {
             t = s.scan(env);
         } catch (exception &) {
@@ -69,7 +70,7 @@ bool display_deps(search_path const & path, environment const & env, std::ostrea
                 k = 0;
             else
                 k = *k + 1;
-        } else if ((import_prefix || import_args) && t == token_kind::Identifier) {
+        } else if ((import_prefix || import_args) && p.first != 0 && t == token_kind::Identifier) {
             display_dep(k, s.get_name_val());
             k = optional<unsigned>();
         } else {

--- a/src/frontends/lean/parser.cpp
+++ b/src/frontends/lean/parser.cpp
@@ -2472,7 +2472,9 @@ bool parser::parse_imports(unsigned & fingerprint, std::vector<module_name> & im
                     module_name m(f);
                     imports.push_back(m);
                 }
-                bool should_consume_next = ([&] {
+                // HACK: always consume tokens with break_at_pos,
+                // otherwise go-to-definition doesn't work on last import.
+                bool should_consume_next = m_break_at_pos || ([&] {
                     scanner::lookahead_scope _scope(m_scanner);
                     auto curr = m_scanner.scan(m_env);
                     bool is_import_tk =

--- a/src/frontends/lean/parser.cpp
+++ b/src/frontends/lean/parser.cpp
@@ -257,8 +257,11 @@ void parser_info::updt_options() {
 
 void parser::sync_command() {
     // Keep consuming tokens until we find a Command or End-of-file
-    while (curr() != token_kind::CommandKeyword && curr() != token_kind::Eof)
-        next();
+    while (curr() != token_kind::CommandKeyword && curr() != token_kind::Eof) {
+        try {
+            next();
+        } catch (parser_exception &) {}
+    }
 }
 
 tag parser::get_tag(expr e) {
@@ -2415,7 +2418,7 @@ void parser::parse_mod_doc_block() {
 #pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
 #endif
 
-void parser::parse_imports(unsigned & fingerprint, std::vector<module_name> & imports) {
+bool parser::parse_imports(unsigned & fingerprint, std::vector<module_name> & imports) {
     init_scanner();
     scanner::field_notation_scope scope(m_scanner, false);
     m_last_cmd_pos = pos();
@@ -2469,7 +2472,20 @@ void parser::parse_imports(unsigned & fingerprint, std::vector<module_name> & im
                     module_name m(f);
                     imports.push_back(m);
                 }
-                next();
+                bool should_consume_next = ([&] {
+                    scanner::lookahead_scope _scope(m_scanner);
+                    auto curr = m_scanner.scan(m_env);
+                    bool is_import_tk =
+                        (curr == token_kind::Keyword || curr == token_kind::CommandKeyword) &&
+                        get_token_info().value() == get_import_tk();
+                    return m_scanner.get_pos() != 0 || is_import_tk;
+                })();
+                if (should_consume_next) {
+                    next();
+                } else {
+                    // let process_import scan this token again after importing the dependencies
+                    return true;
+                }
             } catch (break_at_pos_exception & e) {
                 if (k_init)
                     e.m_token_info.m_token = std::string(k + 1, '.') + e.m_token_info.m_token.to_string();
@@ -2479,6 +2495,7 @@ void parser::parse_imports(unsigned & fingerprint, std::vector<module_name> & im
             }
         }
     }
+    return false;
 }
 
 void parser::process_imports() {
@@ -2487,8 +2504,9 @@ void parser::process_imports() {
 
     std::exception_ptr exception_during_scanning;
     auto begin_pos = pos();
+    bool needs_to_scan_again = false;
     try {
-        parse_imports(fingerprint, imports);
+        needs_to_scan_again = parse_imports(fingerprint, imports);
     } catch (parser_exception &) {
         exception_during_scanning = std::current_exception();
     }
@@ -2538,6 +2556,10 @@ void parser::process_imports() {
     m_env = activate_export_decls(m_env, {}); // explicitly activate exports in root namespace
     m_env = replay_export_decls_core(m_env, m_ios);
     m_imports_parsed = true;
+
+    if (needs_to_scan_again) {
+        next();
+    }
 
     if (exception_during_scanning) std::rethrow_exception(exception_during_scanning);
 }

--- a/src/frontends/lean/parser.h
+++ b/src/frontends/lean/parser.h
@@ -530,7 +530,7 @@ public:
 
     bool parse_command_like();
     void parse_command(cmd_meta const & meta);
-    void parse_imports(unsigned & fingerprint, std::vector<module_name> &);
+    bool parse_imports(unsigned & fingerprint, std::vector<module_name> &);
 
     struct quote_scope {
         parser &    m_p;

--- a/tests/lean/run/import_open_locale1.lean
+++ b/tests/lean/run/import_open_locale1.lean
@@ -1,0 +1,5 @@
+open lean lean.parser interactive tactic
+
+@[user_command]
+meta def open_locale_cmd (_ : parse $ tk "open_locale") : parser unit :=
+ident *> pure ()

--- a/tests/lean/run/import_open_locale2.lean
+++ b/tests/lean/run/import_open_locale2.lean
@@ -1,0 +1,3 @@
+import .import_open_locale1
+
+open_locale classical


### PR DESCRIPTION
This PR changes the parser to parse the imports indentation-sensitively, like some things in Lean 4:
```lean
import foo
  bar
open_locale classical -- runs user command
```
and
```lean
import foo
  bar
  open_locale classical -- imports open_locale and classical modules
```

The unexpectedly hard part about the implementation is that the `open_locale` token is parsed differently after importing the dependencies.  Before it is an identifier, afterwards it is a command keyword.  Hence we do not consume the final token in the `parse_imports` function and let the `process_imports` function do this after importing the dependencies.