### PR TITLE
[Merged by Bors] - chore(library/*): use fully qualified import paths

### DIFF
--- a/library/init/algebra/ordered_field.lean
+++ b/library/init/algebra/ordered_field.lean
@@ -4,7 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Robert Lewis, Leonardo de Moura
 -/
 prelude
-import init.algebra.ordered_ring .field
+import init.algebra.ordered_ring init.algebra.field
 
 set_option old_structure_cmd true
 

--- a/library/init/data/char/classes.lean
+++ b/library/init/data/char/classes.lean
@@ -4,7 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Author: Gabriel Ebner
 -/
 prelude
-import .basic .lemmas init.meta init.data.int
+import init.data.char.basic init.data.char.lemmas init.meta init.data.int
 
 namespace char
 

--- a/library/init/data/nat/default.lean
+++ b/library/init/data/nat/default.lean
@@ -5,4 +5,4 @@ Authors: Leonardo de Moura
 -/
 prelude
 import init.data.nat.basic init.data.nat.div init.data.nat.lemmas
-       init.data.nat.bitwise
+import init.data.nat.bitwise

--- a/library/init/data/ordering/default.lean
+++ b/library/init/data/ordering/default.lean
@@ -4,4 +4,4 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Leonardo de Moura
 -/
 prelude
-import .basic .lemmas
+import init.data.ordering.basic init.data.ordering.lemmas


### PR DESCRIPTION
This one isn't very important, but it's useful when auto-generating import graphs.