### PR TITLE
[Merged by Bors] - fix(vm_override): indexes are not preserved across instances

### DIFF
--- a/src/library/tactic/vm_monitor.cpp
+++ b/src/library/tactic/vm_monitor.cpp
@@ -230,7 +230,7 @@ vm_obj vm_decl_args_info(vm_obj const & d) {
 }
 
 vm_obj vm_decl_override_idx(vm_obj const & d) {
-    if (optional<unsigned int> i = to_vm_decl(d).get_overridden()) {
+    if (optional<unsigned int> i = to_vm_decl(d).get_overridden_idx()) {
         return mk_vm_some(mk_vm_nat(*i));
     } else {
         return mk_vm_none();

--- a/src/library/vm/vm.h
+++ b/src/library/vm/vm.h
@@ -559,7 +559,8 @@ struct vm_decl_cell {
     optional<pos_info>    m_pos;
     optional<std::string> m_olean;
     /** If this declaration has been overridden using `@[vm_override]`, then this has the index of the override decalaration. */
-    optional<unsigned>    m_overridden;
+    optional<unsigned>    m_overridden_idx;
+
     union {
         struct {
             unsigned   m_code_size;
@@ -572,7 +573,7 @@ struct vm_decl_cell {
     vm_decl_cell(name const & n, unsigned idx, unsigned arity, vm_cfunction fn);
     vm_decl_cell(name const & n, unsigned idx, unsigned arity, unsigned code_sz, vm_instr const * code,
                  list<vm_local_info> const & args_info, optional<pos_info> const & pos,
-                 optional<unsigned> const & overridden,
+                 optional<unsigned> const & overridden_idx,
                  optional<std::string> const & olean);
     ~vm_decl_cell();
     void dealloc();
@@ -590,9 +591,9 @@ public:
         vm_decl(new vm_decl_cell(n, idx, arity, fn)) {}
     vm_decl(name const & n, unsigned idx, unsigned arity, unsigned code_sz, vm_instr const * code,
             list<vm_local_info> const & args_info, optional<pos_info> const & pos,
-            optional<unsigned> const & overridden = optional<unsigned>(),
+            optional<unsigned> const & overridden_idx = optional<unsigned>(),
             optional<std::string> const & olean = optional<std::string>()):
-        vm_decl(new vm_decl_cell(n, idx, arity, code_sz, code, args_info, pos, overridden, olean)) {}
+        vm_decl(new vm_decl_cell(n, idx, arity, code_sz, code, args_info, pos, overridden_idx, olean)) {}
     vm_decl(vm_decl const & s):m_ptr(s.m_ptr) { if (m_ptr) m_ptr->inc_ref(); }
     vm_decl(vm_decl && s):m_ptr(s.m_ptr) { s.m_ptr = nullptr; }
     ~vm_decl() { if (m_ptr) m_ptr->dec_ref(); }
@@ -620,7 +621,8 @@ public:
     vm_cfunction get_cfn() const { lean_assert(is_cfun()); return m_ptr->m_cfn; }
     list<vm_local_info> const & get_args_info() const { lean_assert(is_bytecode()); return m_ptr->m_args_info; }
     optional<pos_info> const & get_pos_info() const { lean_assert(is_bytecode()); return m_ptr->m_pos; }
-    optional<unsigned> const & get_overridden() const { lean_assert(m_ptr); return m_ptr->m_overridden; }
+    optional<unsigned> const & get_overridden_idx() const { lean_assert(m_ptr); return m_ptr->m_overridden_idx; }
+    bool is_overridden() const {lean_assert(m_ptr); return m_ptr->m_overridden_idx.has_value(); }
     optional<std::string> const & get_olean() const { lean_assert(is_bytecode()); return m_ptr->m_olean; }
 };
 


### PR DESCRIPTION
When VM_override was serialising a declaration, it was storing the
vm decl index of the override.
However there is no guarantee that the same decl will be given the
same index in different sessions, since indexes are not stored in the
olean.
Therefore when vm_code_modification is run it must serialise the
name of the override decl instead of the index.
I also renamed `get_overridden` to `get_overridden_idx`.