### PR TITLE
fix(scanner): read nested doc strings properly

### DIFF
--- a/src/frontends/lean/scanner.cpp
+++ b/src/frontends/lean/scanner.cpp
@@ -359,7 +359,8 @@ void scanner::read_doc_block_core() {
         next();
         if (c == '/') {
             if (curr() == '-') {
-                m_buffer += c;
+                m_buffer += '/';
+                m_buffer += '-';
                 next();
                 read_comment_block_doc();
             }
@@ -413,13 +414,15 @@ void scanner::read_comment_block_doc() {
         next();
         if (c == '/') {
             if (curr() == '-') {
-                m_buffer += c;
+                m_buffer += '/';
+                c = '-';
                 next();
                 nesting++;
             }
         } else if (c == '-') {
             if (curr() == '/') {
-                m_buffer += c;
+                m_buffer += '-';
+                c = '/';
                 next();
                 nesting--;
                 if (nesting == 0)

--- a/tests/lean/run/doc_string6.lean
+++ b/tests/lean/run/doc_string6.lean
@@ -1,0 +1,10 @@
+/--
+/- /- /- nested docstring -/ -/ -/
+-/
+def foo : string := "/- /- /- nested docstring -/ -/ -/"
+open tactic
+run_cmd do
+  doc ← doc_string `foo,
+  if doc = foo then skip
+  else fail ("doc string of `foo` was:\n" ++ doc ++
+             "\n\nexpected:\n" ++ foo)


### PR DESCRIPTION
This PR fixes a bug in #113 that mangled `/-` and `-/` in nested doc strings. 

Fixes https://github.com/leanprover-community/doc-gen/issues/17.