### PR TITLE
[Merged by Bors] - feat(vm): vm objects may be hashed

### DIFF
--- a/src/kernel/expr.cpp
+++ b/src/kernel/expr.cpp
@@ -903,6 +903,8 @@ unsigned hash_bi(expr const & e) {
     return h;
 }
 
+unsigned hash(expr const & e) { return e.hash(); }
+
 std::ostream & operator<<(std::ostream & out, expr_kind const & k) {
     switch (k) {
     case expr_kind::Var:      out << "Var"; break;

--- a/src/kernel/expr.cpp
+++ b/src/kernel/expr.cpp
@@ -903,8 +903,6 @@ unsigned hash_bi(expr const & e) {
     return h;
 }
 
-unsigned hash(expr const & e) { return e.hash(); }
-
 std::ostream & operator<<(std::ostream & out, expr_kind const & k) {
     switch (k) {
     case expr_kind::Var:      out << "Var"; break;

--- a/src/kernel/expr.h
+++ b/src/kernel/expr.h
@@ -630,7 +630,7 @@ expr const & get_app_fn(expr const & e);
 unsigned get_app_num_args(expr const & e);
 // =======================================
 
-unsigned hash(expr const & e);
+inline unsigned hash(expr const & e) { return e.hash(); }
 // =======================================
 // Auxiliary functionals
 /** \brief Functional object for hashing kernel expressions. */

--- a/src/kernel/expr.h
+++ b/src/kernel/expr.h
@@ -630,6 +630,7 @@ expr const & get_app_fn(expr const & e);
 unsigned get_app_num_args(expr const & e);
 // =======================================
 
+unsigned hash(expr const & e);
 // =======================================
 // Auxiliary functionals
 /** \brief Functional object for hashing kernel expressions. */

--- a/src/library/tactic/backward/backward_lemmas.cpp
+++ b/src/library/tactic/backward/backward_lemmas.cpp
@@ -137,6 +137,7 @@ struct vm_backward_lemmas : public vm_external {
     virtual void dealloc() override { this->~vm_backward_lemmas(); get_vm_allocator().deallocate(sizeof(vm_backward_lemmas), this); }
     virtual vm_external * ts_clone(vm_clone_fn const &) override { return new vm_backward_lemmas(m_val); }
     virtual vm_external * clone(vm_clone_fn const &) override { return new (get_vm_allocator().allocate(sizeof(vm_backward_lemmas))) vm_backward_lemmas(m_val); }
+    virtual unsigned int hash() { return 0; }
 };
 
 backward_lemma_index const & to_backward_lemmas(vm_obj const & o) {

--- a/src/library/tactic/simp_lemmas.cpp
+++ b/src/library/tactic/simp_lemmas.cpp
@@ -1405,6 +1405,7 @@ struct vm_simp_lemmas : public vm_external {
     virtual void dealloc() override { this->~vm_simp_lemmas(); get_vm_allocator().deallocate(sizeof(vm_simp_lemmas), this); }
     virtual vm_external * ts_clone(vm_clone_fn const &) override { return new vm_simp_lemmas(m_val); }
     virtual vm_external * clone(vm_clone_fn const &) override { return new (get_vm_allocator().allocate(sizeof(vm_simp_lemmas))) vm_simp_lemmas(m_val); }
+    virtual unsigned int hash() { return 0; }
 };
 
 bool is_simp_lemmas(vm_obj const & o) {

--- a/src/library/tactic/smt/congruence_tactics.cpp
+++ b/src/library/tactic/smt/congruence_tactics.cpp
@@ -30,6 +30,7 @@ struct vm_cc_state : public vm_external {
     }
     virtual vm_external * ts_clone(vm_clone_fn const &) override { return new vm_cc_state(m_val); }
     virtual vm_external * clone(vm_clone_fn const &) override { return new (get_vm_allocator().allocate(sizeof(vm_cc_state))) vm_cc_state(m_val); }
+    virtual unsigned int hash() { return 0; }
 };
 
 bool is_cc_state(vm_obj const & o) {

--- a/src/library/tactic/smt/ematch.cpp
+++ b/src/library/tactic/smt/ematch.cpp
@@ -1072,6 +1072,7 @@ struct vm_ematch_state : public vm_external {
     virtual void dealloc() override { this->~vm_ematch_state(); get_vm_allocator().deallocate(sizeof(vm_ematch_state), this); }
     virtual vm_external * ts_clone(vm_clone_fn const &) override { return new vm_ematch_state(m_val); }
     virtual vm_external * clone(vm_clone_fn const &) override { return new (get_vm_allocator().allocate(sizeof(vm_ematch_state))) vm_ematch_state(m_val); }
+    virtual unsigned int hash() { return 0; }
 };
 
 ematch_state const & to_ematch_state(vm_obj const & o) {

--- a/src/library/tactic/smt/hinst_lemmas.cpp
+++ b/src/library/tactic/smt/hinst_lemmas.cpp
@@ -691,6 +691,7 @@ struct vm_hinst_lemma : public vm_external {
     virtual void dealloc() override { this->~vm_hinst_lemma(); get_vm_allocator().deallocate(sizeof(vm_hinst_lemma), this); }
     virtual vm_external * ts_clone(vm_clone_fn const &) override { return new vm_hinst_lemma(m_val); }
     virtual vm_external * clone(vm_clone_fn const &) override { return new (get_vm_allocator().allocate(sizeof(vm_hinst_lemma))) vm_hinst_lemma(m_val); }
+    virtual unsigned int hash() { return 0; }
 };
 
 hinst_lemma const & to_hinst_lemma(vm_obj const & o) {
@@ -736,6 +737,7 @@ struct vm_hinst_lemmas : public vm_external {
     virtual void dealloc() override { this->~vm_hinst_lemmas(); get_vm_allocator().deallocate(sizeof(vm_hinst_lemmas), this); }
     virtual vm_external * ts_clone(vm_clone_fn const &) override { return new vm_hinst_lemmas(m_val); }
     virtual vm_external * clone(vm_clone_fn const &) override { return new (get_vm_allocator().allocate(sizeof(vm_hinst_lemmas))) vm_hinst_lemmas(m_val); }
+    virtual unsigned int hash() { return 0; }
 };
 
 hinst_lemmas const & to_hinst_lemmas(vm_obj const & o) {

--- a/src/library/tactic/smt/smt_state.cpp
+++ b/src/library/tactic/smt/smt_state.cpp
@@ -126,6 +126,7 @@ struct vm_smt_goal : public vm_external {
     }
     virtual vm_external * ts_clone(vm_clone_fn const &) override { return new vm_smt_goal(m_val); }
     virtual vm_external * clone(vm_clone_fn const &) override { return new (get_vm_allocator().allocate(sizeof(vm_smt_goal))) vm_smt_goal(m_val); }
+    virtual unsigned int hash() { return 0; }
 };
 
 bool is_smt_goal(vm_obj const & o) {

--- a/src/library/tactic/vm_local_context.cpp
+++ b/src/library/tactic/vm_local_context.cpp
@@ -12,6 +12,7 @@ struct vm_local_context : public vm_external {
     virtual void dealloc() override { this->~vm_local_context(); get_vm_allocator().deallocate(sizeof(vm_local_context), this);}
     virtual vm_external * ts_clone(vm_clone_fn const &) override { return new vm_local_context(m_val); }
     virtual vm_external * clone(vm_clone_fn const &) override { return new (get_vm_allocator().allocate(sizeof(vm_local_context))) vm_local_context(m_val); }
+    virtual unsigned int hash() { return 0; }
 };
 vm_obj to_obj(local_context const & lc) {
     return mk_vm_external(new(get_vm_allocator().allocate(sizeof(vm_local_context))) vm_local_context(lc));

--- a/src/library/tactic/vm_monitor.cpp
+++ b/src/library/tactic/vm_monitor.cpp
@@ -171,6 +171,7 @@ struct vm_vm_decl : public vm_external {
     virtual void dealloc() override { this->~vm_vm_decl(); get_vm_allocator().deallocate(sizeof(vm_vm_decl), this); }
     virtual vm_external * ts_clone(vm_clone_fn const &) override { return new vm_vm_decl(m_val); }
     virtual vm_external * clone(vm_clone_fn const &) override { return new (get_vm_allocator().allocate(sizeof(vm_vm_decl))) vm_vm_decl(m_val); }
+    virtual unsigned int hash() { return 0; }
 };
 
 vm_decl const & to_vm_decl(vm_obj const & o) {

--- a/src/library/tactic/vm_type_context.cpp
+++ b/src/library/tactic/vm_type_context.cpp
@@ -27,6 +27,7 @@ struct vm_type_context_old : public vm_external {
     virtual void dealloc() override { this->~vm_type_context_old(); get_vm_allocator().deallocate(sizeof(vm_type_context_old), this); }
     virtual vm_external * ts_clone(vm_clone_fn const &) override { return new vm_type_context_old(m_val); }
     virtual vm_external * clone(vm_clone_fn const &) override { return new (get_vm_allocator().allocate(sizeof(vm_type_context_old))) vm_type_context_old(m_val); }
+    virtual unsigned int hash() { return 0; }
 };
 type_context_old & to_type_context_old(vm_obj const & o) {
     return static_cast<vm_type_context_old*>(to_external(o))->m_val;

--- a/src/library/vm/interaction_state.h
+++ b/src/library/vm/interaction_state.h
@@ -29,6 +29,7 @@ struct interaction_monad {
            cloned between threads. */
         virtual vm_external * ts_clone(vm_clone_fn const &) override;
         virtual vm_external * clone(vm_clone_fn const &) override;
+        virtual unsigned int hash() { return 0; }
     };
 
     typedef std::tuple<format, optional<pos_info>, State> im_exception_info;

--- a/src/library/vm/vm.cpp
+++ b/src/library/vm/vm.cpp
@@ -319,6 +319,7 @@ void vm_obj_cell::dealloc() {
 }
 
 unsigned hash(vm_obj const & o) {
+    check_system("hash(vm_obj)");
     unsigned int h = 555; // just a seed for the hash
     h = hash(h, (unsigned int)(kind(o)));
     if (is_simple(o)) {

--- a/src/library/vm/vm.cpp
+++ b/src/library/vm/vm.cpp
@@ -334,7 +334,6 @@ unsigned hash(vm_obj const & o) {
     } else if (is_external(o)) {
         unsigned int oh = to_external(o)->hash();
         return oh;
-        // return oh == 0 ? hash(h, hash_ptr(o.raw())) : oh;
     } else if (is_native_closure(o)) {
         auto nc = to_native_closure(o);
         h = hash_ptr(nc->get_fn());

--- a/src/library/vm/vm.cpp
+++ b/src/library/vm/vm.cpp
@@ -18,6 +18,7 @@ Author: Leonardo de Moura
 #include "util/small_object_allocator.h"
 #include "util/sexpr/option_declarations.h"
 #include "util/shared_mutex.h"
+#include "util/hash.h"
 #include "kernel/replace_fn.h"
 #include "library/constants.h"
 #include "library/kernel_serializer.h"
@@ -314,6 +315,36 @@ void vm_obj_cell::dealloc() {
     } catch (std::bad_alloc&) {
         // We need this catch, because push_back may fail when expanding the buffer.
         // In this case, we avoid the crash, and "accept" the memory leak.
+    }
+}
+
+unsigned hash(vm_obj const & o) {
+    unsigned int h = 555; // just a seed for the hash
+    h = hash(h, (unsigned int)(kind(o)));
+    if (is_simple(o)) {
+        return hash(h, (unsigned int)(0));
+    } else if (is_constructor(o) || is_closure(o)) {
+        h = hash(h, is_closure(o) ? cfn_idx(o) : cidx(o));
+        for (unsigned i = 0; i < csize(o); i++) {
+            h = hash(h, hash(cfield(o, i)));
+        }
+        return h;
+    } else if (is_mpz(o)) {
+        return hash(h, to_mpz(o).hash());
+    } else if (is_external(o)) {
+        unsigned int oh = to_external(o)->hash();
+        return oh;
+        // return oh == 0 ? hash(h, hash_ptr(o.raw())) : oh;
+    } else if (is_native_closure(o)) {
+        auto nc = to_native_closure(o);
+        h = hash_ptr(nc->get_fn());
+        vm_obj const *  args = nc->get_args();
+        for (unsigned i = 0; i < nc->get_num_args(); i++) {
+            h = hash(h, hash(args[i]));
+        }
+        return h;
+    } else { // unknown
+        return h;
     }
 }
 

--- a/src/library/vm/vm.h
+++ b/src/library/vm/vm.h
@@ -59,6 +59,12 @@ public:
 #define lean_vm_check(cond) { if (LEAN_UNLIKELY(!(cond))) vm_check_failed(#cond); }
 #endif
 
+/** Hashes a VM object. If it's a `vm_external`, then
+ * use `vm_external::hash()`.
+ * [warning] `hash()` is not implemented for all of the inheritors of `vm_external`
+ * and by default returns zero. So this means that if the hashes are the same
+ * it is not necessarily true that they are equal. */
+unsigned hash(vm_obj const & o);
 void display(std::ostream & out, vm_obj const & o);
 
 /** \brief VM object */
@@ -152,6 +158,9 @@ public:
     virtual ~vm_external() {}
     virtual vm_external * ts_clone(vm_clone_fn const &) = 0;
     virtual vm_external * clone(vm_clone_fn const &) = 0;
+    /** A hash function for externals so that equality of vm objects can be checked.
+     * [hack] this should be made abstract but there are too many inheritors. */
+    virtual unsigned int hash() { return 0; }
 };
 
 /* Thread safe vm_obj, it can be used to move vm_obj's between threads.

--- a/src/library/vm/vm.h
+++ b/src/library/vm/vm.h
@@ -62,8 +62,7 @@ public:
 /** Hashes a VM object. If it's a `vm_external`, then
  * use `vm_external::hash()`.
  * [warning] `hash()` is not implemented for all of the inheritors of `vm_external`
- * and by default returns zero. So this means that if the hashes are the same
- * it is not necessarily true that they are equal. */
+ * and by default returns zero. */
 unsigned hash(vm_obj const & o);
 void display(std::ostream & out, vm_obj const & o);
 
@@ -158,9 +157,8 @@ public:
     virtual ~vm_external() {}
     virtual vm_external * ts_clone(vm_clone_fn const &) = 0;
     virtual vm_external * clone(vm_clone_fn const &) = 0;
-    /** A hash function for externals so that equality of vm objects can be checked.
-     * [hack] this should be made abstract but there are too many inheritors. */
-    virtual unsigned int hash() { return 0; }
+    /** A hash function for externals so that equality of vm objects can be checked. */
+    virtual unsigned int hash() = 0;
 };
 
 /* Thread safe vm_obj, it can be used to move vm_obj's between threads.
@@ -1043,6 +1041,7 @@ environment vm_monitor_register(environment const & env, name const & d);
         virtual vm_external * clone(vm_clone_fn const &) override { \
             return new (get_vm_allocator().allocate(sizeof(vm_##name))) vm_##name(m_val); \
         } \
+        virtual unsigned int hash() { return 0; } \
     }; \
     vm_obj to_obj(cls const & val) { \
         return mk_vm_external(new (get_vm_allocator().allocate(sizeof(vm_##name))) vm_##name(val)); \

--- a/src/library/vm/vm_array.cpp
+++ b/src/library/vm/vm_array.cpp
@@ -43,6 +43,13 @@ struct vm_array_ts_copy : public vm_external {
     virtual void dealloc() override { lean_unreachable(); }
     virtual vm_external * ts_clone(vm_clone_fn const &) override { lean_unreachable(); }
     virtual vm_external * clone(vm_clone_fn const &) override;
+    virtual unsigned int hash() override {
+        unsigned int h = 118118;
+        for(vm_obj const & o : m_entries) {
+            h = lean::hash(h, lean::hash(o));
+        }
+        return h;
+    }
 };
 
 vm_external * vm_array::ts_clone(vm_clone_fn const & fn) {

--- a/src/library/vm/vm_array.cpp
+++ b/src/library/vm/vm_array.cpp
@@ -5,6 +5,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Author: Leonardo de Moura
 */
 #include <vector>
+#include "util/hash.h"
 #include "library/parray.h"
 #include "library/vm/vm.h"
 #include "library/vm/vm_nat.h"
@@ -17,6 +18,13 @@ struct vm_array : public vm_external {
     virtual void dealloc() override { this->~vm_array(); get_vm_allocator().deallocate(sizeof(vm_array), this); }
     virtual vm_external * ts_clone(vm_clone_fn const &) override;
     virtual vm_external * clone(vm_clone_fn const &) override { lean_unreachable(); }
+    virtual unsigned int hash() override {
+        unsigned int h = 9435;
+        for (unsigned int i = 0; i < m_array.size(); i++) {
+            h = lean::hash(h, lean::hash(m_array[i]));
+        }
+        return h;
+    }
 };
 
 /* Auxiliary object used by vm_array::ts_clone.

--- a/src/library/vm/vm_array.cpp
+++ b/src/library/vm/vm_array.cpp
@@ -45,7 +45,7 @@ struct vm_array_ts_copy : public vm_external {
     virtual vm_external * clone(vm_clone_fn const &) override;
     virtual unsigned int hash() override {
         unsigned int h = 118118;
-        for(vm_obj const & o : m_entries) {
+        for (vm_obj const & o : m_entries) {
             h = lean::hash(h, lean::hash(o));
         }
         return h;

--- a/src/library/vm/vm_declaration.cpp
+++ b/src/library/vm/vm_declaration.cpp
@@ -45,6 +45,7 @@ struct vm_declaration : public vm_external {
     virtual void dealloc() override { this->~vm_declaration(); get_vm_allocator().deallocate(sizeof(vm_declaration), this); }
     virtual vm_external * ts_clone(vm_clone_fn const &) override { return new vm_declaration(m_val); }
     virtual vm_external * clone(vm_clone_fn const &) override { return new (get_vm_allocator().allocate(sizeof(vm_declaration))) vm_declaration(m_val); }
+    virtual unsigned int hash() { return 0; }
 };
 
 bool is_declaration(vm_obj const & o) {

--- a/src/library/vm/vm_environment.cpp
+++ b/src/library/vm/vm_environment.cpp
@@ -42,6 +42,7 @@ struct vm_environment : public vm_external {
     virtual void dealloc() override { this->~vm_environment(); get_vm_allocator().deallocate(sizeof(vm_environment), this); }
     virtual vm_external * ts_clone(vm_clone_fn const &) override { return new vm_environment(m_val); }
     virtual vm_external * clone(vm_clone_fn const &) override { return new (get_vm_allocator().allocate(sizeof(vm_environment))) vm_environment(m_val); }
+    virtual unsigned int hash() { return 0; }
 };
 
 bool is_env(vm_obj const & o) {

--- a/src/library/vm/vm_exceptional.cpp
+++ b/src/library/vm/vm_exceptional.cpp
@@ -18,6 +18,7 @@ struct vm_throwable : public vm_external {
     virtual void dealloc() override { this->~vm_throwable(); get_vm_allocator().deallocate(sizeof(vm_throwable), this); }
     virtual vm_external * ts_clone(vm_clone_fn const &) override { return new vm_throwable(*m_val); }
     virtual vm_external * clone(vm_clone_fn const &) override { return new (get_vm_allocator().allocate(sizeof(vm_throwable))) vm_throwable(*m_val); }
+    virtual unsigned int hash() { return 0; }
 };
 
 throwable * to_throwable(vm_obj const & o) {

--- a/src/library/vm/vm_expr.cpp
+++ b/src/library/vm/vm_expr.cpp
@@ -47,6 +47,7 @@ struct vm_macro_definition : public vm_external {
     }
     virtual vm_external * ts_clone(vm_clone_fn const &) override { return new vm_macro_definition(m_val); }
     virtual vm_external * clone(vm_clone_fn const &) override { return new (get_vm_allocator().allocate(sizeof(vm_macro_definition))) vm_macro_definition(m_val); }
+    virtual unsigned int hash() { return 0; }
 };
 
 macro_definition const & to_macro_definition(vm_obj const & o) {

--- a/src/library/vm/vm_expr.cpp
+++ b/src/library/vm/vm_expr.cpp
@@ -65,6 +65,7 @@ struct vm_expr : public vm_external {
     virtual void dealloc() override { this->~vm_expr(); get_vm_allocator().deallocate(sizeof(vm_expr), this); }
     virtual vm_external * ts_clone(vm_clone_fn const &) override { return new vm_expr(m_val); }
     virtual vm_external * clone(vm_clone_fn const &) override { return new (get_vm_allocator().allocate(sizeof(vm_expr))) vm_expr(m_val); }
+    virtual unsigned int hash() override { return m_val.hash(); }
 };
 
 bool is_expr(vm_obj const & o) {

--- a/src/library/vm/vm_float.cpp
+++ b/src/library/vm/vm_float.cpp
@@ -23,6 +23,7 @@ struct vm_float : public vm_external {
     virtual vm_external * clone(vm_clone_fn const &) override {
         return new (get_vm_allocator().allocate(sizeof(vm_float))) vm_float(m_val);
     }
+    virtual unsigned int hash() override { return std::hash<float>{}(m_val); }
 };
 
 static vm_obj mk_vm_float(float d) {

--- a/src/library/vm/vm_format.cpp
+++ b/src/library/vm/vm_format.cpp
@@ -25,6 +25,7 @@ struct vm_format : public vm_external {
     virtual void dealloc() override { this->~vm_format(); get_vm_allocator().deallocate(sizeof(vm_format), this); }
     virtual vm_external * ts_clone(vm_clone_fn const &) override { return new vm_format(m_val); }
     virtual vm_external * clone(vm_clone_fn const &) override { return new (get_vm_allocator().allocate(sizeof(vm_format))) vm_format(m_val); }
+    virtual unsigned int hash() override { return m_val.hash(); }
 };
 
 bool is_format(vm_obj const & o) {

--- a/src/library/vm/vm_format.cpp
+++ b/src/library/vm/vm_format.cpp
@@ -145,7 +145,9 @@ struct vm_format_thunk : public vm_external {
     virtual void dealloc() override { this->~vm_format_thunk(); get_vm_allocator().deallocate(sizeof(vm_format_thunk), this); }
     virtual vm_external * ts_clone(vm_clone_fn const &) override { return new vm_format_thunk(m_val); }
     virtual vm_external * clone(vm_clone_fn const &) override { return new (get_vm_allocator().allocate(sizeof(vm_format_thunk))) vm_format_thunk(m_val); }
+    virtual unsigned hash() { return 0; }
 };
+
 
 std::function<format()> const & to_format_thunk(vm_obj const & o) {
     lean_vm_check(dynamic_cast<vm_format_thunk*>(to_external(o)));

--- a/src/library/vm/vm_io.cpp
+++ b/src/library/vm/vm_io.cpp
@@ -122,6 +122,7 @@ struct vm_handle : public vm_external {
     virtual void dealloc() override { this->~vm_handle(); get_vm_allocator().deallocate(sizeof(vm_handle), this); }
     virtual vm_external * clone(vm_clone_fn const &) override { return new vm_handle(m_handle); }
     virtual vm_external * ts_clone(vm_clone_fn const &) override { lean_unreachable(); }
+    virtual unsigned int hash() { return 0; }
 };
 
 static handle_ref const & to_handle(vm_obj const & o) {
@@ -140,6 +141,7 @@ struct vm_socket : public vm_external {
     virtual void dealloc() override { this->~vm_socket(); get_vm_allocator().deallocate(sizeof(vm_socket), this); }
     virtual vm_external * clone(vm_clone_fn const &) override { return new vm_socket(m_fd); }
     virtual vm_external * ts_clone(vm_clone_fn const &) override { lean_unreachable(); }
+    virtual unsigned int hash() { return 0; }
 };
 
 static SOCKET socket_to_fd(vm_obj const &o) {
@@ -159,6 +161,7 @@ struct vm_child : public vm_external {
     virtual void dealloc() override { this->~vm_child(); get_vm_allocator().deallocate(sizeof(vm_child), this); }
     virtual vm_external * clone(vm_clone_fn const &) override { return new vm_child(m_child); }
     virtual vm_external * ts_clone(vm_clone_fn const &) override { lean_unreachable(); }
+    virtual unsigned int hash() { return 0; }
 };
 
 std::shared_ptr<child> const & to_child(vm_obj const & o) {

--- a/src/library/vm/vm_level.cpp
+++ b/src/library/vm/vm_level.cpp
@@ -21,6 +21,7 @@ struct vm_level : public vm_external {
     virtual void dealloc() override { this->~vm_level(); get_vm_allocator().deallocate(sizeof(vm_level), this); }
     virtual vm_external * ts_clone(vm_clone_fn const &) override { return new vm_level(m_val); }
     virtual vm_external * clone(vm_clone_fn const &) override { return new (get_vm_allocator().allocate(sizeof(vm_level))) vm_level(m_val); }
+    virtual unsigned int hash() override { return m_val.hash(); }
 };
 
 bool is_level(vm_obj const & o) {

--- a/src/library/vm/vm_list.cpp
+++ b/src/library/vm/vm_list.cpp
@@ -19,10 +19,8 @@ namespace lean {
 
 template<typename T> unsigned hash(list<T> const & l) {
     unsigned int r = 023445;
-    list<T> const * it = &l;
-    while (*it) {
-        r = lean::hash(r, lean::hash(head(*it)));
-        it = &tail(*it);
+    for (T const & x : l) {
+        r = lean::hash(r, lean::hash(x));
     }
     return r;
 }

--- a/src/library/vm/vm_list.cpp
+++ b/src/library/vm/vm_list.cpp
@@ -4,6 +4,11 @@ Released under Apache 2.0 license as described in the file LICENSE.
 
 Author: Leonardo de Moura
 */
+#include "util/hash.h"
+#include "util/list.h"
+#include "util/name.h"
+#include "kernel/expr.h"
+#include "kernel/level.h"
 #include "library/vm/vm_name.h"
 #include "library/vm/vm_nat.h"
 #include "library/vm/vm_level.h"
@@ -11,6 +16,21 @@ Author: Leonardo de Moura
 #include "library/vm/vm_list.h"
 
 namespace lean {
+
+template<typename T> unsigned hash(list<T> const & l) {
+    unsigned int r = 023445;
+    list<T> const * it = &l;
+    while (*it) {
+        r = lean::hash(r, lean::hash(head(*it)));
+        it = &tail(*it);
+    }
+    return r;
+}
+template unsigned hash<name>(list<name> const & l);
+template unsigned hash<expr>(list<expr> const & l);
+template unsigned hash<level>(list<level> const & l);
+template unsigned hash<list<expr>>(list<list<expr>> const & l);
+
 template<typename A>
 struct vm_list : public vm_external {
     list<A> m_val;
@@ -21,7 +41,13 @@ struct vm_list : public vm_external {
     }
     virtual vm_external * ts_clone(vm_clone_fn const &) override { return new vm_list<A>(m_val); }
     virtual vm_external * clone(vm_clone_fn const &) override { return new (get_vm_allocator().allocate(sizeof(vm_list<A>))) vm_list<A>(m_val); }
+    virtual unsigned int hash() override { return lean::hash(m_val); }
 };
+
+template class vm_list<name>;
+template class vm_list<level>;
+template class vm_list<expr>;
+template class vm_list<list<expr>>;
 
 template<typename A>
 vm_obj list_to_obj(list<A> const & l) {

--- a/src/library/vm/vm_name.cpp
+++ b/src/library/vm/vm_name.cpp
@@ -21,6 +21,7 @@ struct vm_name : public vm_external {
     virtual void dealloc() override { this->~vm_name(); get_vm_allocator().deallocate(sizeof(vm_name), this); }
     virtual vm_external * ts_clone(vm_clone_fn const &) override { return new vm_name(m_val); }
     virtual vm_external * clone(vm_clone_fn const &) override { return new (get_vm_allocator().allocate(sizeof(vm_name))) vm_name(m_val); }
+    virtual unsigned int hash() override { return m_val.hash(); }
 };
 
 bool is_name(vm_obj const & o) {

--- a/src/library/vm/vm_options.cpp
+++ b/src/library/vm/vm_options.cpp
@@ -19,6 +19,7 @@ struct vm_options : public vm_external {
     virtual void dealloc() override { this->~vm_options(); get_vm_allocator().deallocate(sizeof(vm_options), this); }
     virtual vm_external * ts_clone(vm_clone_fn const &) override { return new vm_options(m_val); }
     virtual vm_external * clone(vm_clone_fn const &) override { return new (get_vm_allocator().allocate(sizeof(vm_options))) vm_options(m_val); }
+    virtual unsigned int hash() { return 0; }
 };
 
 bool is_options(vm_obj const & o) {

--- a/src/library/vm/vm_parser.cpp
+++ b/src/library/vm/vm_parser.cpp
@@ -83,6 +83,7 @@ struct vm_decl_attributes : public vm_external {
     virtual void dealloc() override { this->~vm_decl_attributes(); get_vm_allocator().deallocate(sizeof(vm_decl_attributes), this); }
     virtual vm_external * ts_clone(vm_clone_fn const &) override { return new vm_decl_attributes(m_val); }
     virtual vm_external * clone(vm_clone_fn const &) override { return new (get_vm_allocator().allocate(sizeof(vm_decl_attributes))) vm_decl_attributes(m_val); }
+    virtual unsigned int hash() { return 0; }
 };
 
 static decl_attributes const & to_decl_attributes(vm_obj const & o) {

--- a/src/library/vm/vm_rb_map.cpp
+++ b/src/library/vm/vm_rb_map.cpp
@@ -32,6 +32,7 @@ struct vm_rb_map : public vm_external {
     virtual void dealloc() override { this->~vm_rb_map(); get_vm_allocator().deallocate(sizeof(vm_rb_map), this); }
     virtual vm_external * ts_clone(vm_clone_fn const &) override;
     virtual vm_external * clone(vm_clone_fn const &) override { lean_unreachable(); }
+    virtual unsigned int hash() { return 0; }
 };
 
 /* Auxiliary object used by vm_rb_map::ts_clone.
@@ -55,6 +56,7 @@ struct vm_rb_map_ts_copy : public vm_external {
     virtual void dealloc() override { lean_unreachable(); }
     virtual vm_external * ts_clone(vm_clone_fn const &) override { lean_unreachable(); }
     virtual vm_external * clone(vm_clone_fn const &) override;
+    virtual unsigned int hash() { return 0; }
 };
 
 vm_external * vm_rb_map::ts_clone(vm_clone_fn const & fn) {
@@ -144,6 +146,7 @@ struct vm_name_set : public vm_external {
     virtual void dealloc() override { this->~vm_name_set(); get_vm_allocator().deallocate(sizeof(vm_name_set), this); }
     virtual vm_external * ts_clone(vm_clone_fn const &) override { return new vm_name_set(m_val); }
     virtual vm_external * clone(vm_clone_fn const &) override { return new (get_vm_allocator().allocate(sizeof(vm_name_set))) vm_name_set(m_val); }
+    virtual unsigned int hash() { return 0; }
 };
 
 bool is_name_set(vm_obj const & o) {

--- a/src/library/vm/vm_string.cpp
+++ b/src/library/vm/vm_string.cpp
@@ -7,6 +7,7 @@ Author: Leonardo de Moura
 #include <string>
 #include "util/interrupt.h"
 #include "util/utf8.h"
+#include "util/hash.h"
 #include "library/vm/vm_string.h"
 #include "library/vm/vm_nat.h"
 #include "library/vm/vm_option.h"
@@ -20,6 +21,7 @@ struct vm_string : public vm_external {
     virtual void dealloc() override { this->~vm_string(); get_vm_allocator().deallocate(sizeof(vm_string), this); }
     virtual vm_external * ts_clone(vm_clone_fn const &) override { return new vm_string(m_value, m_length); }
     virtual vm_external * clone(vm_clone_fn const &) override { return new (get_vm_allocator().allocate(sizeof(vm_string))) vm_string(m_value, m_length); }
+    virtual unsigned int hash() override { return lean::hash_data(m_value); }
 };
 
 bool is_string(vm_obj const & o) {

--- a/src/library/vm/vm_task.cpp
+++ b/src/library/vm/vm_task.cpp
@@ -31,6 +31,7 @@ struct vm_task : public vm_external {
     virtual vm_external * clone(vm_clone_fn const &) override {
         lean_unreachable();
     }
+    virtual unsigned int hash() { return 0; }
 };
 
 bool is_task(vm_obj const & o) {

--- a/src/util/name.cpp
+++ b/src/util/name.cpp
@@ -294,6 +294,8 @@ static unsigned num_digits(unsigned k) {
     return r;
 }
 
+unsigned hash(name const & n) { return n.hash(); }
+
 size_t name::size_core(bool unicode) const {
     if (m_ptr == nullptr) {
         return strlen(anonymous_str);

--- a/src/util/name.cpp
+++ b/src/util/name.cpp
@@ -294,8 +294,6 @@ static unsigned num_digits(unsigned k) {
     return r;
 }
 
-unsigned hash(name const & n) { return n.hash(); }
-
 size_t name::size_core(bool unicode) const {
     if (m_ptr == nullptr) {
         return strlen(anonymous_str);

--- a/src/util/name.h
+++ b/src/util/name.h
@@ -223,7 +223,7 @@ public:
     struct ptr_eq { bool operator()(name const & n1, name const & n2) const { return n1.m_ptr == n2.m_ptr; } };
 };
 
-unsigned hash(name const & n);
+inline unsigned hash(name const & n) { return n.hash(); };
 name string_to_name(std::string const & str);
 
 struct name_hash { unsigned operator()(name const & n) const { return n.hash(); } };

--- a/src/util/name.h
+++ b/src/util/name.h
@@ -223,6 +223,7 @@ public:
     struct ptr_eq { bool operator()(name const & n1, name const & n2) const { return n1.m_ptr == n2.m_ptr; } };
 };
 
+unsigned hash(name const & n);
 name string_to_name(std::string const & str);
 
 struct name_hash { unsigned operator()(name const & n) const { return n.hash(); } };

--- a/src/util/sexpr/format.h
+++ b/src/util/sexpr/format.h
@@ -231,7 +231,6 @@ format group(format const & f);
 format above(format const & f1, format const & f2);
 format bracket(std::string const & l, format const & x, std::string const & r);
 format paren(format const & x);
-format wrap(format const & f1, format const & f2);
 
 // is_iterator
 template<typename T, typename = void>

--- a/src/util/sexpr/format.h
+++ b/src/util/sexpr/format.h
@@ -231,6 +231,7 @@ format group(format const & f);
 format above(format const & f1, format const & f2);
 format bracket(std::string const & l, format const & x, std::string const & r);
 format paren(format const & x);
+format wrap(format const & f1, format const & f2);
 
 // is_iterator
 template<typename T, typename = void>


### PR DESCRIPTION
This is needed as an optimisation for widgets. As a quick check of equality
of a pair of vm objects.
At the moment each instance of vm_external needs to implement its own `hash` with a fallback of zero.
A warning of this fallback is in the comment for hash.
It will be prohibitively difficult to implement hashing on all the vm_external members and for the purpose I built it for I would rather have false equality than false non-equality.

It also just recomputes the hash each time rather than caching it, since it will be calculated for the vast minority of vm objects this seems like the right thing to do.

Any comments on how to improve the vm hashing function (eg to remove the magic numbers) would be appreciated.