### PR TITLE
feat(library/fun_info): improve congruence lemmas for coe_fn

### DIFF
--- a/src/library/fun_info.cpp
+++ b/src/library/fun_info.cpp
@@ -213,6 +213,14 @@ static void trace_if_unsupported(type_context_old & ctx, expr const & fn,
 
 unsigned get_specialization_prefix_size(type_context_old & ctx, expr const & fn, unsigned nargs) {
     /*
+    Using the default algorithm, only the first argument of `coe_fn` would be specialized.
+    However we need to specialize the (2nd) type-class argument as well to detect whether the
+    coercion is a dependent coercion.
+    */
+    if (is_constant(fn) && const_name(fn) == get_coe_fn_name()) {
+        return nargs >= 2 ? 2 : nargs;
+    }
+    /*
       We say a function is "cheap" if it is of the form:
 
       a) 0 or more dependent parameters p s.t. there is at least one forward dependency x : C[p]

--- a/tests/lean/run/sebastien_coe_simp.lean
+++ b/tests/lean/run/sebastien_coe_simp.lean
@@ -1,0 +1,20 @@
+variable (α : Type*)
+
+structure my_equiv :=
+(to_fun : α → α)
+
+instance : has_coe_to_fun (my_equiv α) := ⟨_, my_equiv.to_fun⟩
+
+def my_equiv1 : my_equiv α :=
+{ to_fun := id }
+
+def my_equiv2 : my_equiv α :=
+{ to_fun := id }
+
+@[simp] lemma one_eq_two : my_equiv1 α = my_equiv2 α := rfl
+
+lemma other (x : ℕ) : my_equiv1 ℕ (x + 0) = my_equiv2 ℕ x := by simp -- does not fail
+
+@[simp] lemma two_apply (x : α) : my_equiv2 α x = x := rfl
+
+lemma one_apply (x : α) : my_equiv1 α x = x := by simp -- does not fail


### PR DESCRIPTION
The default congruence lemma generated for `coe_fn` is specialized only for the first argument, ignoring the type-class instance for the function coercion.  The congruence lemma hence needs to assume that the coercion is dependent and that the result type is not necessarily a function type.  That is, using the congruence lemma you can neither rewrite the coercee (because the return type depends on it) nor the argument (because the "function coercion" could return a non-function :shrug:).

By specializing to two arguments, we can generate much better congruence lemmas for non-dependent function coercions.  In particular, for a non-dependent coercion to a non-dependent function the resulting congruence lemma can rewrite both the coercee as well as the argument.

We implement this by adding an ad-hoc heuristic.