### PR TITLE
[Merged by Bors] - perf(library/tactic/simplify): freeze instances

### DIFF
--- a/library/init/meta/tactic.lean
+++ b/library/init/meta/tactic.lean
@@ -727,6 +727,10 @@ meta constant get_tag (g : expr) : tactic tag
     reset. Note that, the cache is still used when executing a single tactic that
     may generate many type class resolution problems (e.g., `simp`). -/
 meta constant unfreeze_local_instances : tactic unit
+/--
+Freeze the current set of local instances.
+-/
+meta constant freeze_local_instances : tactic unit
 /- Return the list of frozen local instances. Return `none` if local instances were not frozen. -/
 meta constant frozen_local_instances : tactic (option (list expr))
 

--- a/src/library/tactic/simplify.cpp
+++ b/src/library/tactic/simplify.cpp
@@ -1244,7 +1244,9 @@ meta constant simplify
 */
 vm_obj tactic_simplify(vm_obj const & slss, vm_obj const & u, vm_obj const & e, vm_obj const & c, vm_obj const & rel,
                        vm_obj const & prove, vm_obj const & _s) {
-    tactic_state s = tactic::to_state(_s);
+    tactic_state s0 = tactic::to_state(_s);
+    auto s = freeze_local_instances(s0);
+    bool was_frozen = is_eqp(s, s0);
     try {
         simp_config cfg(c);
         tactic_state_context_cache cache(s);
@@ -1255,6 +1257,7 @@ vm_obj tactic_simplify(vm_obj const & slss, vm_obj const & u, vm_obj const & e, 
         if (!cfg.m_fail_if_unchanged || result.get_new() != to_expr(e)) {
             result = finalize(ctx, to_name(rel), result);
             tactic_state new_s = set_dcs(s, dcs);
+            if (!was_frozen) new_s = unfreeze_local_instances(new_s);
             return tactic::mk_success(mk_vm_pair(to_obj(result.get_new()), to_obj(result.get_proof())), new_s);
         } else {
             return tactic::mk_exception("simplify tactic failed to simplify", s);

--- a/src/library/tactic/tactic_state.cpp
+++ b/src/library/tactic/tactic_state.cpp
@@ -1013,18 +1013,41 @@ vm_obj tactic_get_tag(vm_obj const & g, vm_obj const & s0) {
     }
 }
 
-vm_obj tactic_unfreeze_local_instances(vm_obj const & s0) {
-    tactic_state s             = tactic::to_state(s0);
+static tactic_state change_temperature_of_local_instances(tactic_state s, bool freeze) {
     optional<metavar_decl> g   = s.get_main_goal_decl();
-    if (!g) return mk_no_goals_exception(s);
+    if (!g) return s;
     local_context lctx         = g->get_context();
+    if (!!lctx.get_frozen_local_instances() == freeze) return s;
     tactic_state_context_cache cache(s);
     type_context_old ctx           = cache.mk_type_context();
-    lctx.unfreeze_local_instances();
+    if (freeze) {
+        lctx.freeze_local_instances(ctx.get_local_instances());
+    } else {
+        lctx.unfreeze_local_instances();
+    }
     expr new_mvar              = ctx.mk_metavar_decl(lctx, g->get_type());
     ctx.assign(*s.get_main_goal(), new_mvar);
-    tactic_state new_s = set_mctx_goals(s, ctx.mctx(), cons(new_mvar, tail(s.goals())));
-    return tactic::mk_success(new_s);
+    return set_mctx_goals(s, ctx.mctx(), cons(new_mvar, tail(s.goals())));
+}
+
+tactic_state unfreeze_local_instances(tactic_state const & s) {
+    return change_temperature_of_local_instances(s, false);
+}
+
+tactic_state freeze_local_instances(tactic_state const & s) {
+    return change_temperature_of_local_instances(s, true);
+}
+
+vm_obj tactic_unfreeze_local_instances(vm_obj const & s0) {
+    tactic_state s             = tactic::to_state(s0);
+    s = unfreeze_local_instances(s);
+    return tactic::mk_success(s);
+}
+
+vm_obj tactic_freeze_local_instances(vm_obj const & s0) {
+    tactic_state s             = tactic::to_state(s0);
+    s = freeze_local_instances(s);
+    return tactic::mk_success(s);
 }
 
 vm_obj tactic_frozen_local_instances(vm_obj const & s0) {
@@ -1096,6 +1119,7 @@ void initialize_tactic_state() {
     DECLARE_VM_BUILTIN(name({"tactic", "set_tag"}),              tactic_set_tag);
     DECLARE_VM_BUILTIN(name({"tactic", "get_tag"}),              tactic_get_tag);
     DECLARE_VM_BUILTIN(name({"tactic", "unfreeze_local_instances"}), tactic_unfreeze_local_instances);
+    DECLARE_VM_BUILTIN(name({"tactic", "freeze_local_instances"}),   tactic_freeze_local_instances);
     DECLARE_VM_BUILTIN(name({"tactic", "frozen_local_instances"}),   tactic_frozen_local_instances);
     DECLARE_VM_BUILTIN(name({"io", "run_tactic"}),               io_run_tactic);
 }

--- a/src/library/tactic/tactic_state.h
+++ b/src/library/tactic/tactic_state.h
@@ -137,6 +137,9 @@ inline tactic_state set_dcs(tactic_state const & s, defeq_can_state const & dcs)
 tactic_state set_user_state(tactic_state const & s, tactic_user_state const & us);
 tactic_state set_context_cache_id(tactic_state const & s, context_cache_id const & cid);
 
+tactic_state unfreeze_local_instances(tactic_state const & s);
+tactic_state freeze_local_instances(tactic_state const & s);
+
 /* Auxiliary function that returns an updated tactic_state such s' s.t. the metavariable context is mctx and
    the main goal is of the form
 

--- a/src/library/type_context.h
+++ b/src/library/type_context.h
@@ -624,6 +624,7 @@ public:
        add tactic `unfreeze_local_instances : tactic unit` which unfreezes the set of frozen local instances
        for the current goal. */
     void freeze_local_instances();
+    list<local_instance> get_local_instances() const { return m_local_instances; }
 
     bool is_def_eq(level const & l1, level const & l2);
     virtual expr whnf(expr const & e) override;


### PR DESCRIPTION
This PR freezes the local instances before calling the simplifier (re-unfreezing them afterwards if necessary).  This significantly speeds up `simp` after `unfreeze_locale_instances`.  For example simplifying `↑(set.maps_to.restrict f s t h x)` now takes 3.3s instead of 7.2s.

For fun, we also export a `freeze_local_instances` tactic.