### PR TITLE
[Merged by Bors] - fix(shell/server): do not cancel info queries, etc.

### DIFF
--- a/src/shell/server.h
+++ b/src/shell/server.h
@@ -81,8 +81,6 @@ class server : public module_vfs {
     std::unique_ptr<task_queue> m_tq;
     fs_module_vfs m_fs_vfs;
 
-    cancellation_token m_bg_task_ctok;
-
     template <class Msg>
     void send_msg(Msg const &);
 


### PR DESCRIPTION
If a second info request was sent to the server while the first one was still running, we used to cancel the first one.  This was always only a precaution to prevent high CPU usage.

Now that we're sending many info requests from various parts of the vscode extension to the server at the same time, this behavior is annoying because you get "interrupted" errors for no good reason.