### PR TITLE
[Merged by Bors] - feat(frontends/lean/structure_cmd): add extends_priority option

### DIFF
--- a/src/frontends/lean/structure_cmd.cpp
+++ b/src/frontends/lean/structure_cmd.cpp
@@ -65,7 +65,14 @@ Author: Leonardo de Moura
 #define LEAN_DEFAULT_STRUCTURE_INTRO "mk"
 #endif
 
+#ifndef LEAN_DEFAULT_EXTENDS_PRIORITY
+#define LEAN_DEFAULT_EXTENDS_PRIORITY 100
+#endif
+
 namespace lean {
+// configuration option: priority used for instances produced by `extends`
+static name * g_extends_priority = nullptr;
+
 /** \brief Return the universe parameters, number of parameters and introduction rule for the given parent structure
 
     \pre is_structure_like(env, S) */
@@ -298,7 +305,7 @@ struct structure_cmd_fn {
         m_infer_result_universe    = false;
         m_inductive_predicate      = false;
         m_subobjects               = !p.get_options().get_bool("old_structure_cmd", false);
-        m_prio                     = get_default_priority(p.get_options());
+        m_prio                     = p.get_options().get_unsigned(*g_extends_priority, LEAN_DEFAULT_EXTENDS_PRIORITY);
         if (!meta.m_attrs.ok_for_inductive_type())
             throw exception("only attribute [class] accepted for structures");
     }
@@ -1361,5 +1368,7 @@ void register_structure_cmd(cmd_table & r) {
     add_cmd(r, cmd_info("structure",   "declare a new structure/record type", structure_cmd, false));
     add_cmd(r, cmd_info("class",       "declare a new class", class_cmd, false));
     register_bool_option("old_structure_cmd", false, "use old structures compilation strategy");
+    g_extends_priority = new name{"extends_priority"};
+    register_unsigned_option(*g_extends_priority, LEAN_DEFAULT_EXTENDS_PRIORITY, "priority for `extends` instances");
 }
 }

--- a/tests/lean/397c.lean.expected.out
+++ b/tests/lean/397c.lean.expected.out
@@ -1,6 +1,16 @@
 [class_instances]  class-instance resolution trace
-[class_instances] (0) ?x_0 : has_one α := @ring.to_has_one ?x_1 ?x_2
-[class_instances] (1) ?x_2 : ring α := _inst_1
+[class_instances] (0) ?x_0 : has_one α := native.float.has_one
+failed is_def_eq
+[class_instances] (0) ?x_0 : has_one α := unsigned.has_one
+failed is_def_eq
+[class_instances] (0) ?x_0 : has_one α := @fin.has_one ?x_1
+failed is_def_eq
+[class_instances] (0) ?x_0 : has_one α := int.has_one
+failed is_def_eq
+[class_instances] (0) ?x_0 : has_one α := nat.has_one
+failed is_def_eq
+[class_instances] (0) ?x_0 : has_one α := @ring.to_has_one ?x_2 ?x_3
+[class_instances] (1) ?x_3 : ring α := _inst_1
 [class_instances] caching instance for ring α
 _inst_1
 [class_instances] caching instance for has_one α

--- a/tests/lean/398c.lean.expected.out
+++ b/tests/lean/398c.lean.expected.out
@@ -1,6 +1,16 @@
 [class_instances]  class-instance resolution trace
-[class_instances] (0) ?x_0 : has_one α := @ring.to_has_one ?x_1 ?x_2
-[class_instances] (1) ?x_2 : ring α := _inst_1
+[class_instances] (0) ?x_0 : has_one α := native.float.has_one
+failed is_def_eq
+[class_instances] (0) ?x_0 : has_one α := unsigned.has_one
+failed is_def_eq
+[class_instances] (0) ?x_0 : has_one α := @fin.has_one ?x_1
+failed is_def_eq
+[class_instances] (0) ?x_0 : has_one α := int.has_one
+failed is_def_eq
+[class_instances] (0) ?x_0 : has_one α := nat.has_one
+failed is_def_eq
+[class_instances] (0) ?x_0 : has_one α := @ring.to_has_one ?x_2 ?x_3
+[class_instances] (1) ?x_3 : ring α := _inst_1
 [class_instances] caching instance for ring α
 _inst_1
 [class_instances] caching instance for has_one α

--- a/tests/lean/extends_priority.lean
+++ b/tests/lean/extends_priority.lean
@@ -1,0 +1,31 @@
+class A (α : Type)
+
+class B (α : Type) extends A α
+#print B.to_A
+
+section prio
+set_option extends_priority 37
+class C (α : Type) extends B α
+end prio
+#print C.to_B
+
+class D (α : Type) extends C α
+#print D.to_C
+
+
+set_option old_structure_cmd true
+
+
+class A' (α : Type)
+
+class B' (α : Type) extends A' α
+#print B'.to_A'
+
+section prio
+set_option extends_priority 37
+class C' (α : Type) extends B' α
+end prio
+#print C'.to_B'
+
+class D' (α : Type) extends C' α
+#print D'.to_C'

--- a/tests/lean/extends_priority.lean.expected.out
+++ b/tests/lean/extends_priority.lean.expected.out
@@ -1,0 +1,18 @@
+@[instance, priority 100, reducible]
+def B.to_A : Π {α : Type} [c : B α], A α :=
+λ (α : Type) [c : B α], [B.to_A c]
+@[instance, priority 37, reducible]
+def C.to_B : Π {α : Type} [c : C α], B α :=
+λ (α : Type) [c : C α], [C.to_B c]
+@[instance, priority 100, reducible]
+def D.to_C : Π {α : Type} [c : D α], C α :=
+λ (α : Type) [c : D α], [D.to_C c]
+@[instance, priority 100]
+def B'.to_A' : Π (α : Type) [s : B' α], A' α :=
+λ (α : Type) [s : B' α], A'.mk
+@[instance, priority 37]
+def C'.to_B' : Π (α : Type) [s : C' α], B' α :=
+λ (α : Type) [s : C' α], B'.mk
+@[instance, priority 100]
+def D'.to_C' : Π (α : Type) [s : D' α], C' α :=
+λ (α : Type) [s : D' α], C'.mk

--- a/tests/lean/out_param_proj.lean.expected.out
+++ b/tests/lean/out_param_proj.lean.expected.out
@@ -1,3 +1,3 @@
-@[instance, reducible]
+@[instance, priority 100, reducible]
 def module.to_add_comm_group : Π {α : Type u} {β : Type v} {_inst_1 : ring α} [c : module α β], add_comm_group β :=
 λ {α : Type u} (β : Type v) {_inst_1 : ring α} [c : module α β], [module.to_add_comm_group c]


### PR DESCRIPTION
This option controls the priority of instances produced by `extends`,
and is set to 100 by default.

See https://leanprover.zulipchat.com/#narrow/stream/113488-general/topic/default_extends_priority/near/206814398 for discussion.