### PR TITLE
feat(library/init/meta/*): port `rename` tactic from mathlib

### DIFF
--- a/library/init/data/list/basic.lean
+++ b/library/init/data/list/basic.lean
@@ -140,6 +140,18 @@ def drop_while (p : α → Prop) [decidable_pred p] : list α → list α
 | []     := []
 | (a::l) := if p a then drop_while l else a::l
 
+/-- `after p xs` is the suffix of `xs` after the first element that satisfies
+  `p`, not including that element.
+
+  ```lean
+  after      (eq 1)       [0, 1, 2, 3] = [2, 3]
+  drop_while (not ∘ eq 1) [0, 1, 2, 3] = [1, 2, 3]
+  ```
+-/
+def after (p : α → Prop) [decidable_pred p] : list α → list α
+| [] := []
+| (x :: xs) := if p x then xs else after xs
+
 def span (p : α → Prop) [decidable_pred p] : list α → list α × list α
 | []      := ([], [])
 | (a::xs) := if p a then let (l, r) := span xs in (a :: l, r) else ([], a::xs)

--- a/library/init/meta/interactive.lean
+++ b/library/init/meta/interactive.lean
@@ -168,11 +168,30 @@ h₂ : b = c
 meta def introv (ns : parse ident_*) : tactic unit :=
 propagate_tags (tactic.introv ns >> return ())
 
+/-- Parse a current name and new name for `rename`. -/
+private meta def rename_arg_parser : parser (name × name) :=
+  prod.mk <$> ident <*> (optional (tk "->") *> ident)
+
+/-- Parse the arguments of `rename`. -/
+private meta def rename_args_parser : parser (list (name × name)) :=
+  (functor.map (λ x, [x]) rename_arg_parser)
+  <|>
+  (tk "[" *> sep_by (tk ",") rename_arg_parser <* tk "]")
+
 /--
-The tactic `rename h₁ h₂` renames hypothesis `h₁` to `h₂` in the current local context.
+Rename one or more local hypotheses. The renamings are given as follows:
+
+```
+rename' x y             -- rename x to y
+rename' x → y           -- ditto
+rename' [x y, a b]      -- rename x to y and a to b
+rename' [x → y, a → b]  -- ditto
+```
+
+Brackets are necessary if multiple hypotheses should be renamed in parallel.
 -/
-meta def rename (h₁ h₂ : parse ident) : tactic unit :=
-propagate_tags (tactic.rename h₁ h₂)
+meta def rename (renames : parse rename_args_parser) : tactic unit :=
+propagate_tags $ tactic.rename_many $ native.rb_map.of_list renames
 
 /--
 The `apply` tactic tries to match the current goal against the conclusion of the type of term. The argument term should be a term well-formed in the local context of the main goal. If it succeeds, then the tactic returns as many subgoals as the number of premises that have not been fixed by type inference or type class resolution. Non-dependent premises are added before dependent ones.
@@ -665,7 +684,9 @@ private meta def find_case (goals : list expr) (ty : name) (idx : nat) (num_indi
   end else none
 
 private meta def rename_lams : expr → list name → tactic unit
-| (lam n _ _ e) (n'::ns) := (rename n n' >> rename_lams e ns) <|> rename_lams e (n'::ns)
+| (lam n _ _ e) (n'::ns) :=
+  (propagate_tags (tactic.rename_unstable n n') >> rename_lams e ns) <|>
+  rename_lams e (n'::ns)
 | _             _        := skip
 
 /--

--- a/library/init/meta/tactic.lean
+++ b/library/init/meta/tactic.lean
@@ -1473,8 +1473,7 @@ do let hyp_name : expr → name :=
    -- The new names for all hypotheses in ctx_suffix.
    let new_names :=
      ctx_suffix.map $ λ h,
-       let current_name := hyp_name h in
-       (renames.find current_name).get_or_else current_name,
+       (renames.find $ hyp_name h).get_or_else h.local_pp_name,
    revert_lst ctx_suffix,
    intro_lst new_names,
    pure ()

--- a/tests/lean/1513.lean.expected.out
+++ b/tests/lean/1513.lean.expected.out
@@ -6,8 +6,8 @@ h : m = 0
 1513.lean:8:0: error: tactic failed, there are unsolved goals
 state:
 n : ℕ,
-a : n > 0,
 y : ℕ := 10,
+a : n > 0,
 a_1 : y > 5,
 a_2 : n ≠ y
 ⊢ y + 1 = 1 + y

--- a/tests/lean/rename.lean
+++ b/tests/lean/rename.lean
@@ -1,0 +1,33 @@
+example {α β} (a : α) (b : β) : unit :=
+begin
+  rename a a',              -- rename-compatible syntax
+  guard_hyp a' := α,
+
+  rename a' → a,            -- more suggestive syntax
+  guard_hyp a := α,
+
+  rename [a a', b b'],      -- parallel renaming
+  guard_hyp a' := α,
+  guard_hyp b' := β,
+
+  rename [a' → a, b' → b],  -- ditto with alternative syntax
+  guard_hyp a := α,
+  guard_hyp b := β,
+
+  rename [a → b, b → a],    -- renaming really is parallel
+  guard_hyp a := β,
+  guard_hyp b := α,
+
+  rename b a,               -- shadowing is allowed (but guard_hyp doesn't like it)
+
+  rename d e,               -- cannot rename nonexistent hypothesis
+  exact ()
+end
+
+
+example {α} [decidable α] (a : α) : unit :=
+begin
+  rename a a', -- renaming works after frozen local instances
+
+  rename α α', -- renaming doesn't work before frozen local instances
+end

--- a/tests/lean/rename.lean.expected.out
+++ b/tests/lean/rename.lean.expected.out
@@ -1,0 +1,21 @@
+rename.lean:23:2: error: Cannot rename these hypotheses:
+d
+This is because these hypotheses either do not occur in the
+context or they occur before a frozen local instance.
+In the latter case, try `tactic.unfreeze_local_instances`.
+state:
+α : Sort ?,
+β : Sort ?,
+a : α,
+a : β
+⊢ unit
+rename.lean:32:2: error: Cannot rename these hypotheses:
+α
+This is because these hypotheses either do not occur in the
+context or they occur before a frozen local instance.
+In the latter case, try `tactic.unfreeze_local_instances`.
+state:
+α : Prop,
+_inst_1 : decidable α,
+a' : α
+⊢ unit


### PR DESCRIPTION
This PR ports the `rename` interactive tactic from mathlib (with some additional improvements). Features over current core `rename`:

- Multiple hypotheses can be renamed at once.
- The order of hypotheses doesn't change.
- If there are multiple hypotheses with the same name in the context, they are all renamed.

Breakage in `mathlib`:
- Remove `rename` and `list.after` (now in core).
- Fix one proof that relies on edge case behaviour of old `rename` when there are multiple hypotheses with the same name.