### PR TITLE
fix(frontends/lean/decl_util): collect univ params of implicit instances

### DIFF
--- a/doc/fixing_tests.md
+++ b/doc/fixing_tests.md
@@ -19,7 +19,7 @@ First, we must install [meld](http://meldmerge.org/). On Ubuntu, we can do it by
 sudo apt-get install meld
 ```
 
-Now, suppose `bad_class.lean` test is broken. We can see the problem by going to `test/lean` directory and
+Now, suppose `bad_class.lean` test is broken. We can see the problem by going to `tests/lean` directory and
 executing
 
 ```

--- a/src/frontends/lean/decl_util.cpp
+++ b/src/frontends/lean/decl_util.cpp
@@ -204,7 +204,7 @@ name_set collect_univ_params_ignoring_tactics(expr const & e, name_set const & l
 
         variable [decidable_eq A]
 */
-void collect_annonymous_inst_implicit(parser_info const & p, collected_locals & locals) {
+static void collect_annonymous_inst_implicit(parser_info const & p, collected_locals & locals, name_set & lp_found) {
     buffer<pair<name, expr>> entries;
     to_buffer(p.get_local_entries(), entries);
     unsigned i = entries.size();
@@ -221,8 +221,10 @@ void collect_annonymous_inst_implicit(parser_info const & p, collected_locals & 
                         ok = false;
                     return true;
                 });
-            if (ok)
+            if (ok) {
                 locals.insert(entry.second);
+                lp_found = collect_univ_params_ignoring_tactics(entry.second, lp_found);
+            }
         }
     }
 }
@@ -319,7 +321,7 @@ void collect_implicit_locals(parser_info & p, buffer<name> & lp_names, buffer<ex
         collect_locals_ignoring_tactics(e, locals);
         lp_found = collect_univ_params_ignoring_tactics(e, lp_found);
     }
-    collect_annonymous_inst_implicit(p, locals);
+    collect_annonymous_inst_implicit(p, locals, lp_found);
     sort_locals(locals.get_collected(), p, params);
     update_univ_parameters(p, lp_names, lp_found);
     /* Add as_is annotation to section variables and parameters */

--- a/src/frontends/lean/decl_util.cpp
+++ b/src/frontends/lean/decl_util.cpp
@@ -228,7 +228,7 @@ void collect_annonymous_inst_implicit(parser_info const & p, collected_locals & 
 }
 
 /** \brief Sort local names by order of occurrence, and copy the associated parameters to ps */
-void sort_locals(buffer<expr> const & locals, parser_info const & p, buffer<expr> & ps) {
+static void sort_locals(buffer<expr> const & locals, parser_info const & p, buffer<expr> & ps) {
     buffer<expr> extra;
     name_set     explicit_param_names;
     for (expr const & p : ps) {

--- a/src/frontends/lean/util.cpp
+++ b/src/frontends/lean/util.cpp
@@ -105,22 +105,6 @@ levels collect_local_nonvar_levels(parser & p, level_param_names const & ls) {
     return to_list(section_ls_buffer.begin(), section_ls_buffer.end());
 }
 
-// Version of collect_locals(expr const & e, collected_locals & ls) that ignores local constants occurring in
-// tactics.
-static void collect_locals_ignoring_tactics(expr const & e, collected_locals & ls) {
-    if (!has_local(e))
-        return;
-    for_each(e, [&](expr const & e, unsigned) {
-            if (!has_local(e))
-                return false;
-            // if (is_by(e))
-            // return false; // do not visit children
-            if (is_local(e))
-                ls.insert(e);
-            return true;
-        });
-}
-
 void remove_local_vars(parser const & p, buffer<expr> & locals) {
     unsigned j = 0;
     for (unsigned i = 0; i < locals.size(); i++) {
@@ -137,20 +121,6 @@ levels remove_local_vars(parser const & p, levels const & ls) {
     return filter(ls, [&](level const & l) {
             return is_placeholder(l) || !is_param(l) || !p.is_local_level_variable(param_id(l));
         });
-}
-
-// TODO(Leo): delete these headers
-void collect_annonymous_inst_implicit(parser_info const & p, collected_locals & locals);
-void sort_locals(buffer<expr> const & locals, parser_info const & p, buffer<expr> & ps);
-
-list<expr> locals_to_context(expr const & e, parser const & p) {
-    collected_locals ls;
-    collect_locals_ignoring_tactics(e, ls);
-    collect_annonymous_inst_implicit(p, ls);
-    buffer<expr> locals;
-    sort_locals(ls.get_collected(), p, locals);
-    std::reverse(locals.begin(), locals.end());
-    return to_list(locals.begin(), locals.end());
 }
 
 expr mk_local_ref(name const & n, levels const & ctx_ls, unsigned num_ctx_params, expr const * ctx_params) {

--- a/src/frontends/lean/util.h
+++ b/src/frontends/lean/util.h
@@ -38,15 +38,11 @@ bool is_eqn_prefix(parser & p, bool bar_only = false);
 levels collect_local_nonvar_levels(parser & p, level_param_names const & ls);
 /** \brief Collect local constants occurring in \c type and \c value, sort them, and store in ctx_ps */
 void collect_locals(expr const & type, expr const & value, parser const & p, buffer<expr> & ctx_ps);
-void collect_annonymous_inst_implicit(parser_info const & p, collected_locals & ls);
 name_set collect_univ_params_ignoring_tactics(expr const & e, name_set const & ls = name_set());
-/** \brief Copy the local names to \c ps, then sort \c ps (using the order in which they were declared). */
-void sort_locals(buffer<expr> const & locals, parser_info const & p, buffer<expr> & ps);
 /** \brief Remove from \c ps local constants that are tagged as variables. */
 void remove_local_vars(parser const & p, buffer<expr> & ps);
 /** \brief Remove from \c ls any universe level that is tagged as variable in \c p */
 levels remove_local_vars(parser const & p, levels const & ls);
-list<expr> locals_to_context(expr const & e, parser const & p);
 /** \brief Create the term <tt>(as_atomic (@n.{ls} @params[0] ... @params[num_params-1]))</tt>
     When we declare \c n inside of a context, the parameters and universes are fixed.
     That is, when the user writes \c n inside the section she is really getting the term returned by this function.

--- a/tests/lean/run/univ_of_instances.lean
+++ b/tests/lean/run/univ_of_instances.lean
@@ -1,0 +1,14 @@
+section
+universes v u
+
+class category (C : Type u) := (hom : C → C → Type v)
+end
+
+section
+universes v u
+
+variables (C : Type u) [category.{v} C]
+
+def End (X : C) := category.hom X X
+
+end


### PR DESCRIPTION
Fixes #146.

This fixes a headache that arises throughout mathlib's category theory library.
