### PR TITLE
[Merged by Bors] - chore(library/init/function): use dot notation, add some docstrings

### DIFF
--- a/library/init/function.lean
+++ b/library/init/function.lean
@@ -2,19 +2,23 @@
 Copyright (c) 2014 Microsoft Corporation. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Author: Leonardo de Moura, Jeremy Avigad, Haitao Zhang
-
-General operations on functions.
 -/
 prelude
 import init.data.prod init.funext init.logic
+/-!
+# General operations on functions
+-/
 universes u₁ u₂ u₃ u₄
 
 namespace function
 variables {α : Sort u₁} {β : Sort u₂} {φ : Sort u₃} {δ : Sort u₄} {ζ : Sort u₁}
 
+/-- Composition of functions: `(f ∘ g) x = f (g x)`. -/
 @[inline, reducible] def comp (f : β → φ) (g : α → β) : α → φ :=
 λ x, f (g x)
 
+/-- Composition of dependent functions: `(f ∘' g) x = f (g x)`, where type of `g x` depends on `x`
+and type of `f (g x)` depends on `x` and `g x`. -/
 @[inline, reducible] def dcomp {β : α → Sort u₂} {φ : Π {x : α}, β x → Sort u₃}
   (f : Π {x : α} (y : β x), φ y) (g : Π x, β x) : Π x, φ (g x) :=
 λ x, f (g x)
@@ -28,6 +32,9 @@ infixr  ` ∘' `:80  := function.dcomp
 @[reducible] def comp_left (f : β → β → β) (g : α → β) : α → β → β :=
 λ a b, f (g a) b
 
+/-- Given functions `f : β → β → φ` and `g : α → β`, produce a function `α → α → φ` that evaluates
+`g` on each argument, then applies `f` to the results. Can be used, e.g., to transfer a relation
+from `β` to `α`. -/
 @[reducible] def on_fun (f : β → β → φ) (g : α → β) : α → α → φ :=
 λ x y, f (g x) (g y)
 
@@ -35,6 +42,7 @@ infixr  ` ∘' `:80  := function.dcomp
   : α → β → ζ :=
 λ x y, op (f x y) (g x y)
 
+/-- Constant `λ _, a`. -/
 @[reducible] def const (β : Sort u₂) (a : α) : β → α :=
 λ x, a
 
@@ -61,41 +69,48 @@ lemma comp.assoc (f : φ → δ) (g : β → φ) (h : α → β) : (f ∘ g) ∘
 
 lemma comp_const_right (f : β → φ) (b : β) : f ∘ (const α b) = const α (f b) := rfl
 
+/-- A function `f : α → β` is called injective if `f x = f y` implies `x = y`. -/
 @[reducible] def injective (f : α → β) : Prop := ∀ ⦃a₁ a₂⦄, f a₁ = f a₂ → a₁ = a₂
 
-lemma injective_comp {g : β → φ} {f : α → β} (hg : injective g) (hf : injective f) : injective (g ∘ f) :=
+lemma injective.comp {g : β → φ} {f : α → β} (hg : injective g) (hf : injective f) :
+  injective (g ∘ f) :=
 assume a₁ a₂, assume h, hf (hg h)
 
+/-- A function `f : α → β` is calles surjective if every `b : β` is equal to `f a`
+for some `a : α`. -/
 @[reducible] def surjective (f : α → β) : Prop := ∀ b, ∃ a, f a = b
 
-lemma surjective_comp {g : β → φ} {f : α → β} (hg : surjective g) (hf : surjective f) : surjective (g ∘ f) :=
+lemma surjective.comp {g : β → φ} {f : α → β} (hg : surjective g) (hf : surjective f) :
+  surjective (g ∘ f) :=
 λ (c : φ), exists.elim (hg c) (λ b hb, exists.elim (hf b) (λ a ha,
   exists.intro a (show g (f a) = c, from (eq.trans (congr_arg g ha) hb))))
 
+/-- A function is called bijective if it is both injective and surjective. -/
 def bijective (f : α → β) := injective f ∧ surjective f
 
-lemma bijective_comp {g : β → φ} {f : α → β} : bijective g → bijective f → bijective (g ∘ f)
-| ⟨h_ginj, h_gsurj⟩ ⟨h_finj, h_fsurj⟩ := ⟨injective_comp h_ginj h_finj, surjective_comp h_gsurj h_fsurj⟩
+lemma bijective.comp {g : β → φ} {f : α → β} : bijective g → bijective f → bijective (g ∘ f)
+| ⟨h_ginj, h_gsurj⟩ ⟨h_finj, h_fsurj⟩ := ⟨h_ginj.comp h_finj, h_gsurj.comp h_fsurj⟩
 
 /-- `left_inverse g f` means that g is a left inverse to f. That is, `g ∘ f = id`. -/
 def left_inverse (g : β → α) (f : α → β) : Prop := ∀ x, g (f x) = x
 
+/-- `has_left_inverse f` means that `f` has an unspecified left inverse. -/
 def has_left_inverse (f : α → β) : Prop := ∃ finv : β → α, left_inverse finv f
 
 /-- `right_inverse g f` means that g is a right inverse to f. That is, `f ∘ g = id`. -/
 def right_inverse (g : β → α) (f : α → β) : Prop := left_inverse f g
 
+/-- `has_right_inverse f` means that `f` has an unspecified right inverse. -/
 def has_right_inverse (f : α → β) : Prop := ∃ finv : β → α, right_inverse finv f
 
-lemma injective_of_left_inverse {g : β → α} {f : α → β} : left_inverse g f → injective f :=
-assume h, assume a b, assume faeqfb,
-have h₁ : a = g (f a),       from eq.symm (h a),
-have h₂ : g (f b) = b,       from h b,
-have h₃ : g (f a) = g (f b), from congr_arg g faeqfb,
-eq.trans h₁ (eq.trans h₃ h₂)
+lemma left_inverse.injective {g : β → α} {f : α → β} : left_inverse g f → injective f :=
+assume h a b faeqfb,
+calc a = g (f a) : (h a).symm
+... = g (f b) : congr_arg g faeqfb
+... = b : h b
 
-lemma injective_of_has_left_inverse {f : α → β} : has_left_inverse f → injective f :=
-assume h, exists.elim h (λ finv inv, injective_of_left_inverse inv)
+lemma has_left_inverse.injective {f : α → β} : has_left_inverse f → injective f :=
+assume h, exists.elim h (λ finv inv, inv.injective)
 
 lemma right_inverse_of_injective_of_left_inverse {f : α → β} {g : β → α}
     (injf : injective f) (lfg : left_inverse f g) :
@@ -104,8 +119,11 @@ assume x,
 have h : f (g (f x)) = f x, from lfg (f x),
 injf h
 
-lemma surjective_of_has_right_inverse {f : α → β} : has_right_inverse f → surjective f
-| ⟨finv, inv⟩ b := ⟨finv b, inv b⟩
+lemma right_inverse.surjective {f : α → β} {g : β → α} (h : right_inverse g f) : surjective f :=
+assume y, ⟨g y, h y⟩
+
+lemma has_right_inverse.surjective {f : α → β} : has_right_inverse f → surjective f
+| ⟨finv, inv⟩ := inv.surjective
 
 lemma left_inverse_of_surjective_of_right_inverse {f : α → β} {g : β → α}
     (surjf : surjective f) (rfg : right_inverse f g) :
@@ -126,9 +144,11 @@ end function
 namespace function
 variables {α : Type u₁} {β : Type u₂} {φ : Type u₃}
 
+/-- Interpret a function on `α × β` as a function with two arguments. -/
 @[inline] def curry : (α × β → φ) → α → β → φ :=
 λ f a b, f (a, b)
 
+/-- Interpret a function with two arguments as a function on `α × β` -/
 @[inline] def uncurry : (α → β → φ) → α × β → φ :=
 λ f a, f a.1 a.2
 
@@ -138,10 +158,10 @@ rfl
 @[simp] lemma uncurry_curry (f : α × β → φ) : uncurry (curry f) = f :=
 funext (λ ⟨a, b⟩, rfl)
 
-def id_of_left_inverse {g : β → α} {f : α → β} : left_inverse g f → g ∘ f = id :=
-assume h, funext h
+protected lemma left_inverse.id {g : β → α} {f : α → β} (h : left_inverse g f) : g ∘ f = id :=
+funext h
 
-def id_of_right_inverse {g : β → α} {f : α → β} : right_inverse g f → f ∘ g = id :=
-assume h, funext h
+protected def right_inverse.id {g : β → α} {f : α → β} (h : right_inverse g f) : f ∘ g = id :=
+funext h
 
 end function

--- a/tests/lean/doc_strings.lean
+++ b/tests/lean/doc_strings.lean
@@ -14,5 +14,4 @@ open tactic
 run_cmd doc_string `foo.a >>= trace
 run_cmd doc_string `foo.b >>= trace
 run_cmd doc_string `two >>= trace
-run_cmd olean_doc_strings >>= trace
 run_cmd module_doc_strings >>= trace

--- a/tests/lean/doc_strings.lean.expected.out
+++ b/tests/lean/doc_strings.lean.expected.out
@@ -1,7 +1,6 @@
 Makes foo.
 Makes foo of foo.
 Doesn't make foo.
-[(none, [(⟨1, 0⟩, This module has a doc..), (⟨2, 0⟩, ..or two.)])]
 [(none, This module has a doc..),
  (none, ..or two.),
  ((some foo.b), Makes foo of foo.),


### PR DESCRIPTION
Renamed (in `function` namespace):

* `injective_comp`, `surjective_comp`, `bijective_comp`: `injective.comp`, `surjective.comp`, `bijective.comp`;
* `injective_of_left_inverse` : `left_inverse.injective`;
* `injective_of_has_left_inverse`: `has_left_inverse.injective`;
* `surjective_of_has_right_inverse`: `has_right_inverse.surjective`;
* `right_inverse.surjective (new);
* `id_of_left_inverse`, `id_of_right_inverse`: `left_inverse.id`, `right_inverse.id` (both `protected`).