### PR TITLE
feat(library/module_mgr): add flag to use out-of-date oleans

### DIFF
--- a/src/library/module_mgr.cpp
+++ b/src/library/module_mgr.cpp
@@ -193,7 +193,7 @@ void module_mgr::build_module(module_id const & id, bool can_use_olean, name_set
 
             // If anything in the reflexive-transitive closure of this module under the import relation
             // has changed, rebuild the module.
-            if (mod->m_trans_hash != actual_trans_hash)
+            if (mod->m_trans_hash != actual_trans_hash && !m_use_old_oleans)
                 return build_module(id, false, orig_module_stack);
 
             module_info::parse_result res;
@@ -297,7 +297,7 @@ void module_mgr::build_lean(std::shared_ptr<module_info> const & mod, name_set c
             return parse_res;
         }).build();
 
-    if (m_save_olean) {
+    if (m_save_olean && !m_use_old_oleans) {
         scope_log_tree_core lt3(&lt);
         mod->m_olean_task = compile_olean(mod, lt2.get());
     }

--- a/src/library/module_mgr.h
+++ b/src/library/module_mgr.h
@@ -93,6 +93,7 @@ public:
 class module_mgr {
     bool m_server_mode = false;
     bool m_save_olean = false;
+    bool m_use_old_oleans = false;
 
     search_path m_path;
     environment m_initial_env;
@@ -134,6 +135,9 @@ public:
 
     void set_save_olean(bool save_olean) { m_save_olean = save_olean; }
     bool get_save_olean() const { return m_save_olean; }
+
+    void set_use_old_oleans(bool use_old_oleans) { m_use_old_oleans = use_old_oleans; }
+    bool get_use_old_oleans() const { return m_use_old_oleans; }
 
     environment get_initial_env() const { return m_initial_env; }
     options get_options() const { return m_ios.get_options(); }

--- a/src/shell/lean.cpp
+++ b/src/shell/lean.cpp
@@ -227,6 +227,7 @@ static struct option g_long_options[] = {
     {"run",          required_argument, 0, 'a'},
     {"githash",      no_argument,       0, 'g'},
     {"make",         no_argument,       0, 'm'},
+    {"old-oleans",   no_argument,       0, 'O'},
     {"recursive",    no_argument,       0, 'R'},
     {"export",       required_argument, 0, 'E'},
     {"only-export",  required_argument, 0, 'o'},
@@ -426,6 +427,7 @@ int main(int argc, char ** argv) {
 #endif
     ::initializer init;
     bool make_mode          = false;
+    bool use_old_oleans     = false;
     bool recursive          = false;
     unsigned trust_lvl      = LEAN_BELIEVER_TRUST_LEVEL+1;
     bool only_deps          = false;
@@ -473,6 +475,9 @@ int main(int argc, char ** argv) {
         case 'm':
             make_mode = true;
             recursive = true;
+            break;
+        case 'O':
+            use_old_oleans = true;
             break;
         case 'R':
             recursive = true;
@@ -588,7 +593,7 @@ int main(int argc, char ** argv) {
             std::cin.rdbuf(file_in->rdbuf());
         }
 
-        server(num_threads, path.get_path(), env, ios).run();
+        server(num_threads, path.get_path(), env, ios, use_old_oleans).run();
         return 0;
     }
 #endif
@@ -621,6 +626,7 @@ int main(int argc, char ** argv) {
 
         fs_module_vfs vfs;
         module_mgr mod_mgr(&vfs, lt.get_root(), path.get_path(), env, ios);
+        mod_mgr.set_use_old_oleans(use_old_oleans);
         set_global_module_mgr(mod_mgr);
 
         if (run_arg) {

--- a/src/shell/server.cpp
+++ b/src/shell/server.cpp
@@ -294,7 +294,8 @@ public:
     }
 };
 
-server::server(unsigned num_threads, search_path const & path, environment const & initial_env, io_state const & ios) :
+server::server(unsigned num_threads, search_path const & path, environment const & initial_env, io_state const & ios,
+        bool use_old_oleans) :
         m_path(path), m_initial_env(initial_env), m_ios(ios) {
     m_ios.set_regular_channel(std::make_shared<stderr_channel>());
     m_ios.set_diagnostic_channel(std::make_shared<stderr_channel>());
@@ -320,6 +321,7 @@ server::server(unsigned num_threads, search_path const & path, environment const
 
     set_task_queue(m_tq.get());
     m_mod_mgr.reset(new module_mgr(this, m_lt.get_root(), m_path, m_initial_env, m_ios));
+    m_mod_mgr->set_use_old_oleans(use_old_oleans);
     set_global_module_mgr(*m_mod_mgr);
     m_mod_mgr->set_server_mode(true);
     m_mod_mgr->set_save_olean(false);

--- a/src/shell/server.h
+++ b/src/shell/server.h
@@ -108,7 +108,8 @@ class server : public module_vfs {
     json info(std::shared_ptr<module_info const> const & mod_info, pos_info const & pos);
 
 public:
-    server(unsigned num_threads, search_path const & path, environment const & intial_env, io_state const & ios);
+    server(unsigned num_threads, search_path const & path, environment const & intial_env, io_state const & ios,
+        bool use_old_oleans = false);
     ~server();
 
     std::shared_ptr<module_info> load_module(module_id const & id, bool can_use_olean) override;


### PR DESCRIPTION
Add an option to Lean that uses old oleans instead of rebuilding them.  That is, use oleans whenever available, no matter whether they are out-of-date or not.

Usage: `lean --old ...`

See also https://github.com/leanprover/vscode-lean/issues/151#issuecomment-600257372