### PR TITLE
[Merged by Bors] - fix(frontends/lean/tactic_notation): support `sorry #`

### DIFF
--- a/src/frontends/lean/tactic_notation.cpp
+++ b/src/frontends/lean/tactic_notation.cpp
@@ -190,7 +190,12 @@ static expr parse_interactive_tactic(parser & p, name const & decl_name, name co
             }
             while (p.curr_lbp() >= get_max_prec()) {
                 p.check_break_before();
+                auto pos = p.pos();
                 args.push_back(p.parse_expr(get_max_prec()));
+                if (p.pos() == pos) {
+                    // parse_expr does not necessarily consume input if there is a syntax error
+                    break;
+                }
             }
             p.check_break_before();
         } catch (break_at_pos_exception &) {

--- a/tests/lean/sorry_hash.lean
+++ b/tests/lean/sorry_hash.lean
@@ -1,0 +1,11 @@
+example : true :=
+begin
+sorry #, -- broken
+end
+
+example : true := by { sorry # } -- broken
+
+example : true := begin { sorry # } end -- broken
+
+example : true := by trivial
+#che

--- a/tests/lean/sorry_hash.lean.expected.out
+++ b/tests/lean/sorry_hash.lean.expected.out
@@ -1,0 +1,33 @@
+sorry_hash.lean:3:6: error: invalid expression
+sorry_hash.lean:4:0: error: sync
+sorry_hash.lean:3:0: error: don't know how to synthesize placeholder
+context:
+⊢ Type ?
+sorry_hash.lean:6:29: error: invalid expression
+sorry_hash.lean:8:0: error: sync
+sorry_hash.lean:6:23: error: don't know how to synthesize placeholder
+context:
+⊢ Type ?
+sorry_hash.lean:8:0: error: don't know how to synthesize placeholder
+context:
+⊢ Type ?
+sorry_hash.lean:8:32: error: invalid expression
+sorry_hash.lean:8:36: error: sync
+sorry_hash.lean:10:0: error: sync
+sorry_hash.lean:8:26: error: don't know how to synthesize placeholder
+context:
+⊢ Type ?
+sorry_hash.lean:8:36: error: don't know how to synthesize placeholder
+context:
+⊢ Type ?
+sorry_hash.lean:10:0: error: don't know how to synthesize placeholder
+context:
+⊢ Type ?
+sorry_hash.lean:10:0: error: don't know how to synthesize placeholder
+context:
+⊢ Type ?
+sorry_hash.lean:11:0: error: invalid expression
+sorry_hash.lean:10:21: error: don't know how to synthesize placeholder
+context:
+⊢ Type ?
+sorry_hash.lean:11:0: error: command expected


### PR DESCRIPTION
To pacify the human fuzzers on Zulip:
https://leanprover.zulipchat.com/#narrow/stream/113488-general/topic/memory.20bug.3F

The error messages are far from helpful, but at least it fails quickly.