### PR TITLE
fix(library/init/meta/interactive): removing for `simp [← local_const ...]`

### DIFF
--- a/library/init/meta/interactive.lean
+++ b/library/init/meta/interactive.lean
@@ -1196,6 +1196,7 @@ do (hs, gex, hex, all_hyps) ← decode_simp_arg_list_with_symm hs,
    -- Erase `h` from the default simp set for calls of the form `simp [←h]`.
    let to_erase := hs.foldl (λ l h, match h with
                                     | (const id _, tt) := id :: l
+                                    | (local_const id _ _ _, tt) := id :: l
                                     | _ := l
                                     end ) [],
    let s := s.erase to_erase,

--- a/tests/lean/simp_symm.lean
+++ b/tests/lean/simp_symm.lean
@@ -32,14 +32,7 @@ open tactic.simp_arg_type
 def op : nat → nat → nat := sorry
 @[simp] lemma op_assoc (a b c : nat) : op (op a b) c = op a (op b c) := sorry
 
--- Passing an existing `@[simp]` lemma in reverse direction works:
--- The failure case is that the existing lemma isn't deleted from the set,
--- so the simplifier goes in an infinite loop.
--- We prevent that with the `try_for` call.
-example (a b c : nat) (h : p (op (op a b) c)) : p (op a (op b c)) :=
-by λ s, match try_for 1000 (simp none ff [symm_expr ``(op_assoc)] [] (loc.ns [none]) {} s) with
-        | none := result.exception (some (λ _, format!"timeout in try_for")) none s
-        | (some (result.success _ s')) := assumption s'
-        | (some exception) := exception
-        end
+example (a b c : nat) : op (op a b) c = op a (op b c) := by tactic.try_for 1000 `[ simp [← op_assoc] ]
+example (a b c : nat) : a + b + c = a + (b + c) := by tactic.try_for 1000 `[ simp [← add_assoc] ]
+
 end reverse_conflict


### PR DESCRIPTION
This fixes issue #193.

The code to erase a lemma `h` from the simp set for calls of the form
`simp [←h]` matched on `h = expr.const _ _`. It should also match when `h` is a
`local_const`. I think this issue was not caught by the test because the the
arguments to `simp` were quoted incorrectly, so I've changed the test to use
the tactic quoter instead.
