### PR TITLE
[Merged by Bors] - fix(src/CMakeLists): fix case of header files for building on case-sensitive filesystems

### DIFF
--- a/src/library/process.cpp
+++ b/src/library/process.cpp
@@ -12,7 +12,7 @@ Author: Jared Roesch
 
 #if defined(LEAN_WINDOWS) && !defined(LEAN_CYGWIN)
 #include <windows.h>
-#include <Fcntl.h>
+#include <fcntl.h>
 #include <io.h>
 #include <tchar.h>
 #include <stdio.h>

--- a/src/library/vm/vm_io.cpp
+++ b/src/library/vm/vm_io.cpp
@@ -40,9 +40,9 @@ Author: Leonardo de Moura
     #ifndef NOMINMAX
         #define NOMINMAX
     #endif
-    #include <Winsock2.h>
+    #include <winsock2.h>
     #include <windows.h>
-    #include <Fileapi.h>
+    #include <fileapi.h>
     #define UNIX_PATH_MAX 108
 
     typedef struct sockaddr_un {


### PR DESCRIPTION
Usually Windows uses case-insensitive file systems, instead GNU/Linux systems
usually employs case-sensitive file systems, and MinGW consistenly adopts
lowercase filenames for the headers.

Patch used in https://github.com/JuliaPackaging/Yggdrasil/pull/1103 to build LEAN with [BinaryBuilder](https://binarybuilder.org/)