### PR TITLE
[Merged by Bors] - fix(extras/latex): deleted `eq` and changed `\nsubset` to `\not\subset`, same for `\nsupset`

### DIFF
--- a/extras/latex/lstlean.tex
+++ b/extras/latex/lstlean.tex
@@ -159,13 +159,13 @@ literate=
 
 {∩}{{\color{symbolcolor}\ensuremath{\cap}}}1
 {∪}{{\color{symbolcolor}\ensuremath{\cup}}}1
-{⊂}{{\color{symbolcolor}\ensuremath{\subseteq}}}1
+{⊂}{{\color{symbolcolor}\ensuremath{\subset}}}1
 {⊆}{{\color{symbolcolor}\ensuremath{\subseteq}}}1
-{⊄}{{\color{symbolcolor}\ensuremath{\nsubseteq}}}1
+{⊄}{{\color{symbolcolor}\ensuremath{\not\subset}}}1
 {⊈}{{\color{symbolcolor}\ensuremath{\nsubseteq}}}1
-{⊃}{{\color{symbolcolor}\ensuremath{\supseteq}}}1
+{⊃}{{\color{symbolcolor}\ensuremath{\supset}}}1
 {⊇}{{\color{symbolcolor}\ensuremath{\supseteq}}}1
-{⊅}{{\color{symbolcolor}\ensuremath{\nsupseteq}}}1
+{⊅}{{\color{symbolcolor}\ensuremath{\not\supset}}}1
 {⊉}{{\color{symbolcolor}\ensuremath{\nsupseteq}}}1
 {∈}{{\color{symbolcolor}\ensuremath{\in}}}1
 {∉}{{\color{symbolcolor}\ensuremath{\notin}}}1

--- a/extras/latex/lstlean.tex
+++ b/extras/latex/lstlean.tex
@@ -213,8 +213,6 @@ literate=
 
 {...}{{\ensuremath{\ldots}}}1
 
-{▸}{{\ensuremath{\triangleright}}}1
-
 {𝒳}{{\ensuremath{\mathcal{X}}}}1
 
 {⌊}{{\ensuremath{\lfloor}}}1


### PR DESCRIPTION
4 lines were changed to fix an issue with displaying the strict subset/supset symbols in a LaTeX file that uses lstlean.tex for typesetting Lean code.

Here is a testsubset.tex file that shows the problem:

\documentclass{article}
\usepackage[utf8x]{inputenc}
\usepackage{amssymb, upgreek}
\usepackage{color}
\definecolor{keywordcolor}{rgb}{0.7, 0.1, 0.1}   % red
\definecolor{commentcolor}{rgb}{0.4, 0.4, 0.4}   % grey
\definecolor{symbolcolor}{rgb}{0.0, 0.1, 0.6}    % blue
\definecolor{sortcolor}{rgb}{0.1, 0.5, 0.1}      % green
\definecolor{errorcolor}{rgb}{1, 0, 0}           % bright red
\definecolor{stringcolor}{rgb}{0.5, 0.3, 0.2}    % brown
\usepackage{listings}
\def\lstlanguagefiles{lstlean.tex}
\lstset{language=lean}

\title{Testing subset/supset PR}
\begin{document}
\maketitle
\begin{lstlisting}
Subset/supset symbols: ⊂ ⊆ ⊄ ⊈ ⊃ ⊇ ⊅ ⊉
\end{lstlisting}
The resulting PDF file should contain the same 8 subset/supset symbols as the input testsubset.tex file.

\noindent
(Before this PR is accepted, the output PDF displays \lstinline{⊆ ⊆ ⊈ ⊈ ⊇ ⊇ ⊉ ⊉}.)
\end{document}
