### PR TITLE
[Merged by Bors] - fix(src/CMakeLists): remove useless setting of `_GLIBCXX_USE_CXX11_ABI` with MinGW

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -162,12 +162,6 @@ else()
   message(WARNING "Disabling JSON support, compile server will not be available")
 endif()
 
-if(MINGW AND CMAKE_COMPILER_IS_GNUCXX)
-  # See https://github.com/leanprover/lean/issues/930#issuecomment-172555475
-  message(STATUS "Set _GLIBCXX_USE_CXX11_ABI = 0 for a system using MSYS2 + g++")
-  set(LEAN_EXTRA_CXX_FLAGS "${LEAN_EXTRA_CXX_FLAGS} -D_GLIBCXX_USE_CXX11_ABI=0")
-endif()
-
 if(NOT MULTI_THREAD)
   message(STATUS "Disabled multi-thread support, it will not be safe to run multiple threads in parallel")
   set(AUTO_THREAD_FINALIZATION OFF)


### PR DESCRIPTION
As explained in [this comment](https://github.com/leanprover/lean/issues/930#issuecomment-263053475),
forcing the value `_GLIBCXX_USE_CXX11_ABI` doesn't make any sense for what it
was originally introduced, and it's also useless: with this patch I can compile with
MinGW for both C++ string ABIs without problems.

Patch used in https://github.com/JuliaPackaging/Yggdrasil/pull/1103 to build LEAN with [BinaryBuilder](https://binarybuilder.org/)