### PR TITLE
[Merged by Bors] - perf(simp_lemmas): cache constructed simp_lemma objects

### DIFF
--- a/src/frontends/lean/cmd_table.h
+++ b/src/frontends/lean/cmd_table.h
@@ -31,8 +31,8 @@ template<typename F>
 struct cmd_info_tmpl {
     name        m_name;
     std::string m_descr;
-    F           m_fn;
-    bool        m_skip_token;
+    F           m_fn {};
+    bool        m_skip_token = false;
 public:
     cmd_info_tmpl(name const & n, char const * d, F const & fn, bool skip_token = true):
         m_name(n), m_descr(d), m_fn(fn), m_skip_token(skip_token) {}

--- a/src/kernel/inductive/inductive.cpp
+++ b/src/kernel/inductive/inductive.cpp
@@ -99,9 +99,9 @@ struct inductive_env_ext : public environment_extension {
     struct elim_info {
         name              m_inductive_name; // name of the inductive datatype associated with eliminator
         level_param_names m_level_names; // level parameter names used in computational rule
-        unsigned          m_num_params;  // number of global parameters A
-        unsigned          m_num_ACe;     // sum of number of global parameters A, type former C, and minor preimises e.
-        unsigned          m_num_indices; // number of inductive datatype indices
+        unsigned          m_num_params = 0;  // number of global parameters A
+        unsigned          m_num_ACe = 0;     // sum of number of global parameters A, type former C, and minor preimises e.
+        unsigned          m_num_indices = 0; // number of inductive datatype indices
         /** \brief We support K-like reduction when the inductive datatype is in Type.{0} (aka Prop), proof irrelevance
             is enabled, it has only one introduction rule, the introduction rule has "0 arguments".
             Example: equality defined as
@@ -111,9 +111,9 @@ struct inductive_env_ext : public environment_extension {
 
             satisfies these requirements when proof irrelevance is enabled.
             Another example is heterogeneous equality. */
-        bool              m_K_target;
+        bool              m_K_target = false;
         /** \brief m_dep_elim == true, if dependent elimination is used for this eliminator */
-        bool              m_dep_elim;
+        bool              m_dep_elim = false;
         elim_info() {}
         elim_info(name const & id_name, level_param_names const & ls, unsigned num_ps, unsigned num_ACe, unsigned num_indices,
                   bool is_K_target, bool dep_elim):
@@ -123,7 +123,7 @@ struct inductive_env_ext : public environment_extension {
 
     struct comp_rule {
         name              m_elim_name;     // name of the corresponding eliminator
-        unsigned          m_num_bu;        // sum of number of arguments u and v in the corresponding introduction rule.
+        unsigned          m_num_bu = 0;    // sum of number of arguments u and v in the corresponding introduction rule.
         expr              m_comp_rhs;      // computational rule RHS: Fun (A, C, e, b, u), (e_k_i b u v)
         expr              m_comp_rhs_body; // body of m_comp_rhs:  (e_k_i b u v)
         comp_rule() {}

--- a/src/library/projection.h
+++ b/src/library/projection.h
@@ -21,9 +21,9 @@ namespace lean {
 */
 struct projection_info {
     name     m_constructor;   // mk in the rule above
-    unsigned m_nparams;       // number of parameters of the inductive datatype
-    unsigned m_i;             // i in the rule above
-    bool     m_inst_implicit; // true if it is the projection of a "class"
+    unsigned m_nparams = 0;   // number of parameters of the inductive datatype
+    unsigned m_i = 0;         // i in the rule above
+    bool     m_inst_implicit = false; // true if it is the projection of a "class"
 
     projection_info() {}
     projection_info(name const & c, unsigned nparams, unsigned i, bool inst_implicit):

--- a/src/library/tactic/simp_lemmas.cpp
+++ b/src/library/tactic/simp_lemmas.cpp
@@ -46,7 +46,6 @@ struct simp_lemma_cell {
     unsigned            m_priority;
     MK_LEAN_RC(); // Declare m_rc counter
     void dealloc();
-    simp_lemma_cell():m_kind(simp_lemma_kind::Simp) {}
     simp_lemma_cell(simp_lemma_kind k,
                     name const & id, unsigned umetas, list<expr> const & emetas,
                     list<bool> const & instances, expr const & lhs, expr const & rhs,

--- a/src/library/tactic/simp_lemmas.cpp
+++ b/src/library/tactic/simp_lemmas.cpp
@@ -1149,7 +1149,7 @@ static simp_lemmas get_simp_lemmas_from_attribute(type_context_old & ctx, name c
     buffer<name> simp_lemmas;
     attr.get_instances(ctx.env(), simp_lemmas);
     std::reverse(simp_lemmas.begin(), simp_lemmas.end());
-    auto cache_attr = get_simp_cache_attr();
+    auto & cache_attr = get_simp_cache_attr();
     for (name const & id : simp_lemmas) {
         if (auto cached = cache_attr.get(ctx.env(), id)) {
             for (auto & sl : cached->m_sls) {

--- a/src/library/tactic/simp_lemmas.cpp
+++ b/src/library/tactic/simp_lemmas.cpp
@@ -1134,7 +1134,7 @@ static environment on_add_simp_lemma(environment const & env, io_state const & i
         sls_buf.push_back({rel, sl});
     });
 
-    return get_simp_cache_attr().set(env, ios, c, prio, to_list(sls_buf), persistent);
+    return get_simp_cache_attr().set(env, ios, c, prio, reverse_to_list(sls_buf), persistent);
 }
 
 static void on_add_congr_lemma(environment const & env, name const & c, bool) {

--- a/src/library/tactic/simp_lemmas.cpp
+++ b/src/library/tactic/simp_lemmas.cpp
@@ -262,6 +262,7 @@ deserializer & operator>>(deserializer & d, simp_lemma & sl) {
             sl = mk_rfl_lemma(id, num_umeta, emetas, instances, lhs, rhs, proof, priority);
             break;
         }
+        default: lean_unreachable();
     }
     return d;
 }

--- a/src/library/tactic/simp_lemmas.cpp
+++ b/src/library/tactic/simp_lemmas.cpp
@@ -1108,7 +1108,7 @@ struct simp_cache_attr_data : public attr_data {
     simp_cache_attr_data(list<pair<name, simp_lemma>> const & sls) : m_sls(sls) {}
 
     virtual unsigned hash() const override {
-        return 0; // TODO
+        return 0; // This is probably ok.
     }
 
     void write(serializer & s) const { write_list(s, m_sls); }

--- a/src/library/tactic/simp_lemmas.cpp
+++ b/src/library/tactic/simp_lemmas.cpp
@@ -89,10 +89,7 @@ void simp_lemma_cell::dealloc() {
     }
 }
 
-static simp_lemma_cell * g_dummy = nullptr;
-
-simp_lemma::simp_lemma():simp_lemma(g_dummy) {
-}
+simp_lemma::simp_lemma() : m_ptr(nullptr) {}
 
 simp_lemma::simp_lemma(simp_lemma_cell * ptr):m_ptr(ptr) {
     if (m_ptr) m_ptr->inc_ref();
@@ -1675,7 +1672,6 @@ vm_obj vm_mk_simp_attr_decl_name(vm_obj const & n) {
 }
 
 void initialize_simp_lemmas() {
-    g_dummy               = new simp_lemma_cell();
     g_simp_lemmas_configs = new std::vector<simp_lemmas_config>();
     g_name2simp_token     = new name_map<unsigned>();
     g_default_token       = register_simp_attribute("default", {"simp", "wrapper_eq"}, {"congr"});
@@ -1710,7 +1706,6 @@ void finalize_simp_lemmas() {
     delete g_simp_cache;
     delete g_simp_lemmas_configs;
     delete g_name2simp_token;
-    delete g_dummy;
     delete g_refl_lemma_attr;
 }
 }

--- a/src/library/tactic/simp_lemmas.h
+++ b/src/library/tactic/simp_lemmas.h
@@ -19,13 +19,13 @@ private:
     simp_lemma_cell * m_ptr;
     explicit simp_lemma(simp_lemma_cell * ptr);
     simp_lemma_cell * steal_ptr();
-    friend simp_lemma mk_simp_lemma(name const & id, levels const & umetas, list<expr> const & emetas,
+    friend simp_lemma mk_simp_lemma(name const & id, unsigned umetas, list<expr> const & emetas,
                                     list<bool> const & instances, expr const & lhs, expr const & rhs,
                                     expr const & proof, bool is_perm, unsigned priority);
-    friend simp_lemma mk_rfl_lemma(name const & id, levels const & umetas, list<expr> const & emetas,
+    friend simp_lemma mk_rfl_lemma(name const & id, unsigned umetas, list<expr> const & emetas,
                                    list<bool> const & instances, expr const & lhs, expr const & rhs, expr const & proof,
                                    unsigned priority);
-    friend simp_lemma mk_congr_lemma(name const & id, levels const & umetas, list<expr> const & emetas,
+    friend simp_lemma mk_congr_lemma(name const & id, unsigned umetas, list<expr> const & emetas,
                                      list<bool> const & instances, expr const & lhs, expr const & rhs,
                                      expr const & proof, list<expr> const & congr_hyps, unsigned priority);
 public:

--- a/src/library/user_recursors.h
+++ b/src/library/user_recursors.h
@@ -12,10 +12,10 @@ class recursor_info {
     name                     m_recursor;
     name                     m_type_name;
     list<unsigned>           m_universe_pos; // position of the recursor universe level parameters.
-    bool                     m_dep_elim;
-    bool                     m_recursive;
-    unsigned                 m_num_args; // total number of arguments
-    unsigned                 m_major_pos;
+    bool                     m_dep_elim = false;
+    bool                     m_recursive = false;
+    unsigned                 m_num_args = 0; // total number of arguments
+    unsigned                 m_major_pos = 0;
     // if param is <none>, then it should be resolved by type class resolution
     list<optional<unsigned>> m_params_pos;  // position of the recursor parameters in the major premise
     list<unsigned>           m_indices_pos; // position of the recursor indices in the major premise

--- a/src/library/vm/vm.cpp
+++ b/src/library/vm/vm.cpp
@@ -790,6 +790,9 @@ void vm_instr::release_memory() {
     case opcode::LocalInfo:
         delete m_local_info;
         break;
+    case opcode::String:
+        delete m_string;
+        break;
     default:
         break;
     }

--- a/src/util/sexpr/option_declarations.h
+++ b/src/util/sexpr/option_declarations.h
@@ -18,7 +18,7 @@ namespace lean {
 */
 class option_declaration {
     name        m_name;
-    option_kind m_kind;
+    option_kind m_kind = StringOption;
     std::string m_default;
     std::string m_description;
 public:

--- a/tests/lean/attribute_bug1.lean.expected.out
+++ b/tests/lean/attribute_bug1.lean.expected.out
@@ -2,6 +2,7 @@ attribute_bug1.lean:7:3: error: simplify tactic failed to simplify
 state:
 n : ℕ
 ⊢ f n = n + 1
+@[_simp_cache]
 constant fdef : ∀ (n : ℕ), f n = n + 1
 attribute_bug1.lean:19:3: error: simplify tactic failed to simplify
 state:


### PR DESCRIPTION
This was a lot easier than I'd imagined because temporary metavariables can be safely serialized.  When the user writes `@[simp]` we simply store all generated simp lemmas in the `_simp_cache` attribute.