### PR TITLE
[Merged by Bors] - feat(meta): additional constants

### DIFF
--- a/library/init/meta/expr.lean
+++ b/library/init/meta/expr.lean
@@ -246,6 +246,9 @@ meta constant expr.get_depth : expr → ℕ
     If `m` is not a metavariable then this is equivalent to `abstract_locals`.
  -/
 meta constant expr.mk_delayed_abstraction : expr → list name → expr
+/-- If the given expression is a delayed abstraction macro, return `some ls`
+where `ls` is a list of unique names of locals that will be abstracted. -/
+meta constant expr.get_delayed_abstraction_locals : expr → option (list name)
 
 /-- (reflected a) is a special opaque container for a closed `expr` representing `a`.
     It can only be obtained via type class inference, which will use the representation

--- a/library/init/meta/local_context.lean
+++ b/library/init/meta/local_context.lean
@@ -1,5 +1,5 @@
 prelude
-import init.meta.name init.meta.expr
+import init.meta.name init.meta.expr init.data.option.basic
 meta structure local_decl :=
 (unique_name : name)
 (pp_name : name)
@@ -8,26 +8,51 @@ meta structure local_decl :=
 (bi : binder_info)
 (idx : nat)
 
+meta def local_decl.to_expr : local_decl → expr
+| ⟨un, pn, y, _, bi, _⟩ := expr.local_const un pn bi y
+
 /-- A local context is a list of local constant declarations.
     Each metavariable in a metavariable context holds a local_context
     to declare which locals the metavariable is allowed to depend on. -/
 meta constant local_context : Type
+
 namespace local_context
+
 /-- The empty local context. -/
 meta constant empty : local_context
+
 /-- Add a new local constant to the lc. The new local has an unused unique_name. Fails when the type depends on local constants that are not present in the context.-/
 meta constant mk_local (pretty_name : name) (type : expr) (bi : binder_info) : local_context → option (expr × local_context)
+
 meta constant get_local_decl : name → local_context → option local_decl
+
 meta constant get_local : name → local_context → option expr
+
 meta constant is_subset : local_context → local_context → bool
+
 meta constant has_decidable_eq : decidable_eq local_context
 attribute [instance] has_decidable_eq
+
 meta constant fold {α : Type} (f : α → expr → α): α → local_context → α
-meta def to_list : local_context → list expr := list.reverse ∘ fold (λ acc e, e :: acc) []
+
+meta def to_list : local_context → list expr :=
+list.reverse ∘ fold (λ acc e, e :: acc) []
+
 meta def to_format : local_context → format := to_fmt ∘ to_list
+
 meta instance lc_has_to_format : has_to_format local_context := ⟨to_format⟩
+
 meta instance lc_has_le : has_le local_context := ⟨λ a b, local_context.is_subset a b⟩
+
 meta instance lc_dec_le : decidable_rel ((≤) : local_context → local_context → Prop) := infer_instance
+
 meta instance lc_has_emptyc : has_emptyc local_context := ⟨empty⟩
+
 meta instance lc_inhabited : inhabited local_context := ⟨empty⟩
+
+meta instance mem_expr_lc  : has_mem expr local_context :=
+⟨λ e lc, option.is_some $ get_local (expr.local_uniq_name e) lc⟩
+
+meta instance mem_expr_lc_dec {e : expr} {lc : local_context} : decidable (e ∈ lc) := infer_instance
+
 end local_context

--- a/library/init/meta/local_context.lean
+++ b/library/init/meta/local_context.lean
@@ -26,4 +26,8 @@ meta constant fold {α : Type} (f : α → expr → α): α → local_context �
 meta def to_list : local_context → list expr := list.reverse ∘ fold (λ acc e, e :: acc) []
 meta def to_format : local_context → format := to_fmt ∘ to_list
 meta instance lc_has_to_format : has_to_format local_context := ⟨to_format⟩
+meta instance lc_has_le : has_le local_context := ⟨λ a b, local_context.is_subset a b⟩
+meta instance lc_dec_le : decidable_rel ((≤) : local_context → local_context → Prop) := infer_instance
+meta instance lc_has_emptyc : has_emptyc local_context := ⟨empty⟩
+meta instance lc_inhabited : inhabited local_context := ⟨empty⟩
 end local_context

--- a/library/init/meta/local_context.lean
+++ b/library/init/meta/local_context.lean
@@ -1,5 +1,6 @@
 prelude
 import init.meta.name init.meta.expr init.data.option.basic
+
 meta structure local_decl :=
 (unique_name : name)
 (pp_name : name)
@@ -12,8 +13,8 @@ meta def local_decl.to_expr : local_decl → expr
 | ⟨un, pn, y, _, bi, _⟩ := expr.local_const un pn bi y
 
 /-- A local context is a list of local constant declarations.
-    Each metavariable in a metavariable context holds a local_context
-    to declare which locals the metavariable is allowed to depend on. -/
+Each metavariable in a metavariable context holds a local_context
+to declare which locals the metavariable is allowed to depend on. -/
 meta constant local_context : Type
 
 namespace local_context
@@ -21,7 +22,8 @@ namespace local_context
 /-- The empty local context. -/
 meta constant empty : local_context
 
-/-- Add a new local constant to the lc. The new local has an unused unique_name. Fails when the type depends on local constants that are not present in the context.-/
+/-- Add a new local constant to the lc. The new local has an unused unique_name.
+Fails when the type depends on local constants that are not present in the context.-/
 meta constant mk_local (pretty_name : name) (type : expr) (bi : binder_info) : local_context → option (expr × local_context)
 
 meta constant get_local_decl : name → local_context → option local_decl
@@ -40,19 +42,19 @@ list.reverse ∘ fold (λ acc e, e :: acc) []
 
 meta def to_format : local_context → format := to_fmt ∘ to_list
 
-meta instance lc_has_to_format : has_to_format local_context := ⟨to_format⟩
+meta instance : has_to_format local_context := ⟨to_format⟩
 
-meta instance lc_has_le : has_le local_context := ⟨λ a b, local_context.is_subset a b⟩
+meta instance : has_le local_context := ⟨λ a b, local_context.is_subset a b⟩
 
-meta instance lc_dec_le : decidable_rel ((≤) : local_context → local_context → Prop) := infer_instance
+meta instance : decidable_rel ((≤) : local_context → local_context → Prop) := infer_instance
 
-meta instance lc_has_emptyc : has_emptyc local_context := ⟨empty⟩
+meta instance : has_emptyc local_context := ⟨empty⟩
 
-meta instance lc_inhabited : inhabited local_context := ⟨empty⟩
+meta instance : inhabited local_context := ⟨empty⟩
 
-meta instance mem_expr_lc  : has_mem expr local_context :=
+meta instance : has_mem expr local_context :=
 ⟨λ e lc, option.is_some $ get_local (expr.local_uniq_name e) lc⟩
 
-meta instance mem_expr_lc_dec {e : expr} {lc : local_context} : decidable (e ∈ lc) := infer_instance
+meta instance {e : expr} {lc : local_context} : decidable (e ∈ lc) := infer_instance
 
 end local_context

--- a/library/init/meta/local_context.lean
+++ b/library/init/meta/local_context.lean
@@ -20,6 +20,8 @@ meta constant mk_local (pretty_name : name) (type : expr) (bi : binder_info) : l
 meta constant get_local_decl : name → local_context → option local_decl
 meta constant get_local : name → local_context → option expr
 meta constant is_subset : local_context → local_context → bool
+meta constant has_decidable_eq : decidable_eq local_context
+attribute [instance] has_decidable_eq
 meta constant fold {α : Type} (f : α → expr → α): α → local_context → α
 meta def to_list : local_context → list expr := list.reverse ∘ fold (λ acc e, e :: acc) []
 meta def to_format : local_context → format := to_fmt ∘ to_list

--- a/library/init/meta/local_context.lean
+++ b/library/init/meta/local_context.lean
@@ -13,6 +13,8 @@ meta structure local_decl :=
     to declare which locals the metavariable is allowed to depend on. -/
 meta constant local_context : Type
 namespace local_context
+/-- The empty local context. -/
+meta constant empty : local_context
 /-- Add a new local constant to the lc. The new local has an unused unique_name. Fails when the type depends on local constants that are not present in the context.-/
 meta constant mk_local (pretty_name : name) (type : expr) (bi : binder_info) : local_context → option (expr × local_context)
 meta constant get_local_decl : name → local_context → option local_decl

--- a/src/library/tactic/vm_local_context.cpp
+++ b/src/library/tactic/vm_local_context.cpp
@@ -62,6 +62,10 @@ vm_obj lc_is_subset(vm_obj const & lc1, vm_obj const & lc2) {
         .is_subset_of(to_local_context(lc2)));
 }
 
+vm_obj lc_has_decidable_eq(vm_obj const & lc1, vm_obj const & lc2) {
+    return mk_vm_bool(equal_locals(to_local_context(lc1), to_local_context(lc2)));
+}
+
 vm_obj lc_fold(vm_obj const &, vm_obj const & f0, vm_obj const & a0, vm_obj const & lc0) {
     vm_obj r0 = a0;
     to_local_context(lc0).for_each([&](local_decl const & ld) {
@@ -76,6 +80,7 @@ void initialize_vm_local_context() {
     DECLARE_VM_BUILTIN(name({"local_context", "get_local"}), lc_get_local);
     DECLARE_VM_BUILTIN(name({"local_context", "get_local_decl"}), lc_get_local_decl);
     DECLARE_VM_BUILTIN(name({"local_context", "is_subset"}), lc_is_subset);
+    DECLARE_VM_BUILTIN(name({"local_context", "has_decidable_eq"}), lc_has_decidable_eq);
     DECLARE_VM_BUILTIN(name({"local_context", "fold"}), lc_fold);
 }
 void finalize_vm_local_context() {

--- a/src/library/tactic/vm_local_context.cpp
+++ b/src/library/tactic/vm_local_context.cpp
@@ -34,6 +34,11 @@ vm_obj to_obj(local_decl const & ld) {
     return mk_vm_constructor(0, 6, args);
 }
 
+vm_obj lc_mk_empty() {
+    local_context lc;
+    return to_obj(lc);
+}
+
 vm_obj lc_mk_local_decl(vm_obj const & pn, vm_obj const & y, vm_obj const & bi, vm_obj const & lc) {
     local_context lctx = to_local_context(lc);
     expr h = lctx.mk_local_decl(to_name(pn), to_expr(y), to_binder_info(bi));
@@ -66,6 +71,7 @@ vm_obj lc_fold(vm_obj const &, vm_obj const & f0, vm_obj const & a0, vm_obj cons
 }
 
 void initialize_vm_local_context() {
+    DECLARE_VM_BUILTIN(name({"local_context", "empty"}),  lc_mk_empty);
     DECLARE_VM_BUILTIN(name({"local_context", "mk_local"}),  lc_mk_local_decl);
     DECLARE_VM_BUILTIN(name({"local_context", "get_local"}), lc_get_local);
     DECLARE_VM_BUILTIN(name({"local_context", "get_local_decl"}), lc_get_local_decl);

--- a/src/library/vm/vm_expr.cpp
+++ b/src/library/vm/vm_expr.cpp
@@ -506,6 +506,15 @@ vm_obj expr_mk_delayed_abstraction(vm_obj const & e, vm_obj const & ns) {
     return to_obj(mk_delayed_abstraction(to_expr(e), names));
 }
 
+vm_obj expr_get_delayed_abstraction_locals(vm_obj const & eo) {
+    expr e = to_expr(eo);
+    if (!is_delayed_abstraction(e)) { return mk_vm_none(); }
+    buffer<name> names;
+    buffer<expr> exprs;
+    get_delayed_abstraction_info(e, names, exprs);
+    return mk_vm_some(to_obj(names));
+}
+
 void initialize_vm_expr() {
     DECLARE_VM_BUILTIN(name({"expr", "var"}),              expr_var_intro);
     DECLARE_VM_BUILTIN(name({"expr", "sort"}),             expr_sort_intro);
@@ -571,7 +580,8 @@ void initialize_vm_expr() {
     DECLARE_VM_BUILTIN(name({"expr", "is_internal_cnstr"}), expr_is_internal_cnstr);
     DECLARE_VM_BUILTIN(name({"expr", "get_nat_value"}), expr_get_nat_value);
 
-    DECLARE_VM_BUILTIN(name({"expr", "mk_delayed_abstraction"}), expr_mk_delayed_abstraction);
+    DECLARE_VM_BUILTIN(name({"expr", "mk_delayed_abstraction"}),         expr_mk_delayed_abstraction);
+    DECLARE_VM_BUILTIN(name({"expr", "get_delayed_abstraction_locals"}), expr_get_delayed_abstraction_locals);
 }
 
 void finalize_vm_expr() {

--- a/tests/lean/type_context.lean
+++ b/tests/lean/type_context.lean
@@ -242,3 +242,6 @@ run_cmd do
         ),
         in_tmp_mode >>= guardb ∘ bnot
     )
+
+#eval to_bool $ local_context.empty = local_context.empty
+

--- a/tests/lean/type_context.lean.expected.out
+++ b/tests/lean/type_context.lean.expected.out
@@ -28,3 +28,4 @@ state:
 []
 [hi, there]
 [hi]
+tt


### PR DESCRIPTION
Add some more constants for working with local_context and expr.

- `expr.get_delayed_abstraction_locals`
- add an empty local context
- add decidable equality for local contexts
- Add newlines between items in local_context.lean
- Add instances for has_le, has_mem, has_emptyc, inhabited, decidable_mem, decidable_le to local_context.