### PR TITLE
[Merged by Bors] -  chore(github): speed up emscripten build

### DIFF
--- a/.github/workflows/on-push.yml
+++ b/.github/workflows/on-push.yml
@@ -145,7 +145,7 @@ jobs:
       working-directory: ./build
     - run: |
         emmake make gmp
-        NODE_OPTIONS="--max-old-space-size=4096" emmake make -j2 lean_js
+        NODE_OPTIONS="--max-old-space-size=4096" emmake make -j2 lean_js_js lean_js_wasm
       working-directory: ./build
     - run: ./script/ci_emscripten_zip.sh
     - name: Release

--- a/.github/workflows/on-push.yml
+++ b/.github/workflows/on-push.yml
@@ -143,7 +143,9 @@ jobs:
     - run: mkdir -p ./build
     - run: emconfigure cmake ../src -DCMAKE_BUILD_TYPE=Emscripten -DLEAN_EMSCRIPTEN_BUILD=Main
       working-directory: ./build
-    - run: NODE_OPTIONS="--max-old-space-size=4096" emmake make lean_js
+    - run: |
+        emmake make gmp
+        NODE_OPTIONS="--max-old-space-size=4096" emmake make -j2 lean_js
       working-directory: ./build
     - run: ./script/ci_emscripten_zip.sh
     - name: Release
@@ -171,7 +173,9 @@ jobs:
     - run: mkdir -p ./build
     - run: emconfigure cmake ../src -DCMAKE_BUILD_TYPE=Emscripten -DLEAN_EMSCRIPTEN_BUILD=Main
       working-directory: ./build
-    - run: NODE_OPTIONS="--max-old-space-size=4096" emmake make -j2
+    - run: |
+        emmake make gmp
+        NODE_OPTIONS="--max-old-space-size=4096" emmake make -j2
       working-directory: ./build
     - name: Test
       run: ctest -j2 --output-on-failure

--- a/.github/workflows/on-push.yml
+++ b/.github/workflows/on-push.yml
@@ -145,7 +145,7 @@ jobs:
       working-directory: ./build
     - run: |
         emmake make gmp
-        NODE_OPTIONS="--max-old-space-size=4096" emmake make -j2 lean_js_js lean_js_wasm
+        NODE_OPTIONS="--max-old-space-size=4096" emmake make -j2
       working-directory: ./build
     - run: ./script/ci_emscripten_zip.sh
     - name: Release
@@ -160,23 +160,25 @@ jobs:
         name: lean-nightly-emscripten
         path: ./build/lean-*-browser.zip
 
-  test_emscripten_job:
-    runs-on: ubuntu-latest
-    container: trzeci/emscripten:sdk-incoming-64bit
-    name: Test emscripten
-    steps:
-    - name: Install dependencies
-      run: |
-        apt-get update
-        apt-get install -y m4
-    - uses: actions/checkout@v1
-    - run: mkdir -p ./build
-    - run: emconfigure cmake ../src -DCMAKE_BUILD_TYPE=Emscripten -DLEAN_EMSCRIPTEN_BUILD=Main
-      working-directory: ./build
-    - run: |
-        emmake make gmp
-        NODE_OPTIONS="--max-old-space-size=4096" emmake make -j2
-      working-directory: ./build
-    - name: Test
-      run: ctest -j2 --output-on-failure
-      working-directory: ./build
+  # takes a long time (70 minutes) and a few tests fail
+  #
+  # test_emscripten_job:
+  #   runs-on: ubuntu-latest
+  #   container: trzeci/emscripten:sdk-incoming-64bit
+  #   name: Test emscripten
+  #   steps:
+  #   - name: Install dependencies
+  #     run: |
+  #       apt-get update
+  #       apt-get install -y m4
+  #   - uses: actions/checkout@v1
+  #   - run: mkdir -p ./build
+  #   - run: emconfigure cmake ../src -DCMAKE_BUILD_TYPE=Emscripten -DLEAN_EMSCRIPTEN_BUILD=Main
+  #     working-directory: ./build
+  #   - run: |
+  #       emmake make gmp
+  #       NODE_OPTIONS="--max-old-space-size=4096" emmake make -j2
+  #     working-directory: ./build
+  #   - name: Test
+  #     run: ctest -j2 --output-on-failure
+  #     working-directory: ./build

--- a/.github/workflows/on-push.yml
+++ b/.github/workflows/on-push.yml
@@ -143,7 +143,7 @@ jobs:
     - run: mkdir -p ./build
     - run: emconfigure cmake ../src -DCMAKE_BUILD_TYPE=Emscripten -DLEAN_EMSCRIPTEN_BUILD=Main
       working-directory: ./build
-    - run: NODE_OPTIONS="--max-old-space-size=4096" emmake make
+    - run: NODE_OPTIONS="--max-old-space-size=4096" emmake make lean_js
       working-directory: ./build
     - run: ./script/ci_emscripten_zip.sh
     - name: Release
@@ -157,3 +157,22 @@ jobs:
       with:
         name: lean-nightly-emscripten
         path: ./build/lean-*-browser.zip
+
+  test_emscripten_job:
+    runs-on: ubuntu-latest
+    container: trzeci/emscripten:sdk-incoming-64bit
+    name: Test emscripten
+    steps:
+    - name: Install dependencies
+      run: |
+        apt-get update
+        apt-get install -y m4
+    - uses: actions/checkout@v1
+    - run: mkdir -p ./build
+    - run: emconfigure cmake ../src -DCMAKE_BUILD_TYPE=Emscripten -DLEAN_EMSCRIPTEN_BUILD=Main
+      working-directory: ./build
+    - run: NODE_OPTIONS="--max-old-space-size=4096" emmake make -j2
+      working-directory: ./build
+    - name: Test
+      run: ctest -j2 --output-on-failure
+      working-directory: ./build


### PR DESCRIPTION
Enables `-j2` in the emscripten build.  This didn't work before because the `gmp` target doesn't work with `-j2` so it has to be built separately.  This change saves about 15 minutes and brings the emscripten build time down to the time taken by the debug builds.

I've also tried only building the `lean_js_wasm` and `lean_js_js` targets.  This would save another 14 minutes, but I'd like to keep building the standard library as a sanity check.

Enabling the tests would also be possible, but they take a very long time.  (45 minutes just for the tests.)  A few tests fail, namely the IO tests and the type context test.  They would need to be commented out or fixed.