### PR TITLE
feat(library/init/data/sum/basic): add projections out of sum

### DIFF
--- a/library/init/data/sum/basic.lean
+++ b/library/init/data/sum/basic.lean
@@ -12,10 +12,30 @@ notation α ⊕ β := sum α β
 
 universes u v
 
+namespace sum
+
 variables {α : Type u} {β : Type v}
 
-instance sum.inhabited_left [h : inhabited α] : inhabited (α ⊕ β) :=
-⟨sum.inl (default α)⟩
+instance inhabited_left [h : inhabited α] : inhabited (α ⊕ β) :=
+⟨inl (default α)⟩
 
-instance sum.inhabited_right [h : inhabited β] : inhabited (α ⊕ β) :=
-⟨sum.inr (default β)⟩
+instance inhabited_right [h : inhabited β] : inhabited (α ⊕ β) :=
+⟨inr (default β)⟩
+
+def get_left : α ⊕ β → option α
+| (inl a) := some a
+| _ := none
+
+def get_right : α ⊕ β → option β
+| (inr b) := some b
+| _ := none
+
+def is_left : α ⊕ β → bool
+| (inl _) := tt
+| (inr _) := ff
+
+def is_right : α ⊕ β → bool
+| (inl _) := ff
+| (inr _) := tt
+
+end sum


### PR DESCRIPTION
This commit adds

- `get_left : α ⊕ β → option α`
- `get_right : α ⊕ β → option β`
- `is_left : α ⊕ β → bool`
- `is_right : α ⊕ β → bool`