### PR TITLE
[Merged by Bors] - fix(kernel): don't check levels on meta inductives

### DIFF
--- a/src/frontends/lean/inductive_cmds.cpp
+++ b/src/frontends/lean/inductive_cmds.cpp
@@ -351,7 +351,8 @@ class inductive_cmd_fn {
             expr arg_ty = binding_domain(ty);
             type_checker ctx(m_env);
             level arg_level = get_level(ctx, arg_ty);
-            if (!(is_geq(constant_resultant_level, arg_level) || is_zero(constant_resultant_level))) {
+            bool is_trusted = !m_meta_info.m_modifiers.m_is_meta;
+            if (!(is_geq(constant_resultant_level, arg_level) || is_zero(constant_resultant_level)) && is_trusted) {
                 throw exception(sstream() << "universe level of type_of(arg #" << ir_arg << ") "
                                 << "of '" << mlocal_name(ir) << "' is too big for the corresponding inductive datatype");
             }

--- a/src/kernel/inductive/inductive.cpp
+++ b/src/kernel/inductive/inductive.cpp
@@ -410,7 +410,7 @@ struct add_inductive_fn {
                 // the sort is ok IF
                 //   1- its level is <= inductive datatype level, OR
                 //   2- inductive datatype is at level 0
-                if (!(is_geq(m_it_level, sort_level(s)) || is_zero(m_it_level)))
+                if (!(is_geq(m_it_level, sort_level(s)) || is_zero(m_it_level)) && m_is_trusted)
                     throw kernel_exception(m_env, sstream() << "universe level of type_of(arg #" << (i + 1) << ") "
                                            << "of '" << n << "' is too big for the corresponding inductive datatype");
                 if (m_is_trusted)

--- a/tests/lean/meta_ind_univ.lean
+++ b/tests/lean/meta_ind_univ.lean
@@ -1,0 +1,8 @@
+-- should fail
+inductive foo : Type → Type
+| mk : Π (α β : Type), (β → α) → foo α
+
+-- should be fine
+meta inductive foom : Type → Type
+| mk : Π (α β : Type), (β → α) → foom α
+

--- a/tests/lean/meta_ind_univ.lean.expected.out
+++ b/tests/lean/meta_ind_univ.lean.expected.out
@@ -1,0 +1,1 @@
+meta_ind_univ.lean:2:0: error: universe level of type_of(arg #1) of 'foo.mk' is too big for the corresponding inductive datatype


### PR DESCRIPTION
Removes the kernel universe check when declaration is untrusted.
The check wasn't helpful because we don't worry about universe paradoxes in meta-world anyway, we've already descended from grace.