### PR TITLE
[Merged by Bors] - chore(*): release 3.13.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@
 About
 -----
 
-- **Important**: This is Lean 3.12.0c, a fork of Lean 3 maintained and updated by the Lean community. The last official release of Lean 3.x was Lean 3.4.2, which can be found [here](https://github.com/leanprover/lean). The Lean developers are currently developing [Lean 4](https://github.com/leanprover/lean4).
+- **Important**: This is Lean 3.13.0c, a fork of Lean 3 maintained and updated by the Lean community. The last official release of Lean 3.x was Lean 3.4.2, which can be found [here](https://github.com/leanprover/lean). The Lean developers are currently developing [Lean 4](https://github.com/leanprover/lean4).
 - [Lean Homepage](http://leanprover.github.io)
 - [Lean Prover Community Homepage](https://leanprover-community.github.io)
 - [Theorem Proving in Lean](https://leanprover.github.io/theorem_proving_in_lean/index.html)

--- a/doc/changes.md
+++ b/doc/changes.md
@@ -1,3 +1,20 @@
+v3.13.0c (16 May 2020)
+----------------------
+
+Features:
+ - use persistent data structures, to improve performance
+   of (module) docstrings (#241)
+ - cache constructed `simp_lemma` objects (#234)
+ - support `local attribute [-instance]` (#240)
+ - show goal after `;` (#239)
+ - `==`: compare id (#238)
+ - mark deps of fixed as fixed (#237)
+
+
+Changes:
+ - Most of `library/init/algebra/*` has been deleted,
+   as part of moving the algebraic hierarchy to mathlib (#229)
+
 v3.12.0c (14 May 2020)
 ----------------------
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -4,7 +4,7 @@ if ((${CMAKE_MAJOR_VERSION}.${CMAKE_MINOR_VERSION} GREATER 3.1) OR (${CMAKE_MAJO
 endif()
 project(LEAN CXX C)
 set(LEAN_VERSION_MAJOR 3)
-set(LEAN_VERSION_MINOR 12)
+set(LEAN_VERSION_MINOR 13)
 set(LEAN_VERSION_PATCH 0)
 set(LEAN_VERSION_IS_RELEASE 1)  # This number is 1 in the release revision, and 0 otherwise.
 set(LEAN_SPECIAL_VERSION_DESC "" CACHE STRING "Additional version description like 'nightly-2018-03-11'")


### PR DESCRIPTION
Features:
 - use persistent data structures, to improve performance
   of (module) docstrings (#241)
 - cache constructed `simp_lemma` objects (#234)
 - support `local attribute [-instance]` (#240)
 - show goal after `;` (#239)
 - `==`: compare id (#238)
 - mark deps of fixed as fixed (#237)

Changes:
 - Most of `library/init/algebra/*` has been deleted,
   as part of moving the algebraic hierarchy to mathlib (#229)