### PR TITLE
[Merged by Bors] - fix(library/vm/vm): handle exceptions in ts_clone

### DIFF
--- a/src/library/vm/vm.cpp
+++ b/src/library/vm/vm.cpp
@@ -453,7 +453,9 @@ struct ts_vm_obj::to_ts_vm_obj_fn {
         case vm_obj_kind::External:      r = visit_external(o); break;
         case vm_obj_kind::NativeClosure: r = visit_native_closure(o); break;
         }
-        m_objs.push_back(r.raw());
+        // Leak r so that the vm_obj destructor is never called.
+        // We use a different allocator here so it needs to be deallocated in ts_vm_obj::data::~data
+        m_objs.push_back(vm_obj(r).steal_ptr());
         m_cache.insert(mk_pair(o.raw(), r));
         return r;
     }


### PR DESCRIPTION
Fixes segfault in #349.  That segfault happened because a closure contained a `parser_state`, which is not serializable.  Upon serialization, the `ts_clone` function throws an exception.  However the `ts_vm_obj` constructor was not exception-safe.