### PR TITLE
[Merged by Bors] - fix(init/meta/interactive): fix broken docstring

### DIFF
--- a/library/init/meta/interactive.lean
+++ b/library/init/meta/interactive.lean
@@ -150,6 +150,7 @@ a b : ℕ,
 h : a = b
 ⊢ b = a
 ```
+
 ```
 example : ∀ a b : nat, a = b → ∀ c, b = c → a = c :=
 begin


### PR DESCRIPTION
Right now the docstring rendering is broken for `introv`. I suspect it's due to the consecutive code blocks, so I added a blank line between them. Not tested so I don't know if this works. Also is this a bug in doc-gen/rendering of docs?

![image](https://user-images.githubusercontent.com/15098580/89730247-b7e9cf80-da6f-11ea-9527-6962d8727aa6.png)
