### PR TITLE
fix(library/type_context): do not unfold irreducible definitions when trying to unify/match types

### DIFF
--- a/src/library/tactic/rewrite_tactic.cpp
+++ b/src/library/tactic/rewrite_tactic.cpp
@@ -93,7 +93,13 @@ static vm_obj rewrite_core(expr h, expr e, rewrite_cfg const & cfg, tactic_state
         type_context_old::transparency_scope scope(ctx, ensure_semireducible_mode(ctx.mode()));
         check(ctx, motive);
     } catch (exception & ex) {
-        throw nested_exception("rewrite tactic failed, motive is not type correct", ex);
+        auto new_s = update_option_if_undef(s, get_pp_beta_name(), false);
+        auto thunk = [=]() {
+            format msg = format("rewrite tactic failed, motive is not type correct");
+            msg += pp_indented_expr(new_s, motive);
+            return msg;
+        };
+        return tactic::mk_exception(thunk, new_s);
     }
     expr prf           = mk_eq_rec(ctx, motive, mk_eq_refl(ctx, e), h);
     tactic_state new_s = set_mctx_goals(s, ctx.mctx(), append(cons(head(s.goals()), to_list(new_goals)), tail(s.goals())));

--- a/src/library/type_context.cpp
+++ b/src/library/type_context.cpp
@@ -1993,15 +1993,14 @@ bool type_context_old::process_assignment(expr const & m, expr const & v) {
     try {
         expr t1 = infer(mvar);
         expr t2 = infer(new_v);
-        /* TODO(Leo): check whether using transparency_mode::All hurts performance.
-           We use Semireducible to make sure we will not fail an unification step
+        /* We use Semireducible to make sure we will not fail an unification step
                    ?m := t
            because we cannot establish that the types of ?m and t are definitionally equal
            due to the current transparency setting.
            This change is consistent with the general approach used in the rest of the code
            base where spurious typing errors due reducibility are avoided by using
            relaxed_is_def_eq. */
-        relaxed_scope _(*this);
+        relaxed_scope _(*this, transparency_mode::Semireducible);
         if (!is_def_eq_core(t1, t2)) {
             lean_trace(name({"type_context", "is_def_eq_detail"}),
                        scope_trace_env scope(env(), *this);

--- a/src/library/type_context.cpp
+++ b/src/library/type_context.cpp
@@ -1101,7 +1101,7 @@ expr type_context_old::infer_lambda(expr e) {
 }
 
 optional<level> type_context_old::get_level_core(expr const & A) {
-    lean_assert(m_transparency_mode == transparency_mode::All);
+    // lean_assert(m_transparency_mode == transparency_mode::All);
     expr A_type = whnf(infer_core(A));
     while (true) {
         if (is_sort(A_type)) {
@@ -1174,7 +1174,7 @@ expr type_context_old::infer_app(expr const & e) {
         if (is_pi(f_type)) {
             f_type = binding_body(f_type);
         } else {
-            lean_assert(m_transparency_mode == transparency_mode::All);
+            // lean_assert(m_transparency_mode == transparency_mode::All);
             f_type = whnf(instantiate_rev(f_type, i-j, args.data()+j));
             if (!is_pi(f_type)) {
                 throw generic_exception(e, [=](formatter const & fmt) {

--- a/src/library/type_context.h
+++ b/src/library/type_context.h
@@ -784,7 +784,7 @@ public:
     struct relaxed_scope {
         transparency_scope m_transparency_scope;
         zeta_scope         m_zeta_scope;
-        relaxed_scope(type_context_old & ctx, transparency_mode m = transparency_mode::All):
+        relaxed_scope(type_context_old & ctx, transparency_mode m = transparency_mode::Semireducible):
             m_transparency_scope(ctx, m),
             m_zeta_scope(ctx, true) {}
     };

--- a/src/library/type_context.h
+++ b/src/library/type_context.h
@@ -784,8 +784,8 @@ public:
     struct relaxed_scope {
         transparency_scope m_transparency_scope;
         zeta_scope         m_zeta_scope;
-        relaxed_scope(type_context_old & ctx):
-            m_transparency_scope(ctx, transparency_mode::All),
+        relaxed_scope(type_context_old & ctx, transparency_mode m = transparency_mode::All):
+            m_transparency_scope(ctx, m),
             m_zeta_scope(ctx, true) {}
     };
 

--- a/tests/lean/1277.lean.expected.out
+++ b/tests/lean/1277.lean.expected.out
@@ -1,6 +1,5 @@
 1277.lean:8:2: error: rewrite tactic failed, motive is not type correct
-nested exception message:
-check failed, application type mismatch (use 'set_option trace.check true' for additional details)
+  λ (_a : α₁ → α₁), map f₁ f₂ = id = (map _a f₂ = id)
 state:
 α₁ : Type,
 α₂ : α₁ → Type,

--- a/tests/lean/run/mario_type_context.lean
+++ b/tests/lean/run/mario_type_context.lean
@@ -14,5 +14,5 @@ by do
   pr ← mk_app `eq.refl [ht],
   pr' ← mk_app `eq.refl [ht'],
   trace [ht, ht, pr', h],
-  mk_mapp `eq.mp [ht, ht, pr', h], -- takes 23s
+  try_for 100 $ mk_mapp `eq.mp [ht, ht, pr', h], -- slow step
   admit

--- a/tests/lean/run/mario_type_context.lean
+++ b/tests/lean/run/mario_type_context.lean
@@ -1,0 +1,18 @@
+-- see https://leanprover.zulipchat.com/#narrow/stream/116395-maths/topic/witt.20vectors/near/168407094
+set_option profiler true
+open tactic
+
+def bar (α) [semiring α] : α := sorry
+
+lemma foo (α) [comm_ring α]
+  (h : bar α = @bar α (@comm_semiring.to_semiring α _)) : true :=
+by do
+  h ← get_local `h,
+  ht ← infer_type h,
+  `(%%h1 = %%h2) ← return ht,
+  ht' ← to_expr ``(%%h2 = %%h2),
+  pr ← mk_app `eq.refl [ht],
+  pr' ← mk_app `eq.refl [ht'],
+  trace [ht, ht, pr', h],
+  mk_mapp `eq.mp [ht, ht, pr', h], -- takes 23s
+  admit


### PR DESCRIPTION
Fix copied from https://github.com/kha/lean4/commit/f8cedb33e70c9d90c9d81a542340bba0b504f8e6.

See discussion: https://leanprover.zulipchat.com/#narrow/stream/116395-maths/topic/witt.20vectors/near/169124238