### PR TITLE
[Merged by Bors] - chore(init/meta/interactive): use `guard_hyp h : t`

### DIFF
--- a/library/init/meta/interactive.lean
+++ b/library/init/meta/interactive.lean
@@ -1524,10 +1524,10 @@ meta def guard_target (p : parse texpr) : tactic unit :=
 do t ← target, guard_expr_eq t p
 
 /--
-`guard_hyp h := t` fails if the hypothesis `h` does not have type `t`.
+`guard_hyp h : t` fails if the hypothesis `h` does not have type `t`.
 We use this tactic for writing tests.
 -/
-meta def guard_hyp (n : parse ident) (p : parse $ tk ":=" *> texpr) : tactic unit :=
+meta def guard_hyp (n : parse ident) (p : parse $ tk ":" *> texpr) : tactic unit :=
 do h ← get_local n >>= infer_type, guard_expr_eq h p
 
 /--

--- a/tests/lean/rename.lean
+++ b/tests/lean/rename.lean
@@ -1,22 +1,22 @@
 example {α β} (a : α) (b : β) : unit :=
 begin
   rename a a',              -- rename-compatible syntax
-  guard_hyp a' := α,
+  guard_hyp a' : α,
 
   rename a' → a,            -- more suggestive syntax
-  guard_hyp a := α,
+  guard_hyp a : α,
 
   rename [a a', b b'],      -- parallel renaming
-  guard_hyp a' := α,
-  guard_hyp b' := β,
+  guard_hyp a' : α,
+  guard_hyp b' : β,
 
   rename [a' → a, b' → b],  -- ditto with alternative syntax
-  guard_hyp a := α,
-  guard_hyp b := β,
+  guard_hyp a : α,
+  guard_hyp b : β,
 
   rename [a → b, b → a],    -- renaming really is parallel
-  guard_hyp a := β,
-  guard_hyp b := α,
+  guard_hyp a : β,
+  guard_hyp b : α,
 
   rename b a,               -- shadowing is allowed (but guard_hyp doesn't like it)
 

--- a/tests/lean/run/1797.lean
+++ b/tests/lean/run/1797.lean
@@ -1,6 +1,6 @@
 example (n : nat) : true :=
 begin
   cases h : n with m,
-  { guard_hyp h := n = nat.zero, admit },
-  { guard_hyp h := n = nat.succ m, admit}
+  { guard_hyp h : n = nat.zero, admit },
+  { guard_hyp h : n = nat.succ m, admit}
 end

--- a/tests/lean/run/1804a.lean
+++ b/tests/lean/run/1804a.lean
@@ -8,7 +8,7 @@ include P
 example : false :=
 begin
   dsimp [_match_1] at P,
-  guard_hyp P := true,
+  guard_hyp P : true,
   admit
 end
 end
@@ -23,7 +23,7 @@ include P
 example : false :=
 begin
   dsimp [_match_1] at P,
-  guard_hyp P := true,
+  guard_hyp P : true,
   admit
 end
 end
@@ -44,7 +44,7 @@ include P
 example : false :=
 begin
   dsimp [_match_1] at P,
-  guard_hyp P := true,
+  guard_hyp P : true,
   admit
 end
 end
@@ -54,7 +54,7 @@ include Q
 example : false :=
 begin
   dsimp [_match_2] at Q,
-  guard_hyp Q := true,
+  guard_hyp Q : true,
   admit
 end
 end

--- a/tests/lean/run/1804b.lean
+++ b/tests/lean/run/1804b.lean
@@ -9,7 +9,7 @@ end
 example (a : nat) (h : a = foo 0) : a = 1 :=
 begin
   simp [foo] at h,
-  guard_hyp h := a = 1,
+  guard_hyp h : a = 1,
   exact h
 end
 
@@ -18,7 +18,7 @@ begin
   simp [foo] at h,
   simp [p] at h,
   simp [foo._match_1] at h,
-  guard_hyp h := a = 1,
+  guard_hyp h : a = 1,
   exact h
 end
 
@@ -27,14 +27,14 @@ begin
   simp [foo] at h,
   simp [p] at h,
   simp [foo] at h,
-  guard_hyp h := a = 1,
+  guard_hyp h : a = 1,
   exact h
 end
 
 example (a b : nat) (p : b = 0) (h : a = foo b) : a = 1 :=
 begin
   simp [foo, p] at h,
-  guard_hyp h := a = 1,
+  guard_hyp h : a = 1,
   exact h
 end
 

--- a/tests/lean/run/1805.lean
+++ b/tests/lean/run/1805.lean
@@ -1,20 +1,20 @@
 example (x y z x' y' z': ℕ)  (h : (x, y, z) = (x', y', z')) : false :=
 begin
   injection h,
-  guard_hyp h_1 := x = x',
-  guard_hyp h_2 := (y, z) = (y', z'),
+  guard_hyp h_1 : x = x',
+  guard_hyp h_2 : (y, z) = (y', z'),
   injection h_2,
-  guard_hyp h_3 := y = y',
-  guard_hyp h_4 := z = z',
+  guard_hyp h_3 : y = y',
+  guard_hyp h_4 : z = z',
   admit
 end
 
 example (x y z x' y' z': ℕ)  (h : (x, y, z) = (x', y', z')) : false :=
 begin
   injections,
-  guard_hyp h_1 := x = x',
-  guard_hyp h_2 := (y, z) = (y', z'),
-  guard_hyp h_3 := y = y',
-  guard_hyp h_4 := z = z',
+  guard_hyp h_1 : x = x',
+  guard_hyp h_2 : (y, z) = (y', z'),
+  guard_hyp h_3 : y = y',
+  guard_hyp h_4 : z = z',
   admit
 end

--- a/tests/lean/run/1813.lean
+++ b/tests/lean/run/1813.lean
@@ -3,23 +3,23 @@ open tactic
 example {A B : Type} (f : A -> B) (a b c) (h1 : f a = b) (h2 : f a = c) : false :=
 begin
   rw h1 at *,
-  guard_hyp h1 := f a = b,
-  guard_hyp h2 := b = c,
+  guard_hyp h1 : f a = b,
+  guard_hyp h2 : b = c,
   admit
 end
 
 example {A B : Type} (f : A -> B) (a b c) (h1 : f a = b) (h2 : f a = c) : false :=
 begin
   rw [id h1] at *,
-  guard_hyp h1 := f a = b,
-  guard_hyp h2 := b = c,
+  guard_hyp h1 : f a = b,
+  guard_hyp h2 : b = c,
   admit
 end
 
 example {A B : Type} (f : A -> B) (a b c) (h1 : f a = b) (h2 : f a = c) : false :=
 begin
   rw [id id h1] at *,
-  guard_hyp h1 := f a = b,
-  guard_hyp h2 := b = c,
+  guard_hyp h1 : f a = b,
+  guard_hyp h2 : b = c,
   admit
 end

--- a/tests/lean/run/400.lean
+++ b/tests/lean/run/400.lean
@@ -1,11 +1,11 @@
 example (n m k : ℕ) (h : n + 1 = m + 1) : m = k → n = k :=
 begin
   injection h with x y z,
-  guard_hyp n := ℕ,
-  guard_hyp m := ℕ,
-  guard_hyp k := ℕ,
-  guard_hyp h := n + 1 = m + 1,
-  guard_hyp x := n = m,
+  guard_hyp n : ℕ,
+  guard_hyp m : ℕ,
+  guard_hyp k : ℕ,
+  guard_hyp h : n + 1 = m + 1,
+  guard_hyp x : n = m,
   guard_target m = k → n = k,
   admit
 end

--- a/tests/lean/run/injection_ginductive.lean
+++ b/tests/lean/run/injection_ginductive.lean
@@ -9,8 +9,8 @@ example (f₁ f₂ : string) (as₁ as₂ : list term) (h : term.app f₁ as₁ 
 begin
   injection h,
   trace_state,
-  guard_hyp h_1 := f₁ = f₂,
-  guard_hyp h_2 := as₁ = as₂,
+  guard_hyp h_1 : f₁ = f₂,
+  guard_hyp h_2 : as₁ = as₂,
   rw p_ax,
   assumption
 end

--- a/tests/lean/run/simp_arrow.lean
+++ b/tests/lean/run/simp_arrow.lean
@@ -2,6 +2,6 @@ example (p q : Prop) (h₀ : q) : ∀ (h : p ∧ true), q :=
 begin
   simp, intros,
   trace_state,
-  guard_hyp h := p,
+  guard_hyp h : p,
   exact h₀
 end


### PR DESCRIPTION
instead of `guard_hyp h := t`. This affects many files but it is a simple
find and replace.

# Motivation
If `h` has type `t` then we almost universally write that `h : t` in lean. Saying `h := t` looks more appropriate for checking the value of a let binding in the context rather than the type.