### PR TITLE
[Merged by Bors] - feat(widget): add 'copy text' effect.

### DIFF
--- a/library/init/meta/widget/basic.lean
+++ b/library/init/meta/widget/basic.lean
@@ -178,6 +178,7 @@ meta inductive effect : Type
 | reveal_position (file_name : option string) (p : pos)
 | highlight_position (file_name : option string) (p : pos)
 | clear_highlighting
+| copy_text (text : string)
 | custom (key : string) (value : string)
 
 meta def effects := list effect

--- a/src/frontends/lean/widget.cpp
+++ b/src/frontends/lean/widget.cpp
@@ -50,7 +50,8 @@ enum effect_idx {
     reveal_position = 1,
     highlight_position = 2,
     clear_highlighting = 3,
-    custom = 4,
+    copy_text = 4,
+    custom = 5
 };
 
 std::atomic_uint g_fresh_component_instance_id;
@@ -548,6 +549,12 @@ void get_effects(vm_obj const & o_effects, json & result) {
             } case effect_idx::clear_highlighting: {
                 result.push_back({
                     {"kind", "clear_highlighting"}
+                });
+                break;
+            } case effect_idx::copy_text: {
+                result.push_back({
+                    {"kind", "copy_text"},
+                    {"text", to_string(cfield(e, 0))}
                 });
                 break;
             } case effect_idx::custom: {


### PR DESCRIPTION
For implementing copying text to the clipboard. Saves user needing to do it by inserting the text as a comment first.