### PR TITLE
[Merged by Bors] - feat(widget): component.with_effects

### DIFF
--- a/library/init/meta/widget/basic.lean
+++ b/library/init/meta/widget/basic.lean
@@ -171,11 +171,16 @@ inductive mouse_event_kind
 | on_mouse_enter
 | on_mouse_leave
 
-@[derive decidable_eq]
-inductive mouse_capture_state
-| outside
-| immediate
-| child
+/-- An effect is an action at the root of the widget component hierarchy
+and can give instructions to the editor to perform some task. -/
+meta inductive effect : Type
+| insert_text (text : string)
+| reveal_position (file_name : option string) (p : pos)
+| highlight_position (file_name : option string) (p : pos)
+| clear_highlighting
+| custom (key : string) (value : string)
+
+meta def effects := list effect
 
 meta mutual inductive component, html, attr
 
@@ -203,6 +208,10 @@ with component : Type → Type → Type
      (props_changed : Props → Props → State → State)
      (update : Props → State → InnerAction → State × option Action)
      : component (State × Props) InnerAction → component Props Action
+| with_effects
+     {Props Action : Type}
+     (emit : Props → Action → effects)
+     : component Props Action → component Props Action
 
 with html : Type → Type
 | element      {α : Type} (tag : string) (attrs : list (attr α)) (children : list (html α)) : html α
@@ -353,14 +362,14 @@ end widget
 namespace tactic
 
 /-- Same as `tactic.save_info_thunk` except saves a widget to be displayed by a compatible infoviewer. -/
-meta constant save_widget : pos → widget.component tactic_state string → tactic unit
+meta constant save_widget : pos → widget.component tactic_state empty → tactic unit
 
 /-- Outputs a widget trace position at the given position. -/
-meta constant trace_widget_at (p : pos) (w : widget.component tactic_state string)
+meta constant trace_widget_at (p : pos) (w : widget.component tactic_state empty)
      (text := "(widget)") : tactic unit
 
 /-- Outputs a widget trace position at the current default trace position. -/
-meta def trace_widget (w : widget.component tactic_state string) (text := "(widget)") : tactic unit :=
+meta def trace_widget (w : widget.component tactic_state empty) (text := "(widget)") : tactic unit :=
 do p ← get_trace_msg_pos, trace_widget_at p w text
 
 end tactic

--- a/library/init/meta/widget/html_cmd.lean
+++ b/library/init/meta/widget/html_cmd.lean
@@ -15,14 +15,14 @@ open interactive
 open tactic
 open widget
 
-/-- Accepts terms with the type `component tactic_state string` or `html empty` and
+/-- Accepts terms with the type `component tactic_state empty` or `html empty` and
 renders them interactively. -/
 @[user_command]
 meta def show_widget_cmd (x : parse $ tk "#html") : parser unit := do
   ⟨l,c⟩ ← cur_pos,
   y ← parser.pexpr,
   comp ← parser.of_tactic ((do
-    tactic.eval_pexpr (component tactic_state string) y
+    tactic.eval_pexpr (component tactic_state empty) y
   ) <|> (do
     htm : html empty ← tactic.eval_pexpr (html empty) y,
     c : component unit empty ← pure $ component.stateless (λ _, [htm]),

--- a/library/init/meta/widget/interactive_expr.lean
+++ b/library/init/meta/widget/interactive_expr.lean
@@ -265,16 +265,16 @@ tc.stateless (λ lc, do
   pure [c]
 )
 
-meta def tactic_render : tc unit string :=
+meta def tactic_render : tc unit empty :=
 component.ignore_action $ tactic_view_component show_local_collection_component show_type_component
 
-meta def tactic_state_widget : component tactic_state string :=
+meta def tactic_state_widget : component tactic_state empty :=
 tc.to_component tactic_render
 
 /--
 Widget used to display term-proof goals.
 -/
-meta def term_goal_widget : component tactic_state string :=
+meta def term_goal_widget : component tactic_state empty :=
 (tactic_view_term_goal show_local_collection_component show_type_component).to_component
 
 end widget

--- a/src/frontends/lean/info_manager.cpp
+++ b/src/frontends/lean/info_manager.cpp
@@ -168,6 +168,8 @@ void widget_info::update(json const & message, json & record) {
     lock_guard<mutex> _(m_mutex);
     vm_state S(m_env, options());
     scope_vm_state scope(S);
+    widget_context wc;
+    set_global_widget_context(&wc);
     unsigned handler_idx = message["handler"]["h"];
     json j_route = message["handler"]["r"]; // an array with the root index at the _back_.
     list<unsigned> route; // now root index is at the _front_.
@@ -193,9 +195,15 @@ void widget_info::update(json const & message, json & record) {
         record["widget"]["line"] = m_pos.first;
         record["widget"]["column"] = m_pos.second;
         record["widget"]["id"] = m_id;
-        if (result) {
-            record["status"] = "edit";
-            record["action"] = to_string(*result);
+        if (!wc.m_effects.empty()) {
+            json j_effects = json::array();
+            for (auto effect : wc.m_effects) {
+                get_effects(effect, j_effects);
+            }
+            record["effects"] = j_effects;
+        }
+        if (result) { // should never happen
+            lean_unreachable();
         } else {
             record["status"] = "success";
         }

--- a/src/frontends/lean/info_manager.cpp
+++ b/src/frontends/lean/info_manager.cpp
@@ -169,7 +169,6 @@ void widget_info::update(json const & message, json & record) {
     vm_state S(m_env, options());
     scope_vm_state scope(S);
     widget_context wc;
-    set_global_widget_context(&wc);
     unsigned handler_idx = message["handler"]["h"];
     json j_route = message["handler"]["r"]; // an array with the root index at the _back_.
     list<unsigned> route; // now root index is at the _front_.
@@ -190,7 +189,7 @@ void widget_info::update(json const & message, json & record) {
         throw exception("expecting arg_type to be either 'unit' or 'string' but was '" + arg_type + "'");
     }
     try {
-        optional<vm_obj> result = c->handle_event(route, handler_idx, vm_args);
+        optional<vm_obj> result = c->handle_event(route, handler_idx, vm_args, wc);
         record["widget"]["html"] = to_json();
         record["widget"]["line"] = m_pos.first;
         record["widget"]["column"] = m_pos.second;

--- a/src/frontends/lean/widget.cpp
+++ b/src/frontends/lean/widget.cpp
@@ -12,6 +12,7 @@ Author: E.W.Ayers
 #include "library/vm/vm_option.h"
 #include "library/vm/vm_string.h"
 #include "library/vm/vm_list.h"
+#include "library/vm/vm_pos_info.h"
 #include "util/list.h"
 #include "frontends/lean/widget.h"
 #include "frontends/lean/json.h"
@@ -28,21 +29,28 @@ enum component_idx {
     map_props = 2,
     with_should_update = 3,
     with_state = 4,
-    // with_effects
+    with_effects = 5,
     // with_mouse
     // with_task
 };
 enum html_idx {
-    element = 5,
-    of_string = 6,
-    of_component = 7
+    element = 6,
+    of_string = 7,
+    of_component = 8
 };
 enum attr_idx {
-    val = 8,
-    mouse_event = 9,
-    style = 10,
-    tooltip = 11,
-    text_change_event = 12
+    val = 9,
+    mouse_event = 10,
+    style = 11,
+    tooltip = 12,
+    text_change_event = 13
+};
+enum effect_idx {
+    insert_text = 0,
+    reveal_position = 1,
+    highlight_position = 2,
+    clear_highlighting = 3,
+    custom = 4,
 };
 
 std::atomic_uint g_fresh_component_instance_id;
@@ -180,6 +188,30 @@ struct stateful_hook : public hook_cell {
     stateful_hook(vm_obj const & init, vm_obj const & pc, vm_obj const & update) : m_init(init), m_props_changed(pc), m_update(update) {}
 };
 
+struct effects_hook : public hook_cell {
+    ts_vm_obj const m_emit;
+    optional<ts_vm_obj> m_props;
+    effects_hook(vm_obj const & emit): m_emit(emit) {}
+    void initialize(vm_obj const & props) override {
+        m_props = optional<ts_vm_obj>(props);
+    }
+    optional<vm_obj> action(vm_obj const & action) override {
+        lean_assert(m_props);
+        vm_obj es = invoke(m_emit.to_vm_obj(), (*m_props).to_vm_obj(), action);
+        get_global_widget_context()->m_effects.push_back(es);
+        return optional<vm_obj>(action);
+    }
+};
+
+LEAN_THREAD_PTR(widget_context, g_context);
+widget_context * get_global_widget_context() {
+    lean_assert(g_context);
+    return g_context;
+}
+void set_global_widget_context(widget_context * wc) {
+    g_context = wc;
+}
+
 component_instance::component_instance(vm_obj const & component, vm_obj const & props, list<unsigned> const & route):
   m_props(props), m_route(route) {
     m_id = g_fresh_component_instance_id.fetch_add(1) + 1;
@@ -204,6 +236,10 @@ component_instance::component_instance(vm_obj const & component, vm_obj const & 
             case component_idx::with_state:
                 m_hooks.push_back(hook(new stateful_hook(cfield(c, 0), cfield(c, 1), cfield(c, 2))));
                 c = cfield(c, 3);
+                break;
+            case component_idx::with_effects:
+                m_hooks.push_back(hook(new effects_hook(cfield(c, 0))));
+                c = cfield(c, 1);
                 break;
             default:
                 lean_unreachable();
@@ -476,6 +512,68 @@ std::vector<vdom> render_html_list(vm_obj const & htmls, std::vector<component_i
     }
     return elements;
 }
+
+json to_file_name(vm_obj const & a) {
+    if (is_none(a)) {
+        return nullptr;
+    } else {
+        return to_string(get_some_value(a));
+    }
+}
+
+void get_effects(vm_obj const & o_effects, json & result) {
+    buffer<vm_obj> effects;
+    vm_obj l = o_effects;
+    while (!is_simple(l)) {
+        effects.push_back(head(l));
+        l = tail(l);
+    }
+    for (auto e : effects) {
+        switch (cidx(e)) {
+            case effect_idx::insert_text: {
+                result.push_back({
+                    {"kind", "insert_text"},
+                    {"text", to_string(cfield(e, 0))}
+                });
+                break;
+            } case effect_idx::reveal_position: {
+                auto pos = to_pos_info(cfield(e, 1));
+               result.push_back({
+                    {"kind", "reveal_position"},
+                    {"file_name", to_file_name(cfield(e, 0))},
+                    {"line", pos.first},
+                    {"column", pos.second}
+                });
+                break;
+            } case effect_idx::highlight_position: {
+                auto pos = to_pos_info(cfield(e, 1));
+                result.push_back({
+                    {"kind", "highlight_position"},
+                    {"file_name", to_file_name(cfield(e, 0))},
+                    {"line", pos.first},
+                    {"column", pos.second}
+                });
+                break;
+            } case effect_idx::clear_highlighting: {
+                result.push_back({
+                    {"kind", "clear_highlighting"}
+                });
+                break;
+            } case effect_idx::custom: {
+                result.push_back({
+                    {"kind", "custom"},
+                    {"key", to_string(cfield(e, 0))},
+                    {"value", to_string(cfield(e, 1))}
+                });
+                break;
+            } default: {
+                lean_unreachable();
+            }
+        }
+    }
+}
+
+
 
 void initialize_widget() {}
 

--- a/src/frontends/lean/widget.h
+++ b/src/frontends/lean/widget.h
@@ -144,6 +144,9 @@ vdom render_element(vm_obj const & elt, std::vector<component_instance*> & compo
 vdom render_html(vm_obj const & html, std::vector<component_instance*> & components, event_handlers & handlers, list<unsigned> const & route);
 std::vector<vdom> render_html_list(vm_obj const & htmls, std::vector<component_instance*> & components, event_handlers & handlers, list<unsigned> const & route);
 
+/** Pushes to the given `result_array` array the effects from a given `widget.effects` object */
+void get_effects(vm_obj const & effects, json & result_array);
+
 void initialize_widget();
 void finalize_widget();
 
@@ -159,5 +162,13 @@ public:
     virtual throwable * clone() const { return new invalid_handler(); }
     virtual void rethrow() const { throw *this; }
 };
+
+struct widget_context {
+  std::vector<vm_obj> m_effects;
+  // [todo] tasks go here too.
+};
+
+widget_context * get_global_widget_context();
+void set_global_widget_context(widget_context * wc);
 
 }

--- a/tests/lean/widget/widget1.lean
+++ b/tests/lean/widget/widget1.lean
@@ -59,7 +59,7 @@ meta def todo_list (α : Type) [inhabited α] [decidable_eq α] [has_show_html �
                                     ["+"]
                                 ])]]])
 
-meta def string_todo_list : component tactic_state string :=
+meta def string_todo_list : component tactic_state empty :=
 component.map_action (λ (o : empty), empty.rec (λ _, _) o) $ component.map_props (λ p, ()) $
 todo_list string ["make some tasks", "delete some tasks"]
 

--- a/tests/lean/widget/widget3.lean
+++ b/tests/lean/widget/widget3.lean
@@ -9,7 +9,7 @@ widget.component.stateful
   (λ p ls x, (ls,none))
   (λ p ss, [h "div" [] [html.of_string $ to_string p ++ to_string message ++ to_string ss], button "asdf" ()])
 
-meta def qwerty_c : component tactic_state string :=
+meta def qwerty_c : component tactic_state empty :=
 widget.component.stateful
   unit
   nat

--- a/tests/lean/widget/widget_effects.input
+++ b/tests/lean/widget/widget_effects.input
@@ -1,0 +1,4 @@
+{"seq_num": 0, "command": "sync", "file_name": "widget_effects.lean"}
+{"seq_num": 45, "command": "info", "file_name": "widget_effects.lean", "line": 16, "column": 2}
+{"seq_num": 66, "command": "get_widget", "file_name": "widget_effects.lean", "line": 16, "column": 0, "id": 75}
+{"seq_num": 47, "command" : "widget_event", "handler" : {"h":0, "r" : [75]}, "file_name": "widget_effects.lean", "line": 16, "column": 0, "id": 75, "args" : { "type" : "unit"}}

--- a/tests/lean/widget/widget_effects.input.expected.out
+++ b/tests/lean/widget/widget_effects.input.expected.out
@@ -1,0 +1,5 @@
+{"msgs":[{"caption":"trace output","file_name":"widget_effects.lean","pos_col":0,"pos_line":16,"severity":"information","text":"successfully rendered widget\n"}],"response":"all_messages"}
+{"message":"file invalidated","response":"ok","seq_num":0}
+{"record":{"widget":{"column":0,"id":75,"line":16}},"response":"ok","seq_num":45}
+{"response":"ok","seq_num":66,"widget":{"column":0,"html":{"c":["0",{"a":null,"c":["+"],"e":{"onClick":{"h":0,"r":[75]}},"t":"button"}]},"id":75,"line":16}}
+{"record":{"effects":[{"column":14,"file_name":null,"kind":"reveal_position","line":60},{"kind":"insert_text","text":"hello"},{"key":"hello","kind":"custom","value":"world"},{"column":4,"file_name":"hello/world.lean","kind":"highlight_position","line":3},{"kind":"clear_highlighting"},{"kind":"clear_highlighting"},{"kind":"clear_highlighting"}],"status":"success","widget":{"column":0,"html":{"c":["1",{"a":null,"c":["+"],"e":{"onClick":{"h":0,"r":[75]}},"t":"button"}]},"id":75,"line":16}},"response":"ok","seq_num":47}

--- a/tests/lean/widget/widget_effects.lean
+++ b/tests/lean/widget/widget_effects.lean
@@ -1,0 +1,70 @@
+
+open widget
+meta def effect_c : component tactic_state empty :=
+widget.component.with_state unit nat (λ _, 0) (λ _ _ x, x) (λ _ x _, (x+1,none))
+$ widget.component.with_effects (λ _ _, [
+    effect.reveal_position none (pos.mk 60 14),
+    effect.insert_text "hello",
+    effect.custom "hello" "world",
+    effect.highlight_position (some "hello/world.lean") ⟨3,4⟩,
+    effect.clear_highlighting,
+    effect.clear_highlighting,
+    effect.clear_highlighting
+  ])
+$ widget.component.pure (λ ⟨s,p⟩, [to_string s, button "+" ()])
+
+#html effect_c
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+-- should reveal this!
+
+
+
+
+
+
+
+
+
+


### PR DESCRIPTION
supercedes #361 

with this PR, the user can attach a `with_effects` hook to a component and cause side-effects in vscode when an action is performed, currently supported are;
- highlighting parts of the doc,
- revealing a location (eg go to definition)
- inserting text above the cursor position.
- also a 'custom' effect for prototyping new effects

It should be fairly straightforward to add new effects if they are needed.

see also https://github.com/leanprover/vscode-lean/pull/193

