### PR TITLE
[Merged by Bors] - fix(library/init/data/int/order): remove double namespaces, protect nat and int lemmas

### DIFF
--- a/library/init/data/int/comp_lemmas.lean
+++ b/library/init/data/int/comp_lemmas.lean
@@ -31,7 +31,7 @@ begin
   rw [← h] at h₂,
   change 0 < a at h₁,
   have := le_of_lt h₁,
-  exact absurd (le_of_lt h₁) (not_le_of_gt (neg_of_neg_pos h₂))
+  exact absurd (le_of_lt h₁) (not_le_of_gt (int.neg_of_neg_pos h₂))
 end
 
 protected lemma ne_neg_of_pos {a b : ℤ} : a > 0 → b > 0 → a ≠ -b :=

--- a/library/init/data/int/order.lean
+++ b/library/init/data/int/order.lean
@@ -231,7 +231,7 @@ by rw [int.add_assoc, int.add_right_neg, int.add_zero]
 protected lemma neg_add_cancel_right (a b : ℤ) : a + -b + b = a :=
 by rw [int.add_assoc, int.add_left_neg, int.add_zero]
 
-lemma int.sub_self (a : ℤ) : a - a = 0 :=
+lemma sub_self (a : ℤ) : a - a = 0 :=
 by rw [int.sub_eq_add_neg, int.add_right_neg]
 
 lemma sub_eq_zero_of_eq {a b : ℤ} (h : a = b) : a - b = 0 :=
@@ -938,7 +938,7 @@ theorem sign_eq_neg_one_iff_neg (a : ℤ) : sign a = -1 ↔ a < 0 :=
 theorem sign_eq_zero_iff_zero (a : ℤ) : sign a = 0 ↔ a = 0 :=
 ⟨eq_zero_of_sign_eq_zero, λ h, by rw [h, sign_zero]⟩
 
-lemma int.eq_zero_or_eq_zero_of_mul_eq_zero
+lemma eq_zero_or_eq_zero_of_mul_eq_zero
         {a b : ℤ} (h : a * b = 0) : a = 0 ∨ b = 0 :=
 match lt_trichotomy 0 a with
 | or.inl hlt₁          :=

--- a/library/init/data/int/order.lean
+++ b/library/init/data/int/order.lean
@@ -231,56 +231,52 @@ by rw [int.add_assoc, int.add_right_neg, int.add_zero]
 protected lemma neg_add_cancel_right (a b : ℤ) : a + -b + b = a :=
 by rw [int.add_assoc, int.add_left_neg, int.add_zero]
 
-lemma sub_self (a : ℤ) : a - a = 0 :=
+protected lemma sub_self (a : ℤ) : a - a = 0 :=
 by rw [int.sub_eq_add_neg, int.add_right_neg]
 
-lemma sub_eq_zero_of_eq {a b : ℤ} (h : a = b) : a - b = 0 :=
+protected lemma sub_eq_zero_of_eq {a b : ℤ} (h : a = b) : a - b = 0 :=
 by rw [h, int.sub_self]
 
-lemma eq_of_sub_eq_zero {a b : ℤ} (h : a - b = 0) : a = b :=
+protected lemma eq_of_sub_eq_zero {a b : ℤ} (h : a - b = 0) : a = b :=
 have 0 + b = b, by rw int.zero_add,
 have (a - b) + b = b, by rwa h,
 by rwa [int.sub_eq_add_neg, int.neg_add_cancel_right] at this
 
-lemma sub_eq_zero_iff_eq {a b : ℤ} : a - b = 0 ↔ a = b :=
-⟨int.eq_of_sub_eq_zero, sub_eq_zero_of_eq⟩
+protected lemma sub_eq_zero_iff_eq {a b : ℤ} : a - b = 0 ↔ a = b :=
+⟨int.eq_of_sub_eq_zero, int.sub_eq_zero_of_eq⟩
 
-@[simp] lemma neg_eq_of_add_eq_zero {a b : ℤ} (h : a + b = 0) : -a = b :=
+@[simp] protected lemma neg_eq_of_add_eq_zero {a b : ℤ} (h : a + b = 0) : -a = b :=
 by rw [← int.add_zero (-a), ←h, ←int.add_assoc, int.add_left_neg, int.zero_add]
 
-lemma neg_mul_eq_neg_mul (a b : ℤ) : -(a * b) = -a * b :=
-neg_eq_of_add_eq_zero
+protected lemma neg_mul_eq_neg_mul (a b : ℤ) : -(a * b) = -a * b :=
+int.neg_eq_of_add_eq_zero
   begin rw [← int.distrib_right, int.add_right_neg, int.zero_mul] end
 
-lemma neg_mul_eq_mul_neg (a b : ℤ) : -(a * b) = a * -b :=
-neg_eq_of_add_eq_zero
+protected lemma neg_mul_eq_mul_neg (a b : ℤ) : -(a * b) = a * -b :=
+int.neg_eq_of_add_eq_zero
   begin rw [← int.distrib_left, int.add_right_neg, int.mul_zero] end
 
 @[simp] lemma neg_mul_eq_neg_mul_symm (a b : ℤ) : - a * b = - (a * b) :=
-eq.symm (neg_mul_eq_neg_mul a b)
+eq.symm (int.neg_mul_eq_neg_mul a b)
 
 @[simp] lemma mul_neg_eq_neg_mul_symm (a b : ℤ) : a * - b = - (a * b) :=
-eq.symm (neg_mul_eq_mul_neg a b)
+eq.symm (int.neg_mul_eq_mul_neg a b)
 
-lemma neg_mul_neg (a b : ℤ) : -a * -b = a * b :=
+protected lemma neg_mul_neg (a b : ℤ) : -a * -b = a * b :=
 by simp
 
-lemma neg_mul_comm (a b : ℤ) : -a * b = a * -b :=
+protected lemma neg_mul_comm (a b : ℤ) : -a * b = a * -b :=
 by simp
 
-lemma mul_sub_left_distrib (a b c : ℤ) : a * (b - c) = a * b - a * c :=
+protected lemma mul_sub (a b c : ℤ) : a * (b - c) = a * b - a * c :=
 calc
    a * (b - c) = a * b + a * -c : int.distrib_left a b (-c)
            ... = a * b - a * c  : by simp
 
-def mul_sub := @mul_sub_left_distrib
-
-lemma mul_sub_right_distrib (a b c : ℤ) : (a - b) * c = a * c - b * c :=
+protected lemma sub_mul (a b c : ℤ) : (a - b) * c = a * c - b * c :=
 calc
   (a - b) * c = a * c  + -b * c : int.distrib_right a (-b) c
           ... = a * c - b * c   : by simp
-
-def sub_mul := @mul_sub_right_distrib
 
 section
 
@@ -362,405 +358,405 @@ int.zero_add (0:ℤ) ▸ (int.add_lt_add_of_lt_of_le ha hb)
 protected lemma add_neg_of_nonpos_of_neg {a b : ℤ} (ha : a ≤ 0) (hb : b < 0) : a + b < 0 :=
 int.zero_add (0:ℤ) ▸ (int.add_lt_add_of_le_of_lt ha hb)
 
-lemma lt_add_of_le_of_pos {a b c : ℤ} (hbc : b ≤ c) (ha : 0 < a) : b < c + a :=
+protected lemma lt_add_of_le_of_pos {a b c : ℤ} (hbc : b ≤ c) (ha : 0 < a) : b < c + a :=
 int.add_zero b ▸ int.add_lt_add_of_le_of_lt hbc ha
 
-lemma sub_add_cancel (a b : ℤ) : a - b + b = a :=
+protected lemma sub_add_cancel (a b : ℤ) : a - b + b = a :=
 int.neg_add_cancel_right a b
 
-lemma add_sub_cancel (a b : ℤ) : a + b - b = a :=
+protected lemma add_sub_cancel (a b : ℤ) : a + b - b = a :=
 int.add_neg_cancel_right a b
 
-lemma add_sub_assoc (a b c : ℤ) : a + b - c = a + (b - c) :=
+protected lemma add_sub_assoc (a b c : ℤ) : a + b - c = a + (b - c) :=
 by rw [int.sub_eq_add_neg, int.add_assoc, ←int.sub_eq_add_neg]
 
-lemma neg_le_neg {a b : ℤ} (h : a ≤ b) : -b ≤ -a :=
+protected lemma neg_le_neg {a b : ℤ} (h : a ≤ b) : -b ≤ -a :=
 have 0 ≤ -a + b,           from int.add_left_neg a ▸ int.add_le_add_left h (-a),
 have 0 + -b ≤ -a + b + -b, from int.add_le_add_right this (-b),
 by rwa [int.add_neg_cancel_right, int.zero_add] at this
 
-lemma le_of_neg_le_neg {a b : ℤ} (h : -b ≤ -a) : a ≤ b :=
+protected lemma le_of_neg_le_neg {a b : ℤ} (h : -b ≤ -a) : a ≤ b :=
 suffices -(-a) ≤ -(-b), from
   begin simp [int.neg_neg] at this, assumption end,
-neg_le_neg h
+int.neg_le_neg h
 
-lemma nonneg_of_neg_nonpos {a : ℤ} (h : -a ≤ 0) : 0 ≤ a :=
+protected lemma nonneg_of_neg_nonpos {a : ℤ} (h : -a ≤ 0) : 0 ≤ a :=
 have -a ≤ -0, by rwa int.neg_zero,
-le_of_neg_le_neg this
+int.le_of_neg_le_neg this
 
-lemma neg_nonpos_of_nonneg {a : ℤ} (h : 0 ≤ a) : -a ≤ 0 :=
-have -a ≤ -0, from neg_le_neg h,
+protected lemma neg_nonpos_of_nonneg {a : ℤ} (h : 0 ≤ a) : -a ≤ 0 :=
+have -a ≤ -0, from int.neg_le_neg h,
 by rwa int.neg_zero at this
 
-lemma nonpos_of_neg_nonneg {a : ℤ} (h : 0 ≤ -a) : a ≤ 0 :=
+protected lemma nonpos_of_neg_nonneg {a : ℤ} (h : 0 ≤ -a) : a ≤ 0 :=
 have -0 ≤ -a, by rwa int.neg_zero,
-le_of_neg_le_neg this
+int.le_of_neg_le_neg this
 
-lemma neg_nonneg_of_nonpos {a : ℤ} (h : a ≤ 0) : 0 ≤ -a :=
-have -0 ≤ -a, from neg_le_neg h,
+protected lemma neg_nonneg_of_nonpos {a : ℤ} (h : a ≤ 0) : 0 ≤ -a :=
+have -0 ≤ -a, from int.neg_le_neg h,
 by rwa int.neg_zero at this
 
-lemma neg_lt_neg {a b : ℤ} (h : a < b) : -b < -a :=
+protected lemma neg_lt_neg {a b : ℤ} (h : a < b) : -b < -a :=
 have 0 < -a + b, from int.add_left_neg a ▸ int.add_lt_add_left h (-a),
 have 0 + -b < -a + b + -b, from int.add_lt_add_right this (-b),
 by rwa [int.add_neg_cancel_right, int.zero_add] at this
 
-lemma lt_of_neg_lt_neg {a b : ℤ} (h : -b < -a) : a < b :=
-int.neg_neg a ▸ int.neg_neg b ▸ neg_lt_neg h
+protected lemma lt_of_neg_lt_neg {a b : ℤ} (h : -b < -a) : a < b :=
+int.neg_neg a ▸ int.neg_neg b ▸ int.neg_lt_neg h
 
-lemma pos_of_neg_neg {a : ℤ} (h : -a < 0) : 0 < a :=
+protected lemma pos_of_neg_neg {a : ℤ} (h : -a < 0) : 0 < a :=
 have -a < -0, by rwa int.neg_zero,
-lt_of_neg_lt_neg this
+int.lt_of_neg_lt_neg this
 
-lemma neg_neg_of_pos {a : ℤ} (h : 0 < a) : -a < 0 :=
-have -a < -0, from neg_lt_neg h,
+protected lemma neg_neg_of_pos {a : ℤ} (h : 0 < a) : -a < 0 :=
+have -a < -0, from int.neg_lt_neg h,
 by rwa int.neg_zero at this
 
-lemma neg_of_neg_pos {a : ℤ} (h : 0 < -a) : a < 0 :=
+protected lemma neg_of_neg_pos {a : ℤ} (h : 0 < -a) : a < 0 :=
 have -0 < -a, by rwa int.neg_zero,
-lt_of_neg_lt_neg this
+int.lt_of_neg_lt_neg this
 
-lemma neg_pos_of_neg {a : ℤ} (h : a < 0) : 0 < -a :=
-have -0 < -a, from neg_lt_neg h,
+protected lemma neg_pos_of_neg {a : ℤ} (h : a < 0) : 0 < -a :=
+have -0 < -a, from int.neg_lt_neg h,
 by rwa int.neg_zero at this
 
-lemma le_neg_of_le_neg {a b : ℤ} (h : a ≤ -b) : b ≤ -a :=
+protected lemma le_neg_of_le_neg {a b : ℤ} (h : a ≤ -b) : b ≤ -a :=
 begin
-  have h := neg_le_neg h,
+  have h := int.neg_le_neg h,
   rwa int.neg_neg at h
 end
 
-lemma neg_le_of_neg_le {a b : ℤ} (h : -a ≤ b) : -b ≤ a :=
+protected lemma neg_le_of_neg_le {a b : ℤ} (h : -a ≤ b) : -b ≤ a :=
 begin
-  have h := neg_le_neg h,
+  have h := int.neg_le_neg h,
   rwa int.neg_neg at h
 end
 
-lemma lt_neg_of_lt_neg {a b : ℤ} (h : a < -b) : b < -a :=
+protected lemma lt_neg_of_lt_neg {a b : ℤ} (h : a < -b) : b < -a :=
 begin
-  have h := neg_lt_neg h,
+  have h := int.neg_lt_neg h,
   rwa int.neg_neg at h
 end
 
-lemma neg_lt_of_neg_lt {a b : ℤ} (h : -a < b) : -b < a :=
+protected lemma neg_lt_of_neg_lt {a b : ℤ} (h : -a < b) : -b < a :=
 begin
-  have h := neg_lt_neg h,
+  have h := int.neg_lt_neg h,
   rwa int.neg_neg at h
 end
 
-lemma sub_nonneg_of_le {a b : ℤ} (h : b ≤ a) : 0 ≤ a - b :=
+protected lemma sub_nonneg_of_le {a b : ℤ} (h : b ≤ a) : 0 ≤ a - b :=
 begin
   have h := int.add_le_add_right h (-b),
   rwa int.add_right_neg at h
 end
 
-lemma le_of_sub_nonneg {a b : ℤ} (h : 0 ≤ a - b) : b ≤ a :=
+protected lemma le_of_sub_nonneg {a b : ℤ} (h : 0 ≤ a - b) : b ≤ a :=
 begin
   have h := int.add_le_add_right h b,
   rwa [int.sub_add_cancel, int.zero_add] at h
 end
 
-lemma sub_nonpos_of_le {a b : ℤ} (h : a ≤ b) : a - b ≤ 0 :=
+protected lemma sub_nonpos_of_le {a b : ℤ} (h : a ≤ b) : a - b ≤ 0 :=
 begin
   have h := int.add_le_add_right h (-b),
   rwa int.add_right_neg at h
 end
 
-lemma le_of_sub_nonpos {a b : ℤ} (h : a - b ≤ 0) : a ≤ b :=
+protected lemma le_of_sub_nonpos {a b : ℤ} (h : a - b ≤ 0) : a ≤ b :=
 begin
   have h := int.add_le_add_right h b,
   rwa [int.sub_add_cancel, int.zero_add] at h
 end
 
-lemma sub_pos_of_lt {a b : ℤ} (h : b < a) : 0 < a - b :=
+protected lemma sub_pos_of_lt {a b : ℤ} (h : b < a) : 0 < a - b :=
 begin
   have h := int.add_lt_add_right h (-b),
   rwa int.add_right_neg at h
 end
 
-lemma lt_of_sub_pos {a b : ℤ} (h : 0 < a - b) : b < a :=
+protected lemma lt_of_sub_pos {a b : ℤ} (h : 0 < a - b) : b < a :=
 begin
   have h := int.add_lt_add_right h b,
   rwa [int.sub_add_cancel, int.zero_add] at h
 end
 
-lemma sub_neg_of_lt {a b : ℤ} (h : a < b) : a - b < 0 :=
+protected lemma sub_neg_of_lt {a b : ℤ} (h : a < b) : a - b < 0 :=
 begin
   have h := int.add_lt_add_right h (-b),
   rwa int.add_right_neg at h
 end
 
-lemma lt_of_sub_neg {a b : ℤ} (h : a - b < 0) : a < b :=
+protected lemma lt_of_sub_neg {a b : ℤ} (h : a - b < 0) : a < b :=
 begin
   have h := int.add_lt_add_right h b,
   rwa [int.sub_add_cancel, int.zero_add] at h
 end
 
-lemma add_le_of_le_neg_add {a b c : ℤ} (h : b ≤ -a + c) : a + b ≤ c :=
+protected lemma add_le_of_le_neg_add {a b c : ℤ} (h : b ≤ -a + c) : a + b ≤ c :=
 begin
   have h := int.add_le_add_left h a,
   rwa int.add_neg_cancel_left at h
 end
 
-lemma le_neg_add_of_add_le {a b c : ℤ} (h : a + b ≤ c) : b ≤ -a + c :=
+protected lemma le_neg_add_of_add_le {a b c : ℤ} (h : a + b ≤ c) : b ≤ -a + c :=
 begin
   have h := int.add_le_add_left h (-a),
   rwa int.neg_add_cancel_left at h
 end
 
-lemma add_le_of_le_sub_left {a b c : ℤ} (h : b ≤ c - a) : a + b ≤ c :=
+protected lemma add_le_of_le_sub_left {a b c : ℤ} (h : b ≤ c - a) : a + b ≤ c :=
 begin
   have h := int.add_le_add_left h a,
   rwa [← int.add_sub_assoc, int.add_comm a c, int.add_sub_cancel] at h
 end
 
-lemma le_sub_left_of_add_le {a b c : ℤ} (h : a + b ≤ c) : b ≤ c - a :=
+protected lemma le_sub_left_of_add_le {a b c : ℤ} (h : a + b ≤ c) : b ≤ c - a :=
 begin
   have h := int.add_le_add_right h (-a),
   rwa [int.add_comm a b, int.add_neg_cancel_right] at h
 end
 
-lemma add_le_of_le_sub_right {a b c : ℤ} (h : a ≤ c - b) : a + b ≤ c :=
+protected lemma add_le_of_le_sub_right {a b c : ℤ} (h : a ≤ c - b) : a + b ≤ c :=
 begin
   have h := int.add_le_add_right h b,
-  rwa sub_add_cancel at h
+  rwa int.sub_add_cancel at h
 end
 
-lemma le_sub_right_of_add_le {a b c : ℤ} (h : a + b ≤ c) : a ≤ c - b :=
+protected lemma le_sub_right_of_add_le {a b c : ℤ} (h : a + b ≤ c) : a ≤ c - b :=
 begin
   have h := int.add_le_add_right h (-b),
   rwa int.add_neg_cancel_right at h
 end
 
-lemma le_add_of_neg_add_le {a b c : ℤ} (h : -b + a ≤ c) : a ≤ b + c :=
+protected lemma le_add_of_neg_add_le {a b c : ℤ} (h : -b + a ≤ c) : a ≤ b + c :=
 begin
   have h := int.add_le_add_left h b,
   rwa int.add_neg_cancel_left at h
 end
 
-lemma neg_add_le_of_le_add {a b c : ℤ} (h : a ≤ b + c) : -b + a ≤ c :=
+protected lemma neg_add_le_of_le_add {a b c : ℤ} (h : a ≤ b + c) : -b + a ≤ c :=
 begin
   have h := int.add_le_add_left h (-b),
   rwa int.neg_add_cancel_left at h
 end
 
-lemma le_add_of_sub_left_le {a b c : ℤ} (h : a - b ≤ c) : a ≤ b + c :=
+protected lemma le_add_of_sub_left_le {a b c : ℤ} (h : a - b ≤ c) : a ≤ b + c :=
 begin
   have h := int.add_le_add_right h b,
-  rwa [sub_add_cancel, int.add_comm] at h
+  rwa [int.sub_add_cancel, int.add_comm] at h
 end
 
-lemma sub_left_le_of_le_add {a b c : ℤ} (h : a ≤ b + c) : a - b ≤ c :=
+protected lemma sub_left_le_of_le_add {a b c : ℤ} (h : a ≤ b + c) : a - b ≤ c :=
 begin
   have h := int.add_le_add_right h (-b),
   rwa [int.add_comm b c, int.add_neg_cancel_right] at h
 end
 
-lemma le_add_of_sub_right_le {a b c : ℤ} (h : a - c ≤ b) : a ≤ b + c :=
+protected lemma le_add_of_sub_right_le {a b c : ℤ} (h : a - c ≤ b) : a ≤ b + c :=
 begin
   have h := int.add_le_add_right h c,
-  rwa sub_add_cancel at h
+  rwa int.sub_add_cancel at h
 end
 
-lemma sub_right_le_of_le_add {a b c : ℤ} (h : a ≤ b + c) : a - c ≤ b :=
+protected lemma sub_right_le_of_le_add {a b c : ℤ} (h : a ≤ b + c) : a - c ≤ b :=
 begin
   have h := int.add_le_add_right h (-c),
   rwa int.add_neg_cancel_right at h
 end
 
-lemma le_add_of_neg_add_le_left {a b c : ℤ} (h : -b + a ≤ c) : a ≤ b + c :=
+protected lemma le_add_of_neg_add_le_left {a b c : ℤ} (h : -b + a ≤ c) : a ≤ b + c :=
 begin
   rw int.add_comm at h,
-  exact le_add_of_sub_left_le h
+  exact int.le_add_of_sub_left_le h
 end
 
-lemma neg_add_le_left_of_le_add {a b c : ℤ} (h : a ≤ b + c) : -b + a ≤ c :=
+protected lemma neg_add_le_left_of_le_add {a b c : ℤ} (h : a ≤ b + c) : -b + a ≤ c :=
 begin
   rw int.add_comm,
-  exact sub_left_le_of_le_add h
+  exact int.sub_left_le_of_le_add h
 end
 
-lemma le_add_of_neg_add_le_right {a b c : ℤ} (h : -c + a ≤ b) : a ≤ b + c :=
+protected lemma le_add_of_neg_add_le_right {a b c : ℤ} (h : -c + a ≤ b) : a ≤ b + c :=
 begin
   rw int.add_comm at h,
-  exact le_add_of_sub_right_le h
+  exact int.le_add_of_sub_right_le h
 end
 
-lemma neg_add_le_right_of_le_add {a b c : ℤ} (h : a ≤ b + c) : -c + a ≤ b :=
+protected lemma neg_add_le_right_of_le_add {a b c : ℤ} (h : a ≤ b + c) : -c + a ≤ b :=
 begin
   rw int.add_comm at h,
-  apply neg_add_le_left_of_le_add h
+  exact int.neg_add_le_left_of_le_add h
 end
 
-lemma le_add_of_neg_le_sub_left {a b c : ℤ} (h : -a ≤ b - c) : c ≤ a + b :=
-le_add_of_neg_add_le_left (add_le_of_le_sub_right h)
+protected lemma le_add_of_neg_le_sub_left {a b c : ℤ} (h : -a ≤ b - c) : c ≤ a + b :=
+int.le_add_of_neg_add_le_left (int.add_le_of_le_sub_right h)
 
-lemma neg_le_sub_left_of_le_add {a b c : ℤ} (h : c ≤ a + b) : -a ≤ b - c :=
+protected lemma neg_le_sub_left_of_le_add {a b c : ℤ} (h : c ≤ a + b) : -a ≤ b - c :=
 begin
-  have h := le_neg_add_of_add_le (sub_left_le_of_le_add h),
+  have h := int.le_neg_add_of_add_le (int.sub_left_le_of_le_add h),
   rwa int.add_comm at h
 end
 
-lemma le_add_of_neg_le_sub_right {a b c : ℤ} (h : -b ≤ a - c) : c ≤ a + b :=
-le_add_of_sub_right_le (add_le_of_le_sub_left h)
+protected lemma le_add_of_neg_le_sub_right {a b c : ℤ} (h : -b ≤ a - c) : c ≤ a + b :=
+int.le_add_of_sub_right_le (int.add_le_of_le_sub_left h)
 
-lemma neg_le_sub_right_of_le_add {a b c : ℤ} (h : c ≤ a + b) : -b ≤ a - c :=
-le_sub_left_of_add_le (sub_right_le_of_le_add h)
+protected lemma neg_le_sub_right_of_le_add {a b c : ℤ} (h : c ≤ a + b) : -b ≤ a - c :=
+int.le_sub_left_of_add_le (int.sub_right_le_of_le_add h)
 
-lemma sub_le_of_sub_le {a b c : ℤ} (h : a - b ≤ c) : a - c ≤ b :=
-sub_left_le_of_le_add (le_add_of_sub_right_le h)
+protected lemma sub_le_of_sub_le {a b c : ℤ} (h : a - b ≤ c) : a - c ≤ b :=
+int.sub_left_le_of_le_add (int.le_add_of_sub_right_le h)
 
-lemma sub_le_sub_left {a b : ℤ} (h : a ≤ b) (c : ℤ) : c - b ≤ c - a :=
-int.add_le_add_left (neg_le_neg h) c
+protected lemma sub_le_sub_left {a b : ℤ} (h : a ≤ b) (c : ℤ) : c - b ≤ c - a :=
+int.add_le_add_left (int.neg_le_neg h) c
 
-lemma sub_le_sub_right {a b : ℤ} (h : a ≤ b) (c : ℤ) : a - c ≤ b - c :=
+protected lemma sub_le_sub_right {a b : ℤ} (h : a ≤ b) (c : ℤ) : a - c ≤ b - c :=
 int.add_le_add_right h (-c)
 
-lemma sub_le_sub {a b c d : ℤ} (hab : a ≤ b) (hcd : c ≤ d) : a - d ≤ b - c :=
-int.add_le_add hab (neg_le_neg hcd)
+protected lemma sub_le_sub {a b c d : ℤ} (hab : a ≤ b) (hcd : c ≤ d) : a - d ≤ b - c :=
+int.add_le_add hab (int.neg_le_neg hcd)
 
-lemma add_lt_of_lt_neg_add {a b c : ℤ} (h : b < -a + c) : a + b < c :=
+protected lemma add_lt_of_lt_neg_add {a b c : ℤ} (h : b < -a + c) : a + b < c :=
 begin
   have h := int.add_lt_add_left h a,
   rwa int.add_neg_cancel_left at h
 end
 
-lemma lt_neg_add_of_add_lt {a b c : ℤ} (h : a + b < c) : b < -a + c :=
+protected lemma lt_neg_add_of_add_lt {a b c : ℤ} (h : a + b < c) : b < -a + c :=
 begin
   have h := int.add_lt_add_left h (-a),
   rwa int.neg_add_cancel_left at h
 end
 
-lemma add_lt_of_lt_sub_left {a b c : ℤ} (h : b < c - a) : a + b < c :=
+protected lemma add_lt_of_lt_sub_left {a b c : ℤ} (h : b < c - a) : a + b < c :=
 begin
   have h := int.add_lt_add_left h a,
-  rwa [← add_sub_assoc, int.add_comm a c, add_sub_cancel] at h
+  rwa [← int.add_sub_assoc, int.add_comm a c, int.add_sub_cancel] at h
 end
 
-lemma lt_sub_left_of_add_lt {a b c : ℤ} (h : a + b < c) : b < c - a :=
+protected lemma lt_sub_left_of_add_lt {a b c : ℤ} (h : a + b < c) : b < c - a :=
 begin
   have h := int.add_lt_add_right h (-a),
   rwa [int.add_comm a b, int.add_neg_cancel_right] at h
 end
 
-lemma add_lt_of_lt_sub_right {a b c : ℤ} (h : a < c - b) : a + b < c :=
+protected lemma add_lt_of_lt_sub_right {a b c : ℤ} (h : a < c - b) : a + b < c :=
 begin
   have h := int.add_lt_add_right h b,
-  rwa sub_add_cancel at h
+  rwa int.sub_add_cancel at h
 end
 
-lemma lt_sub_right_of_add_lt {a b c : ℤ} (h : a + b < c) : a < c - b :=
+protected lemma lt_sub_right_of_add_lt {a b c : ℤ} (h : a + b < c) : a < c - b :=
 begin
   have h := int.add_lt_add_right h (-b),
   rwa int.add_neg_cancel_right at h
 end
 
-lemma lt_add_of_neg_add_lt {a b c : ℤ} (h : -b + a < c) : a < b + c :=
+protected lemma lt_add_of_neg_add_lt {a b c : ℤ} (h : -b + a < c) : a < b + c :=
 begin
   have h := int.add_lt_add_left h b,
   rwa int.add_neg_cancel_left at h
 end
 
-lemma neg_add_lt_of_lt_add {a b c : ℤ} (h : a < b + c) : -b + a < c :=
+protected lemma neg_add_lt_of_lt_add {a b c : ℤ} (h : a < b + c) : -b + a < c :=
 begin
   have h := int.add_lt_add_left h (-b),
   rwa int.neg_add_cancel_left at h
 end
 
-lemma lt_add_of_sub_left_lt {a b c : ℤ} (h : a - b < c) : a < b + c :=
+protected lemma lt_add_of_sub_left_lt {a b c : ℤ} (h : a - b < c) : a < b + c :=
 begin
   have h := int.add_lt_add_right h b,
-  rwa [sub_add_cancel, int.add_comm] at h
+  rwa [int.sub_add_cancel, int.add_comm] at h
 end
 
-lemma sub_left_lt_of_lt_add {a b c : ℤ} (h : a < b + c) : a - b < c :=
+protected lemma sub_left_lt_of_lt_add {a b c : ℤ} (h : a < b + c) : a - b < c :=
 begin
   have h := int.add_lt_add_right h (-b),
   rwa [int.add_comm b c, int.add_neg_cancel_right] at h
 end
 
-lemma lt_add_of_sub_right_lt {a b c : ℤ} (h : a - c < b) : a < b + c :=
+protected lemma lt_add_of_sub_right_lt {a b c : ℤ} (h : a - c < b) : a < b + c :=
 begin
   have h := int.add_lt_add_right h c,
-  rwa sub_add_cancel at h
+  rwa int.sub_add_cancel at h
 end
 
-lemma sub_right_lt_of_lt_add {a b c : ℤ} (h : a < b + c) : a - c < b :=
+protected lemma sub_right_lt_of_lt_add {a b c : ℤ} (h : a < b + c) : a - c < b :=
 begin
   have h := int.add_lt_add_right h (-c),
   rwa int.add_neg_cancel_right at h
 end
 
-lemma lt_add_of_neg_add_lt_left {a b c : ℤ} (h : -b + a < c) : a < b + c :=
+protected lemma lt_add_of_neg_add_lt_left {a b c : ℤ} (h : -b + a < c) : a < b + c :=
 begin
   rw int.add_comm at h,
-  exact lt_add_of_sub_left_lt h
+  exact int.lt_add_of_sub_left_lt h
 end
 
-lemma neg_add_lt_left_of_lt_add {a b c : ℤ} (h : a < b + c) : -b + a < c :=
+protected lemma neg_add_lt_left_of_lt_add {a b c : ℤ} (h : a < b + c) : -b + a < c :=
 begin
   rw int.add_comm,
-  exact sub_left_lt_of_lt_add h
+  exact int.sub_left_lt_of_lt_add h
 end
 
-lemma lt_add_of_neg_add_lt_right {a b c : ℤ} (h : -c + a < b) : a < b + c :=
+protected lemma lt_add_of_neg_add_lt_right {a b c : ℤ} (h : -c + a < b) : a < b + c :=
 begin
   rw int.add_comm at h,
-  exact lt_add_of_sub_right_lt h
+  exact int.lt_add_of_sub_right_lt h
 end
 
-lemma neg_add_lt_right_of_lt_add {a b c : ℤ} (h : a < b + c) : -c + a < b :=
+protected lemma neg_add_lt_right_of_lt_add {a b c : ℤ} (h : a < b + c) : -c + a < b :=
 begin
   rw int.add_comm at h,
-  apply neg_add_lt_left_of_lt_add h
+  exact int.neg_add_lt_left_of_lt_add h
 end
 
-lemma lt_add_of_neg_lt_sub_left {a b c : ℤ} (h : -a < b - c) : c < a + b :=
-lt_add_of_neg_add_lt_left (add_lt_of_lt_sub_right h)
+protected lemma lt_add_of_neg_lt_sub_left {a b c : ℤ} (h : -a < b - c) : c < a + b :=
+int.lt_add_of_neg_add_lt_left (int.add_lt_of_lt_sub_right h)
 
-lemma neg_lt_sub_left_of_lt_add {a b c : ℤ} (h : c < a + b) : -a < b - c :=
+protected lemma neg_lt_sub_left_of_lt_add {a b c : ℤ} (h : c < a + b) : -a < b - c :=
 begin
-  have h := lt_neg_add_of_add_lt (sub_left_lt_of_lt_add h),
+  have h := int.lt_neg_add_of_add_lt (int.sub_left_lt_of_lt_add h),
   rwa int.add_comm at h
 end
 
-lemma lt_add_of_neg_lt_sub_right {a b c : ℤ} (h : -b < a - c) : c < a + b :=
-lt_add_of_sub_right_lt (add_lt_of_lt_sub_left h)
+protected lemma lt_add_of_neg_lt_sub_right {a b c : ℤ} (h : -b < a - c) : c < a + b :=
+int.lt_add_of_sub_right_lt (int.add_lt_of_lt_sub_left h)
 
-lemma neg_lt_sub_right_of_lt_add {a b c : ℤ} (h : c < a + b) : -b < a - c :=
-lt_sub_left_of_add_lt (sub_right_lt_of_lt_add h)
+protected lemma neg_lt_sub_right_of_lt_add {a b c : ℤ} (h : c < a + b) : -b < a - c :=
+int.lt_sub_left_of_add_lt (int.sub_right_lt_of_lt_add h)
 
-lemma sub_lt_of_sub_lt {a b c : ℤ} (h : a - b < c) : a - c < b :=
-sub_left_lt_of_lt_add (lt_add_of_sub_right_lt h)
+protected lemma sub_lt_of_sub_lt {a b c : ℤ} (h : a - b < c) : a - c < b :=
+int.sub_left_lt_of_lt_add (int.lt_add_of_sub_right_lt h)
 
-lemma sub_lt_sub_left {a b : ℤ} (h : a < b) (c : ℤ) : c - b < c - a :=
-int.add_lt_add_left (neg_lt_neg h) c
+protected lemma sub_lt_sub_left {a b : ℤ} (h : a < b) (c : ℤ) : c - b < c - a :=
+int.add_lt_add_left (int.neg_lt_neg h) c
 
-lemma sub_lt_sub_right {a b : ℤ} (h : a < b) (c : ℤ) : a - c < b - c :=
+protected lemma sub_lt_sub_right {a b : ℤ} (h : a < b) (c : ℤ) : a - c < b - c :=
 int.add_lt_add_right h (-c)
 
-lemma sub_lt_sub {a b c d : ℤ} (hab : a < b) (hcd : c < d) : a - d < b - c :=
-int.add_lt_add hab (neg_lt_neg hcd)
+protected lemma sub_lt_sub {a b c d : ℤ} (hab : a < b) (hcd : c < d) : a - d < b - c :=
+int.add_lt_add hab (int.neg_lt_neg hcd)
 
-lemma sub_lt_sub_of_le_of_lt {a b c d : ℤ} (hab : a ≤ b) (hcd : c < d) : a - d < b - c :=
-int.add_lt_add_of_le_of_lt hab (neg_lt_neg hcd)
+protected lemma sub_lt_sub_of_le_of_lt {a b c d : ℤ} (hab : a ≤ b) (hcd : c < d) : a - d < b - c :=
+int.add_lt_add_of_le_of_lt hab (int.neg_lt_neg hcd)
 
-lemma sub_lt_sub_of_lt_of_le {a b c d : ℤ} (hab : a < b) (hcd : c ≤ d) : a - d < b - c :=
-int.add_lt_add_of_lt_of_le hab (neg_le_neg hcd)
+protected lemma sub_lt_sub_of_lt_of_le {a b c d : ℤ} (hab : a < b) (hcd : c ≤ d) : a - d < b - c :=
+int.add_lt_add_of_lt_of_le hab (int.neg_le_neg hcd)
 
-lemma sub_le_self (a : ℤ) {b : ℤ} (h : b ≥ 0) : a - b ≤ a :=
+protected lemma sub_le_self (a : ℤ) {b : ℤ} (h : b ≥ 0) : a - b ≤ a :=
 calc
   a - b = a + -b : rfl
-    ... ≤ a + 0  : int.add_le_add_left (neg_nonpos_of_nonneg h) _
+    ... ≤ a + 0  : int.add_le_add_left (int.neg_nonpos_of_nonneg h) _
     ... = a      : by rw int.add_zero
 
-lemma sub_lt_self (a : ℤ) {b : ℤ} (h : b > 0) : a - b < a :=
+protected lemma sub_lt_self (a : ℤ) {b : ℤ} (h : b > 0) : a - b < a :=
 calc
   a - b = a + -b : rfl
-    ... < a + 0  : int.add_lt_add_left (neg_neg_of_pos h) _
+    ... < a + 0  : int.add_lt_add_left (int.neg_neg_of_pos h) _
     ... = a      : by rw int.add_zero
 
-lemma add_le_add_three {a b c d e f : ℤ} (h₁ : a ≤ d) (h₂ : b ≤ e) (h₃ : c ≤ f) :
+protected lemma add_le_add_three {a b c d e f : ℤ} (h₁ : a ≤ d) (h₂ : b ≤ e) (h₃ : c ≤ f) :
       a + b + c ≤ d + e + f :=
 begin
   apply le_trans,
@@ -774,102 +770,104 @@ end
 
 /- missing facts -/
 
-lemma mul_lt_mul_of_pos_left {a b c : ℤ}
+protected lemma mul_lt_mul_of_pos_left {a b c : ℤ}
        (h₁ : a < b) (h₂ : 0 < c) : c * a < c * b :=
-have 0 < b - a,       from sub_pos_of_lt h₁,
+have 0 < b - a,       from int.sub_pos_of_lt h₁,
 have 0 < c * (b - a), from int.mul_pos h₂ this,
 begin
-  rw int.mul_sub_left_distrib at this,
-  apply lt_of_sub_pos this
+  rw int.mul_sub at this,
+  exact int.lt_of_sub_pos this
 end
 
-lemma mul_lt_mul_of_pos_right {a b c : ℤ}
+protected lemma mul_lt_mul_of_pos_right {a b c : ℤ}
       (h₁ : a < b) (h₂ : 0 < c) : a * c < b * c :=
-have 0 < b - a,       from sub_pos_of_lt h₁,
+have 0 < b - a,       from int.sub_pos_of_lt h₁,
 have 0 < (b - a) * c, from int.mul_pos this h₂,
 begin
-  rw mul_sub_right_distrib at this,
-  apply lt_of_sub_pos this
+  rw int.sub_mul at this,
+  exact int.lt_of_sub_pos this
 end
 
-lemma mul_le_mul_of_nonneg_left {a b c : ℤ} (h₁ : a ≤ b) (h₂ : 0 ≤ c) : c * a ≤ c * b :=
+protected lemma mul_le_mul_of_nonneg_left {a b c : ℤ} (h₁ : a ≤ b) (h₂ : 0 ≤ c) : c * a ≤ c * b :=
 begin
   by_cases hba : b ≤ a, { simp [le_antisymm hba h₁] },
   by_cases hc0 : c ≤ 0, { simp [le_antisymm hc0 h₂, int.zero_mul] },
-  exact (le_not_le_of_lt (mul_lt_mul_of_pos_left (lt_of_le_not_le h₁ hba) (lt_of_le_not_le h₂ hc0))).left,
+  exact (le_not_le_of_lt (int.mul_lt_mul_of_pos_left
+    (lt_of_le_not_le h₁ hba) (lt_of_le_not_le h₂ hc0))).left,
 end
 
-lemma mul_le_mul_of_nonneg_right {a b c : ℤ} (h₁ : a ≤ b) (h₂ : 0 ≤ c) : a * c ≤ b * c :=
+protected lemma mul_le_mul_of_nonneg_right {a b c : ℤ} (h₁ : a ≤ b) (h₂ : 0 ≤ c) : a * c ≤ b * c :=
 begin
   by_cases hba : b ≤ a, { simp [le_antisymm hba h₁] },
   by_cases hc0 : c ≤ 0, { simp [le_antisymm hc0 h₂, int.mul_zero] },
-  exact (le_not_le_of_lt (mul_lt_mul_of_pos_right (lt_of_le_not_le h₁ hba) (lt_of_le_not_le h₂ hc0))).left,
+  exact (le_not_le_of_lt (int.mul_lt_mul_of_pos_right (lt_of_le_not_le h₁ hba) (lt_of_le_not_le h₂ hc0))).left,
 end
 
 -- TODO: there are four variations, depending on which variables we assume to be nonneg
-lemma mul_le_mul {a b c d : ℤ} (hac : a ≤ c) (hbd : b ≤ d) (nn_b : 0 ≤ b) (nn_c : 0 ≤ c) : a * b ≤ c * d :=
+protected lemma mul_le_mul {a b c d : ℤ} (hac : a ≤ c) (hbd : b ≤ d) (nn_b : 0 ≤ b) (nn_c : 0 ≤ c) :
+  a * b ≤ c * d :=
 calc
-  a * b ≤ c * b : mul_le_mul_of_nonneg_right hac nn_b
-    ... ≤ c * d : mul_le_mul_of_nonneg_left hbd nn_c
+  a * b ≤ c * b : int.mul_le_mul_of_nonneg_right hac nn_b
+    ... ≤ c * d : int.mul_le_mul_of_nonneg_left hbd nn_c
 
-lemma mul_nonpos_of_nonneg_of_nonpos {a b : ℤ} (ha : a ≥ 0) (hb : b ≤ 0) : a * b ≤ 0 :=
-have h : a * b ≤ a * 0, from mul_le_mul_of_nonneg_left hb ha,
+protected lemma mul_nonpos_of_nonneg_of_nonpos {a b : ℤ} (ha : a ≥ 0) (hb : b ≤ 0) : a * b ≤ 0 :=
+have h : a * b ≤ a * 0, from int.mul_le_mul_of_nonneg_left hb ha,
 by rwa int.mul_zero at h
 
-lemma mul_nonpos_of_nonpos_of_nonneg {a b : ℤ} (ha : a ≤ 0) (hb : b ≥ 0) : a * b ≤ 0 :=
-have h : a * b ≤ 0 * b, from mul_le_mul_of_nonneg_right ha hb,
+protected lemma mul_nonpos_of_nonpos_of_nonneg {a b : ℤ} (ha : a ≤ 0) (hb : b ≥ 0) : a * b ≤ 0 :=
+have h : a * b ≤ 0 * b, from int.mul_le_mul_of_nonneg_right ha hb,
 by rwa int.zero_mul at h
 
-lemma mul_lt_mul {a b c d : ℤ} (hac : a < c) (hbd : b ≤ d) (pos_b : 0 < b) (nn_c : 0 ≤ c) :  a * b < c * d :=
+protected lemma mul_lt_mul {a b c d : ℤ} (hac : a < c) (hbd : b ≤ d) (pos_b : 0 < b) (nn_c : 0 ≤ c) :  a * b < c * d :=
 calc
-  a * b < c * b : mul_lt_mul_of_pos_right hac pos_b
-    ... ≤ c * d : mul_le_mul_of_nonneg_left hbd nn_c
+  a * b < c * b : int.mul_lt_mul_of_pos_right hac pos_b
+    ... ≤ c * d : int.mul_le_mul_of_nonneg_left hbd nn_c
 
-lemma mul_lt_mul' {a b c d : ℤ} (h1 : a ≤ c) (h2 : b < d) (h3 : b ≥ 0) (h4 : c > 0) :
+protected lemma mul_lt_mul' {a b c d : ℤ} (h1 : a ≤ c) (h2 : b < d) (h3 : b ≥ 0) (h4 : c > 0) :
        a * b < c * d :=
 calc
-   a * b ≤ c * b : mul_le_mul_of_nonneg_right h1 h3
-     ... < c * d : mul_lt_mul_of_pos_left h2 h4
+   a * b ≤ c * b : int.mul_le_mul_of_nonneg_right h1 h3
+     ... < c * d : int.mul_lt_mul_of_pos_left h2 h4
 
-lemma mul_neg_of_pos_of_neg {a b : ℤ} (ha : a > 0) (hb : b < 0) : a * b < 0 :=
-have h : a * b < a * 0, from mul_lt_mul_of_pos_left hb ha,
+protected lemma mul_neg_of_pos_of_neg {a b : ℤ} (ha : a > 0) (hb : b < 0) : a * b < 0 :=
+have h : a * b < a * 0, from int.mul_lt_mul_of_pos_left hb ha,
 by rwa int.mul_zero at h
 
-lemma mul_neg_of_neg_of_pos {a b : ℤ} (ha : a < 0) (hb : b > 0) : a * b < 0 :=
-have h : a * b < 0 * b, from mul_lt_mul_of_pos_right ha hb,
+protected lemma mul_neg_of_neg_of_pos {a b : ℤ} (ha : a < 0) (hb : b > 0) : a * b < 0 :=
+have h : a * b < 0 * b, from int.mul_lt_mul_of_pos_right ha hb,
 by rwa int.zero_mul at  h
 
-lemma mul_le_mul_of_nonpos_right {a b c : ℤ} (h : b ≤ a) (hc : c ≤ 0) : a * c ≤ b * c :=
-have -c ≥ 0,              from neg_nonneg_of_nonpos hc,
-have b * -c ≤ a * -c,     from mul_le_mul_of_nonneg_right h this,
-have -(b * c) ≤ -(a * c), by rwa [← neg_mul_eq_mul_neg, ← neg_mul_eq_mul_neg] at this,
-le_of_neg_le_neg this
+protected lemma mul_le_mul_of_nonpos_right {a b c : ℤ} (h : b ≤ a) (hc : c ≤ 0) : a * c ≤ b * c :=
+have -c ≥ 0,              from int.neg_nonneg_of_nonpos hc,
+have b * -c ≤ a * -c,     from int.mul_le_mul_of_nonneg_right h this,
+have -(b * c) ≤ -(a * c), by rwa [← int.neg_mul_eq_mul_neg, ← int.neg_mul_eq_mul_neg] at this,
+int.le_of_neg_le_neg this
 
-lemma mul_nonneg_of_nonpos_of_nonpos {a b : ℤ} (ha : a ≤ 0) (hb : b ≤ 0) : 0 ≤ a * b :=
-have 0 * b ≤ a * b, from mul_le_mul_of_nonpos_right ha hb,
+protected lemma mul_nonneg_of_nonpos_of_nonpos {a b : ℤ} (ha : a ≤ 0) (hb : b ≤ 0) : 0 ≤ a * b :=
+have 0 * b ≤ a * b, from int.mul_le_mul_of_nonpos_right ha hb,
 by rwa int.zero_mul at this
 
-lemma mul_lt_mul_of_neg_left {a b c : ℤ} (h : b < a) (hc : c < 0) : c * a < c * b :=
-have -c > 0,              from neg_pos_of_neg hc,
-have -c * b < -c * a,     from mul_lt_mul_of_pos_left h this,
-have -(c * b) < -(c * a), by rwa [← neg_mul_eq_neg_mul, ← neg_mul_eq_neg_mul] at this,
-lt_of_neg_lt_neg this
+protected lemma mul_lt_mul_of_neg_left {a b c : ℤ} (h : b < a) (hc : c < 0) : c * a < c * b :=
+have -c > 0,              from int.neg_pos_of_neg hc,
+have -c * b < -c * a,     from int.mul_lt_mul_of_pos_left h this,
+have -(c * b) < -(c * a), by rwa [← int.neg_mul_eq_neg_mul, ← int.neg_mul_eq_neg_mul] at this,
+int.lt_of_neg_lt_neg this
 
-lemma mul_lt_mul_of_neg_right {a b c : ℤ} (h : b < a) (hc : c < 0) : a * c < b * c :=
-have -c > 0,              from neg_pos_of_neg hc,
-have b * -c < a * -c,     from mul_lt_mul_of_pos_right h this,
-have -(b * c) < -(a * c), by rwa [← neg_mul_eq_mul_neg, ← neg_mul_eq_mul_neg] at this,
-lt_of_neg_lt_neg this
+protected lemma mul_lt_mul_of_neg_right {a b c : ℤ} (h : b < a) (hc : c < 0) : a * c < b * c :=
+have -c > 0,              from int.neg_pos_of_neg hc,
+have b * -c < a * -c,     from int.mul_lt_mul_of_pos_right h this,
+have -(b * c) < -(a * c), by rwa [← int.neg_mul_eq_mul_neg, ← int.neg_mul_eq_mul_neg] at this,
+int.lt_of_neg_lt_neg this
 
-lemma mul_pos_of_neg_of_neg {a b : ℤ} (ha : a < 0) (hb : b < 0) : 0 < a * b :=
-have 0 * b < a * b, from mul_lt_mul_of_neg_right ha hb,
+protected lemma mul_pos_of_neg_of_neg {a b : ℤ} (ha : a < 0) (hb : b < 0) : 0 < a * b :=
+have 0 * b < a * b, from int.mul_lt_mul_of_neg_right ha hb,
 by rwa int.zero_mul at this
 
-lemma mul_self_le_mul_self {a b : ℤ} (h1 : 0 ≤ a) (h2 : a ≤ b) : a * a ≤ b * b :=
-mul_le_mul h2 h2 h1 (le_trans h1 h2)
+protected lemma mul_self_le_mul_self {a b : ℤ} (h1 : 0 ≤ a) (h2 : a ≤ b) : a * a ≤ b * b :=
+int.mul_le_mul h2 h2 h1 (le_trans h1 h2)
 
-lemma mul_self_lt_mul_self {a b : ℤ} (h1 : 0 ≤ a) (h2 : a < b) : a * a < b * b :=
-mul_lt_mul' (le_of_lt h2) h2 h1 (lt_of_le_of_lt h1 h2)
+protected lemma mul_self_lt_mul_self {a b : ℤ} (h1 : 0 ≤ a) (h2 : a < b) : a * a < b * b :=
+int.mul_lt_mul' (le_of_lt h2) h2 h1 (lt_of_le_of_lt h1 h2)
 
 /- more facts specific to int -/
 
@@ -899,13 +897,13 @@ theorem le_of_lt_add_one {a b : ℤ} (H : a < b + 1) : a ≤ b :=
 int.le_of_add_le_add_right H
 
 theorem sub_one_le_of_lt {a b : ℤ} (H : a ≤ b) : a - 1 < b :=
-sub_right_lt_of_lt_add $ lt_add_one_of_le H
+int.sub_right_lt_of_lt_add $ lt_add_one_of_le H
 
 theorem lt_of_sub_one_le {a b : ℤ} (H : a - 1 < b) : a ≤ b :=
-le_of_lt_add_one $ lt_add_of_sub_right_lt H
+le_of_lt_add_one $ int.lt_add_of_sub_right_lt H
 
 theorem le_sub_one_of_lt {a b : ℤ} (H : a < b) : a ≤ b - 1 :=
-le_sub_right_of_add_le H
+int.le_sub_right_of_add_le H
 
 theorem lt_of_le_sub_one {a b : ℤ} (H : a ≤ b - 1) : a < b :=
 int.add_le_of_le_sub_right H
@@ -938,7 +936,7 @@ theorem sign_eq_neg_one_iff_neg (a : ℤ) : sign a = -1 ↔ a < 0 :=
 theorem sign_eq_zero_iff_zero (a : ℤ) : sign a = 0 ↔ a = 0 :=
 ⟨eq_zero_of_sign_eq_zero, λ h, by rw [h, sign_zero]⟩
 
-lemma eq_zero_or_eq_zero_of_mul_eq_zero
+protected lemma eq_zero_or_eq_zero_of_mul_eq_zero
         {a b : ℤ} (h : a * b = 0) : a = 0 ∨ b = 0 :=
 match lt_trichotomy 0 a with
 | or.inl hlt₁          :=
@@ -948,33 +946,33 @@ match lt_trichotomy 0 a with
     begin rw h at this, exact absurd this (lt_irrefl _) end
   | or.inr (or.inl heq₂) := or.inr heq₂.symm
   | or.inr (or.inr hgt₂) :=
-    have 0 > a * b, from mul_neg_of_pos_of_neg hlt₁ hgt₂,
+    have 0 > a * b, from int.mul_neg_of_pos_of_neg hlt₁ hgt₂,
     begin rw h at this, exact absurd this (lt_irrefl _)  end
   end
 | or.inr (or.inl heq₁) := or.inl heq₁.symm
 | or.inr (or.inr hgt₁) :=
   match lt_trichotomy 0 b with
   | or.inl hlt₂          :=
-    have 0 > a * b, from mul_neg_of_neg_of_pos hgt₁ hlt₂,
+    have 0 > a * b, from int.mul_neg_of_neg_of_pos hgt₁ hlt₂,
     begin rw h at this, exact absurd this (lt_irrefl _)  end
   | or.inr (or.inl heq₂) := or.inr heq₂.symm
   | or.inr (or.inr hgt₂) :=
-    have 0 < a * b, from mul_pos_of_neg_of_neg hgt₁ hgt₂,
+    have 0 < a * b, from int.mul_pos_of_neg_of_neg hgt₁ hgt₂,
     begin rw h at this, exact absurd this (lt_irrefl _)  end
   end
 end
 
-lemma eq_of_mul_eq_mul_right {a b c : ℤ} (ha : a ≠ 0) (h : b * a = c * a) : b = c :=
+protected lemma eq_of_mul_eq_mul_right {a b c : ℤ} (ha : a ≠ 0) (h : b * a = c * a) : b = c :=
 have b * a - c * a = 0, from int.sub_eq_zero_of_eq h,
-have (b - c) * a = 0,   by rw [int.mul_sub_right_distrib, this],
+have (b - c) * a = 0,   by rw [int.sub_mul, this],
 have b - c = 0,         from (int.eq_zero_or_eq_zero_of_mul_eq_zero this).resolve_right ha,
 int.eq_of_sub_eq_zero this
 
-lemma eq_of_mul_eq_mul_left {a b c : ℤ} (ha : a ≠ 0) (h : a * b = a * c) : b = c :=
-have a * b - a * c = 0, from sub_eq_zero_of_eq h,
-have a * (b - c) = 0,   by rw [mul_sub_left_distrib, this],
+protected lemma eq_of_mul_eq_mul_left {a b c : ℤ} (ha : a ≠ 0) (h : a * b = a * c) : b = c :=
+have a * b - a * c = 0, from int.sub_eq_zero_of_eq h,
+have a * (b - c) = 0,   by rw [int.mul_sub, this],
 have b - c = 0,         from (int.eq_zero_or_eq_zero_of_mul_eq_zero this).resolve_left ha,
-eq_of_sub_eq_zero this
+int.eq_of_sub_eq_zero this
 
 theorem eq_one_of_mul_eq_self_left {a b : ℤ} (Hpos : a ≠ 0) (H : b * a = a) : b = 1 :=
 int.eq_of_mul_eq_mul_right Hpos (by rw [int.one_mul, H])

--- a/library/init/data/nat/lemmas.lean
+++ b/library/init/data/nat/lemmas.lean
@@ -1143,7 +1143,7 @@ begin
     { apply (div_lt_iff_lt_mul _ _ npos).2, rwa nat.mul_comm } }
 end
 
-lemma mul_pos {a b : ℕ} (ha : a > 0) (hb : b > 0) : a * b > 0 :=
+protected lemma mul_pos {a b : ℕ} (ha : a > 0) (hb : b > 0) : a * b > 0 :=
 have h : 0 * b < a * b, from nat.mul_lt_mul_of_pos_right ha hb,
 by rwa nat.zero_mul at h
 
@@ -1152,7 +1152,7 @@ begin
   cases eq_zero_or_pos k with k0 kpos, {rw [k0, nat.mul_zero, nat.div_zero, nat.div_zero]},
   cases eq_zero_or_pos n with n0 npos, {rw [n0, nat.zero_mul, nat.div_zero, nat.zero_div]},
   apply le_antisymm,
-  { apply (le_div_iff_mul_le _ _ (mul_pos npos kpos)).2,
+  { apply (le_div_iff_mul_le _ _ (nat.mul_pos npos kpos)).2,
     rw [nat.mul_comm n k, ← nat.mul_assoc],
     apply (le_div_iff_mul_le _ _ npos).1,
     apply (le_div_iff_mul_le _ _ kpos).1,
@@ -1160,7 +1160,7 @@ begin
   { apply (le_div_iff_mul_le _ _ kpos).2,
     apply (le_div_iff_mul_le _ _ npos).2,
     rw [nat.mul_assoc, nat.mul_comm n k],
-    apply (le_div_iff_mul_le _ _ (mul_pos kpos npos)).1,
+    apply (le_div_iff_mul_le _ _ (nat.mul_pos kpos npos)).1,
     refl }
 end
 
@@ -1275,7 +1275,7 @@ calc
      ... < c * d : nat.mul_lt_mul_of_pos_left h2 h4
 
 -- TODO: there are four variations, depending on which variables we assume to be nonneg
-lemma mul_le_mul {a b c d : ℕ} (hac : a ≤ c) (hbd : b ≤ d) (nn_b : 0 ≤ b) (nn_c : 0 ≤ c) : a * b ≤ c * d :=
+protected lemma mul_le_mul {a b c d : ℕ} (hac : a ≤ c) (hbd : b ≤ d) (nn_b : 0 ≤ b) (nn_c : 0 ≤ c) : a * b ≤ c * d :=
 calc
   a * b ≤ c * b : nat.mul_le_mul_of_nonneg_right hac nn_b
     ... ≤ c * d : nat.mul_le_mul_of_nonneg_left hbd nn_c
@@ -1286,13 +1286,13 @@ calc
 
 theorem pow_le_pow_of_le_left {x y : ℕ} (H : x ≤ y) : ∀ i : ℕ, x^i ≤ y^i
 | 0 := le_refl _
-| (succ i) := mul_le_mul (pow_le_pow_of_le_left i) H (zero_le _) (zero_le _)
+| (succ i) := nat.mul_le_mul (pow_le_pow_of_le_left i) H (zero_le _) (zero_le _)
 
 theorem pow_le_pow_of_le_right {x : ℕ} (H : x > 0) {i : ℕ} : ∀ {j}, i ≤ j → x^i ≤ x^j
 | 0        h := by rw eq_zero_of_le_zero h; apply le_refl
 | (succ j) h := (lt_or_eq_of_le h).elim
   (λhl, by rw [pow_succ, ← nat.mul_one (x^i)]; exact
-    mul_le_mul (pow_le_pow_of_le_right $ le_of_lt_succ hl) H (zero_le _) (zero_le _))
+    nat.mul_le_mul (pow_le_pow_of_le_right $ le_of_lt_succ hl) H (zero_le _) (zero_le _))
   (λe, by rw e; refl)
 
 theorem pos_pow_of_pos {b : ℕ} (n : ℕ) (h : 0 < b) : 0 < b^n :=


### PR DESCRIPTION
This PR protects the lemmas listed in https://github.com/leanprover-community/mathlib/pull/2697/commits/85ce04a7eb7705c98500d267d0baa3fc229e02ec since they are superseded in mathlib. They were all added in #229. 

Also, this PR removes:
- `int.mul_sub_left_distrib` in favor of the shorter `int.mul_sub`,
- `int.mul_sub_right_distrib` in favor of the shorter `int.sub_mul`.

Zulip: https://leanprover.zulipchat.com/#narrow/stream/113488-general/topic/preparing.20for.20lean-3.2E13.2E0/near/197817609