### PR TITLE
[Merged by Bors] - fix(library/init/meta/tactic): drop non-local-constant exprs from cases output

### DIFF
--- a/library/init/meta/tactic.lean
+++ b/library/init/meta/tactic.lean
@@ -584,7 +584,10 @@ meta constant induction (h : expr) (ns : list name := []) (rec : option name := 
    number of constructors. Some goals may be discarded when the indices to not match.
    See `induction` for information on the list of substitutions.
 
-   The `cases` tactic is implemented using this one, and it relaxes the restriction of `h`. -/
+   The `cases` tactic is implemented using this one, and it relaxes the restriction of `h`.
+
+   Note: The lists of new hypotheses for each new goal may contain expressions
+   that are not, in fact, local constants. These should be ignored. -/
 meta constant cases_core (h : expr) (ns : list name := []) (md := semireducible) : tactic (list (name × list expr × list (name × expr)))
 /-- Similar to cases tactic, but does not revert/intro/clear hypotheses. -/
 meta constant destruct (e : expr) (md := semireducible) : tactic unit
@@ -1416,6 +1419,14 @@ kdependencies e md >>= revert_lst
 meta def revert_kdeps (e : expr) (md := reducible) :=
 revert_kdependencies e md
 
+/-- Postprocess the output of `cases_core`. The third component of each tuple in
+the input list (the list of substitutions) is dropped. The second component
+(the list of new hypotheses) is filtered: any expression that isn't a local
+constant is dropped. This works around a bug in `cases_core`. -/
+meta def cases_postprocess (hs : list (name × list expr × list (name × expr)))
+  : list (name × list expr) :=
+hs.map $ λ ⟨n, hs, _⟩, (n, hs.filter (λ h, h.is_local_constant))
+
 /-- Similar to `cases_core`, but `e` doesn't need to be a hypothesis.
     Remark, it reverts dependencies using `revert_kdeps`.
 
@@ -1427,7 +1438,7 @@ revert_kdependencies e md
 -/
 meta def cases (e : expr) (ids : list name := []) (md := semireducible) (dmd := semireducible) : tactic (list (name × list expr)) :=
 if e.is_local_constant then
-  do r ← cases_core e ids md, return $ r.map (λ ⟨n, hs, _⟩, ⟨n, hs⟩)
+  do r ← cases_core e ids md, return $ cases_postprocess r
 else do
   n ← revert_kdependencies e dmd,
   x ← get_unused_name,
@@ -1441,7 +1452,7 @@ else do
   focus1 $ do
     r ← cases_core h ids md,
     hs' ← all_goals (intron' n),
-    return $ r.map₂ (λ ⟨n, hs, _⟩ hs', ⟨n, hs ++ hs'⟩) hs'
+    return $ cases_postprocess $ r.map₂ (λ ⟨n, hs, x⟩ hs', (n, hs ++ hs', x)) hs'
 
 /-- The same as `exact` except you can add proof holes. -/
 meta def refine (e : pexpr) : tactic unit :=

--- a/tests/lean/388.lean
+++ b/tests/lean/388.lean
@@ -1,0 +1,21 @@
+inductive trans_gen {α} (r : α → α → Prop) (a : α) : α → Prop
+| single {b} : r a b → trans_gen b
+| tail {b c} : trans_gen b → r b c → trans_gen c
+
+def uncurry {α β γ} (f : α → β → γ) (p : α × β) : γ :=
+f p.fst p.snd
+
+def curry {α β γ} (f : α × β → γ) (a : α) (b : β) : γ :=
+f (a, b)
+
+def foo
+  {α : Type}
+  {r : α × α → Prop}
+  {x : α × α}
+  (h : uncurry (trans_gen (curry r)) x) :
+  true :=
+begin
+  cases h,
+  case tail : a b c { trivial },
+  case single { trivial }
+end


### PR DESCRIPTION
The `case` tactic was getting confused because the list of "new hypotheses" returned by `cases_core` may contain exprs that are not, in fact, local constants. We add a post-processing step to drop these exprs.

fixes #388
fixes #345