### PR TITLE
[Merged by Bors] - fix(library/type_context): reuse type-class cache

### DIFF
--- a/tests/lean/tc_caching.lean
+++ b/tests/lean/tc_caching.lean
@@ -1,0 +1,7 @@
+set_option trace.type_context_cache true
+set_option trace.class_instances true
+
+-- The following declaration should only do two type class searches, and each
+-- only once: `has_one ℕ` and `has_add ℕ`
+def foo : combinator.K ℕ (1 + 1 + 1) :=
+show ℕ, from 1 + 1 + 1

--- a/tests/lean/tc_caching.lean.expected.out
+++ b/tests/lean/tc_caching.lean.expected.out
@@ -1,0 +1,74 @@
+[type_context_cache] flushing instance cache
+[type_context_cache] flushing instance cache
+[type_context_cache] flushing instance cache
+[type_context_cache] flushing instance cache
+[type_context_cache] flushing instance cache
+[type_context_cache] flushing instance cache
+[type_context_cache] flushing instance cache
+[type_context_cache] flushing instance cache
+[type_context_cache] incompatible local instances, flushing instance cache
+[type_context_cache] reusing instance cache
+[type_context_cache] reusing instance cache
+[type_context_cache] flushing instance cache
+[type_context_cache] reusing instance cache
+[type_context_cache] reusing instance cache
+[type_context_cache] reusing instance cache
+[type_context_cache] reusing instance cache
+[type_context_cache] reusing instance cache
+[type_context_cache] reusing instance cache
+[type_context_cache] reusing instance cache
+[type_context_cache] reusing instance cache
+[type_context_cache] reusing instance cache
+[type_context_cache] flushing instance cache
+[type_context_cache] flushing instance cache
+[type_context_cache] flushing instance cache
+[type_context_cache] flushing instance cache
+[type_context_cache] flushing instance cache
+[type_context_cache] flushing instance cache
+[type_context_cache] incompatible local instances, flushing instance cache
+[class_instances]  class-instance resolution trace
+[class_instances] (0) ?x_0 : has_one ℕ := native.float.has_one
+failed is_def_eq
+[class_instances] (0) ?x_0 : has_one ℕ := unsigned.has_one
+failed is_def_eq
+[class_instances] (0) ?x_0 : has_one ℕ := @fin.has_one ?x_1
+failed is_def_eq
+[class_instances] (0) ?x_0 : has_one ℕ := int.has_one
+failed is_def_eq
+[class_instances] (0) ?x_0 : has_one ℕ := nat.has_one
+[class_instances] caching instance for has_one ℕ
+nat.has_one
+[type_context_cache] reusing instance cache
+[class_instances] cached instance for has_one ℕ
+nat.has_one
+[type_context_cache] reusing instance cache
+[class_instances] cached instance for has_one ℕ
+nat.has_one
+[type_context_cache] reusing instance cache
+[class_instances]  class-instance resolution trace
+[class_instances] (0) ?x_0 : has_add ℕ := native.float.has_add
+failed is_def_eq
+[class_instances] (0) ?x_0 : has_add ℕ := unsigned.has_add
+failed is_def_eq
+[class_instances] (0) ?x_0 : has_add ℕ := @fin.has_add ?x_1
+failed is_def_eq
+[class_instances] (0) ?x_0 : has_add ℕ := int.has_add
+failed is_def_eq
+[class_instances] (0) ?x_0 : has_add ℕ := options.has_add
+failed is_def_eq
+[class_instances] (0) ?x_0 : has_add ℕ := nat.has_add
+[class_instances] caching instance for has_add ℕ
+nat.has_add
+[type_context_cache] reusing instance cache
+[class_instances] cached instance for has_add ℕ
+nat.has_add
+[class_instances] cached instance for has_add ℕ
+nat.has_add
+[class_instances] cached instance for has_add ℕ
+nat.has_add
+[class_instances] cached instance for has_one ℕ
+nat.has_one
+[class_instances] cached instance for has_one ℕ
+nat.has_one
+[class_instances] cached instance for has_one ℕ
+nat.has_one


### PR DESCRIPTION
This used to synthesize `has_one ℕ` more than one time:
```
def foo : combinator.K ℕ (1 + 1 + 1) :=
show ℕ, from 1 + 1 + 1
```