### PR TITLE
[Merged by Bors] - fix(widget): fix vm env issue

### DIFF
--- a/src/frontends/lean/info_manager.cpp
+++ b/src/frontends/lean/info_manager.cpp
@@ -331,7 +331,7 @@ void info_manager::add_widget_goal_info(pos_info pos, vm_obj const & props, vm_o
 #ifdef LEAN_NO_INFO
     return;
 #endif
-    add_info(pos, mk_widget_goal_info(tactic::to_state(props).env(), pos, props, widget));
+    add_info(pos, mk_widget_goal_info(get_vm_state().env(), pos, props, widget));
 }
 
 
@@ -410,7 +410,7 @@ vm_obj tactic_save_info_thunk(vm_obj const & pos, vm_obj const & thunk, vm_obj c
     try {
         if (g_info_m) {
             auto _pos = to_pos_info(pos);
-            g_info_m->add_vm_obj_format_info(_pos, tactic::to_state(s).env(), thunk);
+            g_info_m->add_vm_obj_format_info(_pos, get_vm_state().env(), thunk);
         }
         return tactic::mk_success(tactic::to_state(s));
     } catch (exception & ex) {

--- a/tests/lean/widget/widget5.input
+++ b/tests/lean/widget/widget5.input
@@ -1,0 +1,3 @@
+{"seq_num": 0, "command": "sync", "file_name": "widget5.lean"}
+{"seq_num": 45, "command": "info", "file_name": "widget5.lean", "line": 3, "column": 3}
+{"seq_num": 1, "command": "get_widget", "file_name": "widget5.lean", "column":0,"id":15,"line":3}

--- a/tests/lean/widget/widget5.input.expected.out
+++ b/tests/lean/widget/widget5.input.expected.out
@@ -1,0 +1,4 @@
+{"msgs":[{"caption":"trace output","file_name":"widget5.lean","pos_col":0,"pos_line":3,"severity":"information","text":"successfully rendered widget\n"}],"response":"all_messages"}
+{"message":"file invalidated","response":"ok","seq_num":0}
+{"record":{"widget":{"column":0,"id":15,"line":3}},"response":"ok","seq_num":45}
+{"response":"ok","seq_num":1,"widget":{"column":0,"html":{"c":[{"a":{"style":{"color":"blue"}},"c":["hi"],"t":"p"}]},"id":15,"line":3}}

--- a/tests/lean/widget/widget5.lean
+++ b/tests/lean/widget/widget5.lean
@@ -1,0 +1,3 @@
+open tactic widget
+
+#html (component.pure $ λ _, [h "p" [attr.style [("color", "blue")]] ["hi"]])


### PR DESCRIPTION
Issue was that inline lambdas were added to environment but vm state
passed to widget renderer was older so would get lean_unreachable errors
when trying to get the decl of the lambda. Fixed by changing
`tactic::to_state(s).env()` to `get_vm_state().env()` in
`tactic_save_info_thunk` and `tactic_trace_widget_at`