### PR TITLE
[Merged by Bors] - feat(frontends/lean/scanner): add comment-like string blocks

### DIFF
--- a/src/frontends/lean/scanner.h
+++ b/src/frontends/lean/scanner.h
@@ -85,6 +85,7 @@ protected:
     void read_doc_block_core();
     token_kind read_doc_block();
     token_kind read_mod_doc_block();
+    token_kind read_string_block();
 
 public:
     scanner(std::istream & strm, char const * strm_name = nullptr);

--- a/src/frontends/lean/token_table.cpp
+++ b/src/frontends/lean/token_table.cpp
@@ -93,7 +93,7 @@ void init_token_table(token_table & t) {
          {"⟨", g_max_prec}, {"⟩", 0}, {"^", 0},
          {"//", 0}, {"|", 0}, {"with", 0}, {"without", 0}, {"..", 0}, {"...", 0}, {",", 0},
          {".", 0}, {":", 0}, {"!", 0}, {"calc", 0}, {":=", 0}, {"--", 0}, {"#", g_max_prec},
-         {"/-", 0}, {"/--", 0}, {"/-!", 0}, {"begin", g_max_prec}, {"using", 0},
+         {"/-", 0}, {"/--", 0}, {"/-!", 0}, {"/-\"", 0}, {"begin", g_max_prec}, {"using", 0},
          {"@@", g_max_prec}, {"@", g_max_prec},
          {"sorry", g_max_prec}, {"+", g_plus_prec}, {"->", g_arrow_prec}, {"<-", 0},
          {"match", 0}, {"^.", g_max_prec+1},

--- a/tests/lean/string_block.lean
+++ b/tests/lean/string_block.lean
@@ -1,0 +1,19 @@
+#check /-" foo "-/
+#check /-" /- foo -/ "-/
+#check /-" /-"" foo -/ "-/
+#check /-" /-"" foo -/ """-/
+#check /-" /-"" foo -/ "-""""-/++""
+
+#print /-"
+## Markdown heading
+
+String blocks are like comments:
+```lean
+/-- My declaration -/
+def my_declaration : string :=
+/-"
+  They can be nicely nested
+"-/
+```
+
+"-/

--- a/tests/lean/string_block.lean.expected.out
+++ b/tests/lean/string_block.lean.expected.out
@@ -1,0 +1,17 @@
+" foo " : string
+" /- foo -/ " : string
+" /-\"\" foo -/ " : string
+" /-\"\" foo -/ \"\"" : string
+" /-\"\" foo -/ \"-\"\"\"" ++ "" : string
+
+## Markdown heading
+
+String blocks are like comments:
+```lean
+/-- My declaration -/
+def my_declaration : string :=
+/-"
+  They can be nicely nested
+"-/
+```
+


### PR DESCRIPTION
Fixes #351.

```lean
def my_string := /-"
## Markdown heading

String blocks are like comments:
``lean
/-- My declaration -/
def my_declaration : string :=
/-"
  They can be nicely nested
"-/
``
"-/

```