### PR TITLE
[Merged by Bors] - feat(src/CMakeLists): use `BUILD_TESTING` to enable or disable building tests

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -455,7 +455,7 @@ function(add_exec_test name tgt)
     endif()
 endfunction()
 
-if(EMSCRIPTEN AND LEAN_EMSCRIPTEN_BUILD STREQUAL Main)
+if(NOT BUILD_TESTING OR (EMSCRIPTEN AND LEAN_EMSCRIPTEN_BUILD STREQUAL Main))
 # skip building standalone test binaries
 else()
 add_subdirectory(tests/util)
@@ -484,7 +484,7 @@ endif()
 
 endif()
 
-if(EMSCRIPTEN AND LEAN_EMSCRIPTEN_BUILD STREQUAL Test)
+if(NOT BUILD_TESTING OR (EMSCRIPTEN AND LEAN_EMSCRIPTEN_BUILD STREQUAL Main))
 # skip building tests for main files
 else()
 # Include style check


### PR DESCRIPTION
`BUILD_TESTING` is a variable automatically defined by
[`CTest`](https://cmake.org/cmake/help/v3.17/module/CTest.html) whose value can
be used to enable or disable the tests from the command line.

Patch used in https://github.com/JuliaPackaging/Yggdrasil/pull/1103 to build LEAN with [BinaryBuilder](https://binarybuilder.org/)