### PR TITLE
[Merged by Bors] - fix(init/core): lower precedence of unary `-`

### DIFF
--- a/library/init/core.lean
+++ b/library/init/core.lean
@@ -45,7 +45,7 @@ reserve infixl ` - `:65
 reserve infixl ` * `:70
 reserve infixl ` / `:70
 reserve infixl ` % `:70
-reserve prefix `-`:100
+reserve prefix `-`:75
 reserve infixr ` ^ `:80
 
 reserve infixr ` ∘ `:90  -- function composition

--- a/tests/lean/run/neg_precedence.lean
+++ b/tests/lean/run/neg_precedence.lean
@@ -1,0 +1,11 @@
+variables {α : Type} [has_neg α]
+variables [has_add α] [has_sub α] [has_mul α] [has_div α] [has_pow α α]
+variables (x y : α)
+
+example : - x + y = (- x) + y := rfl
+example : - x - y = (- x) - y := rfl
+-- `- (x * y)` and `- (x / y)` would also be fine,
+-- but breaks an annoyingly-large number of things in mathlib.
+example : - x * y = (- x) * y := rfl
+example : - x / y = (- x) / y := rfl
+example : - x ^ y = - (x ^ y) := rfl


### PR DESCRIPTION
This commit moves the precedence of unary `-` below that of `^`
so that `-a^n` parses as `-(a^n)` and not (as formerly) `(-a)^n`.

It would be reasonable to move `-` below `*` as well (so that
`-a*b` parses as `-(a*b)`) but this is surprisingly disruptive
to mathlib, because `∩` and `⊓` have the same precedence as `*`
and `-` is also used for set complement. So, at least for now,
we leave the relative precedence of `-` and `*` unchanged.