### PR TITLE
[Merged by Bors] - feat(library/init/logic): mark dif_ctx_congr as @[congr]

### DIFF
--- a/library/init/logic.lean
+++ b/library/init/logic.lean
@@ -924,6 +924,7 @@ match h with
 | (is_false hnc) := rfl
 end
 
+@[congr]
 lemma dif_ctx_congr {α : Sort u} {b c : Prop} [dec_b : decidable b] [dec_c : decidable c]
                     {x : b → α} {u : c → α} {y : ¬b → α} {v : ¬c → α}
                     (h_c : b ↔ c)


### PR DESCRIPTION
mathlib still compiles, and we can simplify inside the condition of a `dite`:

```
inductive A (α : Type)
| mk : α → A

@[instance] axiom classical {α : Type} : decidable_eq α

example {α : Type} (a b : α) :
  (if h : A.mk a = A.mk b then true else false) ↔ (if h : a = b then true else false) :=
begin
  simp, -- fails
end

attribute [congr] dif_ctx_congr

example {α : Type} (a b : α) :
  (if h : A.mk a = A.mk b then true else false) ↔ (if h : a = b then true else false) :=
begin
  simp, -- succeeds
end
```

The example where I wanted this to work actually using the hypothesis `h` in the branches, and it now works fine.