### PR TITLE
[Merged by Bors] - fix(frontends/lean/brackets): support `{(1 : α)}` and `{(∘), (∘)}`

### DIFF
--- a/src/frontends/lean/brackets.cpp
+++ b/src/frontends/lean/brackets.cpp
@@ -226,13 +226,14 @@ expr parse_curly_bracket(parser & p, unsigned, expr const *, pos_info const & po
         parser::local_scope scope(p);
         parser::all_id_local_scope scope_assumption(p);
         e = parse_lparen(p, 0, NULL, pos); // parses the `expr ')'` part of the expression
-        if (p.curr_is_token(get_rcurly_tk())) {
-            // singleton `{ (...) }`
+        if (p.curr_is_token(get_bar_tk())) {
             p.next();
-            return mk_singleton(p, pos, e);
-        } else {
-            p.check_token_next(get_bar_tk(), "invalid set replacement notation, '|' expected");
             return parse_set_replacement(p, pos, e);
+        } else if (p.curr_is_token(get_comma_tk()) || p.curr_is_token(get_rcurly_tk())) {
+            return parse_fin_set(p, pos, p.patexpr_to_expr(e));
+        } else {
+            p.maybe_throw_error({"invalid set replacement notation, ',', '}', or `|` expected", p.pos()});
+            return mk_singleton(p, pos, p.patexpr_to_expr(e));
         }
     } else if (p.curr_is_token(get_period_tk())) {
         p.next();

--- a/tests/lean/brackets_parens.lean
+++ b/tests/lean/brackets_parens.lean
@@ -1,0 +1,4 @@
+variables {α : Type} [has_one α]
+#check {(1 : α)}
+#check {(1), (2), (3)}
+#check ({(∘), (∘)} : set ((ℕ → ℕ) → (ℕ → ℕ) → (ℕ → ℕ)))

--- a/tests/lean/brackets_parens.lean.expected.out
+++ b/tests/lean/brackets_parens.lean.expected.out
@@ -1,0 +1,3 @@
+{1} : ?M_1
+{1, 2, 3} : ?M_1
+{function.comp, function.comp} : set ((ℕ → ℕ) → (ℕ → ℕ) → ℕ → ℕ)


### PR DESCRIPTION
Fixes #419 and fixes #418.

Co-authored-by: Anne Baanen <vierkantor@vierkantor.com>