### PR TITLE
fix(library/tactic/rewrite_tactic): instantiate mvars in rw

### DIFF
--- a/src/library/tactic/rewrite_tactic.cpp
+++ b/src/library/tactic/rewrite_tactic.cpp
@@ -35,7 +35,7 @@ static vm_obj rewrite_core(expr h, expr e, rewrite_cfg const & cfg, tactic_state
     tactic_state_context_cache cache(s);
     type_context_old ctx = cache.mk_type_context(cfg.m_mode);
     type_context_old::approximate_scope _(ctx, cfg.m_approx);
-    expr h_type      = ctx.infer(h);
+    expr h_type      = ctx.instantiate_mvars(ctx.infer(h));
     /* Generate meta-variables for arguments */
     buffer<expr> metas;
     buffer<bool> is_instance;

--- a/tests/lean/run/rw_instantiate_mvars.lean
+++ b/tests/lean/run/rw_instantiate_mvars.lean
@@ -1,0 +1,2 @@
+example (n : ℕ) (h : n + n ≠ 0) : n ≠ 0 :=
+by refine mt (λ hz, _) h; rw hz


### PR DESCRIPTION
`rw` will sometimes fail to notice an equality if the type of the input theorem is an instantiated metavariable. This does the `instantiate_mvars` call first, before any of the pi-matching or other things that could be affected later in the procedure.