### PR TITLE
[Merged by Bors] - fix(279): fixes a vm environment cache not updating

### DIFF
--- a/tests/lean/vmo1.lean
+++ b/tests/lean/vmo1.lean
@@ -1,0 +1,5 @@
+meta def cheese : string := "edam"
+meta def fromage : string := "comte"
+#eval cheese
+attribute [vm_override fromage] cheese
+#eval cheese

--- a/tests/lean/vmo1.lean.expected.out
+++ b/tests/lean/vmo1.lean.expected.out
@@ -1,0 +1,2 @@
+"edam"
+"comte"

--- a/tests/lean/vmo2.lean
+++ b/tests/lean/vmo2.lean
@@ -1,0 +1,5 @@
+import .vmo1
+
+#eval cheese -- should be comte
+attribute [vm_override fromage] cheese
+#eval cheese -- should be comte

--- a/tests/lean/vmo2.lean.expected.out
+++ b/tests/lean/vmo2.lean.expected.out
@@ -1,0 +1,2 @@
+"comte"
+"comte"


### PR DESCRIPTION
fixes #279

I had to move a function down which ruins the diff somewhat.
The key change is at the end of the method where it adds
```
return module::add_and_perform(new_env, std::make_shared<vm_code_modification>(*d));
```
Which causes Lean to not cache that the vm implementation has changed.