### PR TITLE
[Merged by Bors] - feat(library/init/meta/tactic): informative tactic combinators

### DIFF
--- a/library/init/meta/congr_tactic.lean
+++ b/library/init/meta/congr_tactic.lean
@@ -12,7 +12,7 @@ meta def apply_congr_core (clemma : congr_lemma) : tactic unit :=
 do assert `H_congr_lemma clemma.type,
    exact clemma.proof,
    get_local `H_congr_lemma >>= apply,
-   all_goals $ do
+   all_goals' $ do
      try (applyc `heq_of_eq),
      get_local `H_congr_lemma >>= clear
 
@@ -36,6 +36,6 @@ do tgt ← target,
    <|> fail "congr tactic failed"
 
 meta def congr : tactic unit :=
-do focus1 (try assumption >> congr_core >> all_goals (try reflexivity >> try congr))
+do focus1 (try assumption >> congr_core >> all_goals' (try reflexivity >> try congr))
 
 end tactic

--- a/library/init/meta/converter/conv.lean
+++ b/library/init/meta/converter/conv.lean
@@ -14,7 +14,7 @@ universe u
 
 /-- `conv α` is a tactic for discharging goals of the form `lhs ~ rhs` for some relation `~` (usually equality) and fixed lhs, rhs.
 Known in the literature as a __conversion__ tactic.
-So for example, if one had the lemma `p : x = y`, then the conversion for `p` would be one that solves `p`. 
+So for example, if one had the lemma `p : x = y`, then the conversion for `p` would be one that solves `p`.
 -/
 meta def conv (α : Type u) :=
 tactic α
@@ -119,7 +119,7 @@ do (r, lhs, rhs) ← target_lhs_rhs,
 
 /-- Create a conversion from the function extensionality tactic.-/
 meta def funext : conv unit :=
-iterate $ do
+iterate' $ do
   (r, lhs, rhs) ← target_lhs_rhs,
   guard (r = `eq),
   (expr.lam n _ _ _) ← return lhs,

--- a/library/init/meta/interactive.lean
+++ b/library/init/meta/interactive.lean
@@ -248,7 +248,7 @@ tactic.assumption
 
 /-- Try to apply `assumption` to all goals. -/
 meta def assumption' : tactic unit :=
-tactic.any_goals tactic.assumption
+tactic.any_goals' tactic.assumption
 
 private meta def change_core (e : expr) : option expr → tactic unit
 | none     := tactic.change e
@@ -457,7 +457,7 @@ meta def with_cases (t : itactic) : tactic unit :=
 with_enable_tags $ focus1 $ do
   input_hyp_uids ← collect_hyps_uids,
   t,
-  all_goals (revert_new_hyps input_hyp_uids)
+  all_goals' (revert_new_hyps input_hyp_uids)
 
 private meta def get_type_name (e : expr) : tactic name :=
 do e_type ← infer_type e >>= whnf,
@@ -854,8 +854,8 @@ tactic.contradiction
 -/
 meta def iterate (n : parse small_nat?) (t : itactic) : tactic unit :=
 match n with
-| none   := tactic.iterate t
-| some n := iterate_exactly n t
+| none   := tactic.iterate' t
+| some n := iterate_exactly' n t
 end
 
 /--
@@ -895,13 +895,13 @@ tactic.abstract tac id
 `all_goals { t }` applies the tactic `t` to every goal, and succeeds if each application succeeds.
 -/
 meta def all_goals : itactic → tactic unit :=
-tactic.all_goals
+tactic.all_goals'
 
 /--
 `any_goals { t }` applies the tactic `t` to every goal, and succeeds if at least one application succeeds.
 -/
 meta def any_goals : itactic → tactic unit :=
-tactic.any_goals
+tactic.any_goals'
 
 /--
 `focus { t }` temporarily hides all goals other than the first, applies `t`, and then restores the other goals. It fails if there are no goals.

--- a/library/init/meta/mk_dec_eq_instance.lean
+++ b/library/init/meta/mk_dec_eq_instance.lean
@@ -100,7 +100,7 @@ do
   else dec_eq_diff_constructor
 
 private meta def dec_eq_case_1 (I_name : name) (F_name : name) : tactic unit :=
-intro `w >>= cases >> all_goals (dec_eq_case_2 I_name F_name)
+intro `w >>= cases >> all_goals' (dec_eq_case_2 I_name F_name)
 
 meta def mk_dec_eq_instance_core : tactic unit :=
 do I_name ← get_dec_eq_type_name,
@@ -116,7 +116,7 @@ do I_name ← get_dec_eq_type_name,
    else intro v_name >> return (),
    -- Apply cases to first element of type (I ...)
    get_local v_name >>= cases,
-   all_goals (dec_eq_case_1 I_name F_name)
+   all_goals' (dec_eq_case_1 I_name F_name)
 
 meta def mk_dec_eq_instance : tactic unit :=
 do env ← get_env,

--- a/tests/lean/andthen_focus_error_message.lean.expected.out
+++ b/tests/lean/andthen_focus_error_message.lean.expected.out
@@ -1,16 +1,16 @@
-andthen_focus_error_message.lean:3:14: error: focus tactic failed, insufficient number of goals
+andthen_focus_error_message.lean:3:14: error: focus' tactic failed, insufficient number of goals
 state:
 a b c : ℕ
 ⊢ b = b
-andthen_focus_error_message.lean:9:13: error: focus tactic failed, insufficient number of goals
+andthen_focus_error_message.lean:9:13: error: focus' tactic failed, insufficient number of goals
 state:
 a b c : ℕ
 ⊢ b = b
-andthen_focus_error_message.lean:16:14: error: focus tactic failed, insufficient number of tactics
+andthen_focus_error_message.lean:16:14: error: focus' tactic failed, insufficient number of tactics
 state:
 a : ℕ
 ⊢ a = a
-andthen_focus_error_message.lean:22:14: error: focus tactic failed, insufficient number of tactics
+andthen_focus_error_message.lean:22:14: error: focus' tactic failed, insufficient number of tactics
 state:
 a : ℕ
 ⊢ a = a


### PR DESCRIPTION
Many tactic combinators currently only work with `tactic unit`s. This PR introduces variants of these combinators which work with general `tactic α`s, as suggested in #206.

This is a choose-your-own-PR: It contains two commits corresponding to two different designs from #206. The first commit is more conservative: it leaves the existing combinators alone and implements the new ones with primed names (`all_goals'` etc). This leads to no breakage in core and very minimal breakage in mathlib. The second commit switches the names around so that the `unit`-valued combinators get the prime. This leads to mild breakage in core/mathlib, but is more consistent with the existing naming conventions (e.g. `mmap` vs `mmap'`).

I'd prefer that both commits get merged, but if you want just the first one, that's also fine by me.

fixes #206 