### PR TITLE
[Merged by Bors] - lib(expr.address): add expr.coord and expr.address

### DIFF
--- a/library/init/meta/default.lean
+++ b/library/init/meta/default.lean
@@ -18,3 +18,4 @@ import init.meta.async_tactic init.meta.ref
 import init.meta.hole_command init.meta.congr_tactic
 import init.meta.local_context init.meta.type_context
 import init.meta.module_info
+import init.meta.expr_address

--- a/library/init/meta/expr_address.lean
+++ b/library/init/meta/expr_address.lean
@@ -1,0 +1,86 @@
+prelude
+import init.meta.expr
+import init.data.list.basic
+import init.data.option.basic
+
+namespace expr
+
+/-- An enum representing a recursive argument in an `expr` constructor (except the types of variables). -/
+inductive coord : Type
+| app_fn        | app_arg
+| lam_var_type  | lam_body
+| pi_var_type   | pi_body
+| elet_var_type | elet_assignment | elet_body
+
+namespace coord
+
+def code: coord → ℕ
+| coord.app_fn        := 0 | coord.app_arg         := 1
+| coord.lam_var_type  := 2 | coord.lam_body        := 3
+| coord.pi_var_type   := 4 | coord.pi_body         := 5
+| coord.elet_var_type := 6 | coord.elet_assignment := 7 | coord.elet_body := 8
+
+def repr: coord → string
+| coord.app_fn        := "app_fn"        | coord.app_arg  := "app_arg"
+| coord.lam_var_type  := "lam_var_type"  | coord.lam_body := "lam_body"
+| coord.pi_var_type   := "pi_var_type"   | coord.pi_body := "pi_body"
+| coord.elet_var_type := "elet_var_type" | coord.elet_assignment := "elet_assignment" | coord.elet_body := "elet_body"
+
+instance : has_repr coord := ⟨repr⟩
+
+-- [note] we can't use derive because we need to use this before `interactive`.
+meta constant has_decidable_eq : decidable_eq coord
+attribute [instance] expr.coord.has_decidable_eq
+
+instance has_lt : has_lt coord := ⟨λ x y, x.code < y.code⟩
+
+meta def follow : coord → expr → option expr
+| (coord.app_fn)          (expr.app f a)         := some f
+| (coord.app_arg)         (expr.app f a)         := some a
+| (coord.lam_var_type)    (expr.lam  n bi y   b) := some y
+| (coord.lam_body)        (expr.lam  n bi y   b) := some b
+| (coord.pi_var_type)     (expr.pi   n bi y   b) := some y
+| (coord.pi_body)         (expr.pi   n bi y   b) := some b
+| (coord.elet_var_type)   (expr.elet n    y a b) := some y
+| (coord.elet_assignment) (expr.elet n    y a b) := some a
+| (coord.elet_body)       (expr.elet n    y a b) := some b
+| _                       _                      := none
+
+end coord
+
+/-- An address is a list of coordinates used to reference subterms of an expression.
+The topmost coordinate in the list corresponds to the start of the expression. -/
+def address : Type := list coord
+
+namespace address
+
+meta def has_dec_eq : decidable_eq address :=
+@list.has_dec_eq _ expr.coord.has_decidable_eq
+
+protected def to_string : address → string :=
+to_string ∘ list.map coord.repr
+
+instance has_repr : has_repr address := ⟨address.to_string⟩
+instance has_to_string : has_to_string address := ⟨address.to_string⟩
+
+instance has_append : has_append address := ⟨list.append⟩
+
+/-- `as_below x y` is some z when it finds `∃ z, x = y ++ z` -/
+meta def as_below : address → address → option address
+|a [] := some a -- [] ++ a = a
+|[] _ := none   -- (h::t) ++ _ ≠ []
+-- if t₂ ++ z = t₁ then (h₁ :: t₁) ++ z = (h₁ :: t₂)
+|(h₁ :: t₁) (h₂ :: t₂) := if h₁ = h₂ then as_below t₁ t₂ else none
+
+meta def is_below : address → address → bool
+| a₁ a₂ := option.is_some $ as_below a₁ a₂
+
+infixr  ` ≺ `:50 := is_below
+
+meta def follow : address → expr → option expr
+| [] e := e
+| (h::t) e := coord.follow h e >>= follow t
+
+end address
+
+end expr

--- a/library/init/meta/expr_address.lean
+++ b/library/init/meta/expr_address.lean
@@ -27,6 +27,8 @@ def repr: coord → string
 | coord.elet_var_type := "elet_var_type" | coord.elet_assignment := "elet_assignment" | coord.elet_body := "elet_body"
 
 instance : has_repr coord := ⟨repr⟩
+instance : has_to_string coord := ⟨repr⟩
+meta instance : has_to_format coord := ⟨format.of_string ∘ repr⟩
 
 -- [note] we can't use derive because we need to use this before `interactive`.
 meta constant has_decidable_eq : decidable_eq coord
@@ -62,6 +64,7 @@ to_string ∘ list.map coord.repr
 
 instance has_repr : has_repr address := ⟨address.to_string⟩
 instance has_to_string : has_to_string address := ⟨address.to_string⟩
+meta instance has_to_format : has_to_format address := ⟨list.to_format⟩
 
 instance has_append : has_append address := ⟨list.append⟩
 
@@ -74,8 +77,6 @@ meta def as_below : address → address → option address
 
 meta def is_below : address → address → bool
 | a₁ a₂ := option.is_some $ as_below a₁ a₂
-
-infixr  ` ≺ `:50 := is_below
 
 meta def follow : address → expr → option expr
 | [] e := e

--- a/src/library/CMakeLists.txt
+++ b/src/library/CMakeLists.txt
@@ -21,7 +21,8 @@ add_library(library OBJECT deep_copy.cpp expr_lt.cpp io_state.cpp
   messages.cpp message_builder.cpp module_mgr.cpp comp_val.cpp
   documentation.cpp check.cpp parray.cpp process.cpp
   pipe.cpp handle.cpp profiling.cpp time_task.cpp abstract_context_cache.cpp
-  context_cache.cpp unique_id.cpp persistent_context_cache.cpp elab_context.cpp)
+  context_cache.cpp unique_id.cpp persistent_context_cache.cpp elab_context.cpp
+  expr_address.cpp)
 if(EMSCRIPTEN)
 add_dependencies(library gmp)
 endif()

--- a/src/library/expr_address.cpp
+++ b/src/library/expr_address.cpp
@@ -16,7 +16,6 @@ vm_obj to_obj(address c) {
     return to_obj(b);
 }
 
-
 namespace expr_address {
 
 expr_coord to_coord(vm_obj const & c) {
@@ -62,7 +61,7 @@ address pi_body(unsigned n) {
 address binding_type(expr const & e) {
     lean_assert(is_binding(e));
     if (is_pi(e)) {
-      return address(expr_coord::pi_var_type);
+        return address(expr_coord::pi_var_type);
     } else {
         return address(expr_coord::lam_var_type);
     }
@@ -70,7 +69,7 @@ address binding_type(expr const & e) {
 address binding_body(expr const & e) {
     lean_assert(is_binding(e));
     if (is_pi(e)) {
-      return address(expr_coord::pi_body);
+        return address(expr_coord::pi_body);
     } else {
         return address(expr_coord::lam_body);
     }

--- a/src/library/expr_address.cpp
+++ b/src/library/expr_address.cpp
@@ -1,0 +1,100 @@
+/*
+Copyright (c) E.W.Ayers. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+
+Author: E.W.Ayers
+*/
+#include "library/expr_address.h"
+namespace lean {
+
+vm_obj to_obj(expr_coord c) {
+    return mk_vm_simple(unsigned(c));
+}
+vm_obj to_obj(address c) {
+    buffer<vm_obj> b;
+    for_each(c, [&](expr_coord c) { b.push_back(to_obj(c)); });
+    return to_obj(b);
+}
+
+
+namespace expr_address {
+
+expr_coord to_coord(vm_obj const & c) {
+    return static_cast<expr_coord>(cidx(c));
+}
+address to_address(vm_obj const & a) {
+    list<expr_coord> adr = to_list<expr_coord>(a, [](vm_obj const & p) {
+        return to_coord(p);
+    });
+    return adr;
+}
+
+address app(unsigned sz, unsigned i) {
+    address result;
+    if (sz <= i) {return result;}
+    result = cons(expr_coord::app_arg, result);
+    for (unsigned j = 0; j < sz - i - 1; j++) {
+        result = cons(expr_coord::app_fn, result);
+    }
+    return result;
+}
+
+address fn(unsigned sz) {
+    address result;
+    for (unsigned i = 0; i < sz; i++) {
+        result = cons(expr_coord::app_fn, result);
+    }
+    return result;
+}
+
+address arg() {
+    return address(expr_coord::app_arg);
+}
+
+address pi_body(unsigned n) {
+    address result;
+    for (unsigned i = 0; i < n; i++) {
+        result = cons(expr_coord::pi_body, result);
+    }
+    return result;
+}
+
+address binding_type(expr const & e) {
+    lean_assert(is_binding(e));
+    if (is_pi(e)) {
+      return address(expr_coord::pi_var_type);
+    } else {
+        return address(expr_coord::lam_var_type);
+    }
+}
+address binding_body(expr const & e) {
+    lean_assert(is_binding(e));
+    if (is_pi(e)) {
+      return address(expr_coord::pi_body);
+    } else {
+        return address(expr_coord::lam_body);
+    }
+}
+address lam_body(unsigned n) {
+    address result;
+    for (unsigned i = 0; i < n; i++) {
+        result = cons(expr_coord::lam_body, result);
+    }
+    return result;
+}
+
+address repeat(address e, unsigned n) {
+    address result;
+    for (unsigned i = 0; i < n; i++) {
+        result = append(e, result);
+    }
+    return result;
+}
+
+address mlocal_type(expr const & local) {
+    lean_assert(is_mlocal(local));
+    return is_local(local) ? address(expr_coord::local_const_type) : address(expr_coord::mvar_type);
+}
+
+
+}}

--- a/src/library/expr_address.h
+++ b/src/library/expr_address.h
@@ -13,12 +13,12 @@ Author: E.W.Ayers
 
 namespace lean {
 enum class expr_coord {
-app_fn, app_arg,
-lam_var_type, lam_body,
-pi_var_type, pi_body,
-elet_var_type , elet_assignment, elet_body,
-mvar_type,
-local_const_type,
+    app_fn, app_arg,
+    lam_var_type, lam_body,
+    pi_var_type, pi_body,
+    elet_var_type , elet_assignment, elet_body,
+    mvar_type,
+    local_const_type,
 };
 
 typedef list<expr_coord> address;

--- a/src/library/expr_address.h
+++ b/src/library/expr_address.h
@@ -1,0 +1,42 @@
+/*
+Copyright (c) E.W.Ayers. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+
+Author: E.W.Ayers
+*/
+#pragma once
+#include "util/list.h"
+#include "kernel/expr.h"
+#include "library/vm/vm.h"
+#include "library/vm/vm_list.h"
+
+
+namespace lean {
+enum class expr_coord {
+app_fn, app_arg,
+lam_var_type, lam_body,
+pi_var_type, pi_body,
+elet_var_type , elet_assignment, elet_body,
+mvar_type,
+local_const_type,
+};
+
+typedef list<expr_coord> address;
+
+vm_obj to_obj(expr_coord c);
+vm_obj to_obj(address a);
+
+namespace expr_address {
+    expr_coord to_coord(vm_obj const & c);
+    address to_address(vm_obj const & a);
+    address app(unsigned sz = 1, unsigned i = 0);
+    address fn(unsigned sz = 1);
+    address arg();
+    address pi_body(unsigned n = 1);
+    address mlocal_type(expr const & local);
+    address binding_body(expr const & binder);
+    address binding_type(expr const & binder);
+    address lam_body(unsigned n = 1);
+    address repeat(address e, unsigned n);
+}
+}

--- a/src/library/vm/vm_expr.cpp
+++ b/src/library/vm/vm_expr.cpp
@@ -217,6 +217,10 @@ vm_obj expr_has_decidable_eq(vm_obj const & o1, vm_obj const & o2) {
     return mk_vm_bool(is_bi_equal(to_expr(o1), to_expr(o2)));
 }
 
+vm_obj expr_coord_has_decidable_eq(vm_obj const & o1, vm_obj const & o2) {
+    return mk_vm_bool(cidx(o1) == cidx(o2));
+}
+
 vm_obj expr_alpha_eqv(vm_obj const & o1, vm_obj const & o2) {
     return mk_vm_bool(to_expr(o1) == to_expr(o2));
 }
@@ -512,6 +516,7 @@ void initialize_vm_expr() {
     DECLARE_VM_BUILTIN(name({"expr", "macro"}),            expr_macro_intro);
     DECLARE_VM_BUILTIN(name({"expr", "macro_def_name"}),   expr_macro_def_name);
     DECLARE_VM_BUILTIN(name({"expr", "has_decidable_eq"}), expr_has_decidable_eq);
+    DECLARE_VM_BUILTIN(name({"expr", "coord", "has_decidable_eq"}), expr_coord_has_decidable_eq);
     DECLARE_VM_BUILTIN(name({"expr", "alpha_eqv"}),        expr_alpha_eqv);
     DECLARE_VM_BUILTIN(name({"expr", "to_string"}),        expr_to_string);
     DECLARE_VM_BUILTIN(name({"expr", "lt"}),               expr_lt);

--- a/src/library/vm/vm_expr.cpp
+++ b/src/library/vm/vm_expr.cpp
@@ -217,10 +217,6 @@ vm_obj expr_has_decidable_eq(vm_obj const & o1, vm_obj const & o2) {
     return mk_vm_bool(is_bi_equal(to_expr(o1), to_expr(o2)));
 }
 
-vm_obj expr_coord_has_decidable_eq(vm_obj const & o1, vm_obj const & o2) {
-    return mk_vm_bool(cidx(o1) == cidx(o2));
-}
-
 vm_obj expr_alpha_eqv(vm_obj const & o1, vm_obj const & o2) {
     return mk_vm_bool(to_expr(o1) == to_expr(o2));
 }
@@ -516,7 +512,6 @@ void initialize_vm_expr() {
     DECLARE_VM_BUILTIN(name({"expr", "macro"}),            expr_macro_intro);
     DECLARE_VM_BUILTIN(name({"expr", "macro_def_name"}),   expr_macro_def_name);
     DECLARE_VM_BUILTIN(name({"expr", "has_decidable_eq"}), expr_has_decidable_eq);
-    DECLARE_VM_BUILTIN(name({"expr", "coord", "has_decidable_eq"}), expr_coord_has_decidable_eq);
     DECLARE_VM_BUILTIN(name({"expr", "alpha_eqv"}),        expr_alpha_eqv);
     DECLARE_VM_BUILTIN(name({"expr", "to_string"}),        expr_to_string);
     DECLARE_VM_BUILTIN(name({"expr", "lt"}),               expr_lt);


### PR DESCRIPTION
One of the features of the widgets PR is that the lean pretty printer has been modified so that it also tags certain positions in the formatted expression with information about which subexpression of the original expression generated a pariticular part of the pretty printed string. This allows all of the highlighting and lookup of implicit arguments etc in the widget view.

The main thing it introduces is `expr.coord` which is an enum of labels for each recursive constructor argument in expr. Then an `expr.address` is simply a list of these coordinates. In this way you can reference subexpressions.

It could also be used to implement lenses (or maybe prisms?) on expressions, that is one could implement
```
meta def expr.lens {t} [alternative t] : expr.address → (expr → t expr) → (expr → t expr)
```
which runs the given function on the subexpression and then repackages it.
I didn't include it because I wanted to include in this PR only the minimum amount of stuff that was needed to get to the stage where I had the datatypes and some helper functions for the modified pretty printer.
If people think it doesn't bloat core too much I am happy to include an implementation for the other lensy things.

I also have an implementation of expression zippers in a different project if anyone is interested in that. 