### PR TITLE
change interactive calc to `refine calc`

### DIFF
--- a/src/frontends/lean/tactic_notation.cpp
+++ b/src/frontends/lean/tactic_notation.cpp
@@ -270,7 +270,7 @@ struct parse_tactic_fn {
             }
         } else if (is_curr_exact_shortcut(m_p)) {
             expr arg = parse_qexpr();
-            r = m_p.mk_app(m_p.save_pos(mk_constant(get_interactive_tactic_full_name(m_tac_class, "exact")), pos), arg, pos);
+            r = m_p.mk_app(m_p.save_pos(mk_constant(get_interactive_tactic_full_name(m_tac_class, "refine")), pos), arg, pos);
             if (m_use_istep) r = mk_tactic_istep(m_p, r, pos, pos, m_tac_class);
         } else {
             r = m_p.parse_expr();


### PR DESCRIPTION
In tactic mode, `calc` was an abbreviation for `exact calc`, and I propose we change it to `refine calc`.

# Pull Request Description

Ensure you have read the contribution guide before filling in a description of the
pull request, regardless of whether it is complete or a work in progress.
All Pull Requests should include test case(s) which demonstrates the intended
behavior of a feature, or a regression test demonstrating that the fix resolves
the issue.
