### PR TITLE
[Merged by Bors] - refactor(init/data/nat,int): less choice

### DIFF
--- a/library/init/algebra/order.lean
+++ b/library/init/algebra/order.lean
@@ -156,11 +156,7 @@ match lt_trichotomy a b with
 end
 
 lemma lt_of_not_ge [linear_order α] {a b : α} (h : ¬ a ≥ b) : a < b :=
-match lt_trichotomy a b with
-| or.inl hlt          := hlt
-| or.inr (or.inl heq) := absurd (heq ▸ le_refl a : a ≥ b) h
-| or.inr (or.inr hgt) := absurd (le_of_lt hgt) h
-end
+lt_of_le_not_le ((le_total _ _).resolve_right h) h
 
 lemma lt_or_ge [linear_order α] (a b : α) : a < b ∨ a ≥ b :=
 match lt_trichotomy a b with
@@ -187,6 +183,10 @@ lemma ne_iff_lt_or_gt [linear_order α] {a b : α} : a ≠ b ↔ a < b ∨ a > b
 
 lemma lt_iff_not_ge [linear_order α] (x y : α) : x < y ↔ ¬ x ≥ y :=
 ⟨not_le_of_gt, lt_of_not_ge⟩
+
+@[simp] lemma not_lt [linear_order α] {a b : α} : ¬ a < b ↔ b ≤ a := ⟨le_of_not_gt, not_lt_of_ge⟩
+
+@[simp] lemma not_le [linear_order α] {a b : α} : ¬ a ≤ b ↔ b < a := (lt_iff_not_ge _ _).symm
 
 instance decidable_lt_of_decidable_le [preorder α]
   [decidable_rel ((≤) : α → α → Prop)] :
@@ -241,3 +241,49 @@ is_strict_weak_order_of_is_total_preorder lt_iff_not_ge
 /- TODO(Leo): decide whether we should keep this instance or not -/
 instance is_strict_total_order_of_decidable_linear_order [decidable_linear_order α] : is_strict_total_order α (<) :=
 { trichotomous := lt_trichotomy }
+
+namespace decidable
+
+lemma lt_or_eq_of_le [partial_order α] [@decidable_rel α (≤)] {a b : α} (hab : a ≤ b) : a < b ∨ a = b :=
+if hba : b ≤ a then or.inr (le_antisymm hab hba)
+else or.inl (lt_of_le_not_le hab hba)
+
+lemma eq_or_lt_of_le [partial_order α] [@decidable_rel α (≤)] {a b : α} (hab : a ≤ b) : a = b ∨ a < b :=
+(lt_or_eq_of_le hab).swap
+
+lemma le_iff_lt_or_eq [partial_order α] [@decidable_rel α (≤)] {a b : α} : a ≤ b ↔ a < b ∨ a = b :=
+⟨lt_or_eq_of_le, le_of_lt_or_eq⟩
+
+lemma le_of_not_lt [decidable_linear_order α] {a b : α} (h : ¬ b < a) : a ≤ b :=
+decidable.by_contradiction $ λ h', h $ lt_of_le_not_le ((le_total _ _).resolve_right h') h'
+
+lemma not_lt [decidable_linear_order α] {a b : α} : ¬ a < b ↔ b ≤ a :=
+⟨le_of_not_lt, not_lt_of_ge⟩
+
+lemma lt_or_le [decidable_linear_order α] (a b : α) : a < b ∨ b ≤ a :=
+if hba : b ≤ a then or.inr hba else or.inl $ lt_of_not_ge hba
+
+lemma le_or_lt [decidable_linear_order α] (a b : α) : a ≤ b ∨ b < a :=
+(lt_or_le b a).swap
+
+lemma lt_trichotomy [decidable_linear_order α] (a b : α) : a < b ∨ a = b ∨ b < a :=
+(lt_or_le _ _).imp_right $ λ h, (eq_or_lt_of_le h).imp_left eq.symm
+
+lemma lt_or_gt_of_ne [decidable_linear_order α] {a b : α} (h : a ≠ b) : a < b ∨ b < a :=
+(lt_trichotomy a b).imp_right $ λ h', h'.resolve_left h
+
+/-- Perform a case-split on the ordering of `x` and `y` in a decidable linear order. -/
+def lt_by_cases [decidable_linear_order α] (x y : α) {P : Sort*}
+  (h₁ : x < y → P) (h₂ : x = y → P) (h₃ : y < x → P) : P :=
+if h : x < y then h₁ h else
+if h' : y < x then h₃ h' else
+h₂ (le_antisymm (le_of_not_gt h') (le_of_not_gt h))
+
+lemma ne_iff_lt_or_gt [decidable_linear_order α] {a b : α} : a ≠ b ↔ a < b ∨ b < a :=
+⟨lt_or_gt_of_ne, λo, o.elim ne_of_lt ne_of_gt⟩
+
+lemma le_imp_le_of_lt_imp_lt {β} [preorder α] [decidable_linear_order β]
+  {a b : α} {c d : β} (H : d < c → b < a) (h : a ≤ b) : c ≤ d :=
+le_of_not_lt $ λ h', not_le_of_gt (H h') h
+
+end decidable

--- a/library/init/data/int/basic.lean
+++ b/library/init/data/int/basic.lean
@@ -58,11 +58,11 @@ match (n - m : nat) with
 | (succ k) := -[1+ k]         -- m < n, and n - m = succ k
 end
 
-private lemma sub_nat_nat_of_sub_eq_zero {m n : ℕ} (h : n - m = 0) :
+lemma sub_nat_nat_of_sub_eq_zero {m n : ℕ} (h : n - m = 0) :
   sub_nat_nat m n = of_nat (m - n) :=
 begin unfold sub_nat_nat, rw h, unfold sub_nat_nat._match_1 end
 
-private lemma sub_nat_nat_of_sub_eq_succ {m n k : ℕ} (h : n - m = succ k) :
+lemma sub_nat_nat_of_sub_eq_succ {m n k : ℕ} (h : n - m = succ k) :
   sub_nat_nat m n = -[1+ k] :=
 begin unfold sub_nat_nat, rw h, unfold sub_nat_nat._match_1 end
 
@@ -117,20 +117,20 @@ protected lemma coe_nat_add_one_out (n : ℕ) : ↑n + (1 : ℤ) = ↑(succ n) :
 
 /- these are only for internal use -/
 
-private lemma of_nat_add_of_nat (m n : nat) : of_nat m + of_nat n = of_nat (m + n) := rfl
-private lemma of_nat_add_neg_succ_of_nat (m n : nat) :
+lemma of_nat_add_of_nat (m n : nat) : of_nat m + of_nat n = of_nat (m + n) := rfl
+lemma of_nat_add_neg_succ_of_nat (m n : nat) :
                 of_nat m + -[1+ n] = sub_nat_nat m (succ n) := rfl
-private lemma neg_succ_of_nat_add_of_nat (m n : nat) :
+lemma neg_succ_of_nat_add_of_nat (m n : nat) :
                 -[1+ m] + of_nat n = sub_nat_nat n (succ m) := rfl
-private lemma neg_succ_of_nat_add_neg_succ_of_nat (m n : nat) :
+lemma neg_succ_of_nat_add_neg_succ_of_nat (m n : nat) :
                 -[1+ m] + -[1+ n] = -[1+ succ (m + n)] := rfl
 
-private lemma of_nat_mul_of_nat (m n : nat) : of_nat m * of_nat n = of_nat (m * n) := rfl
-private lemma of_nat_mul_neg_succ_of_nat (m n : nat) :
+lemma of_nat_mul_of_nat (m n : nat) : of_nat m * of_nat n = of_nat (m * n) := rfl
+lemma of_nat_mul_neg_succ_of_nat (m n : nat) :
                 of_nat m * -[1+ n] = neg_of_nat (m * succ n) := rfl
-private lemma neg_succ_of_nat_of_nat (m n : nat) :
+lemma neg_succ_of_nat_of_nat (m n : nat) :
                 -[1+ m] * of_nat n = neg_of_nat (succ m * n) := rfl
-private lemma mul_neg_succ_of_nat_neg_succ_of_nat (m n : nat) :
+lemma mul_neg_succ_of_nat_neg_succ_of_nat (m n : nat) :
                -[1+ m] * -[1+ n] = of_nat (succ m * succ n) := rfl
 
 local attribute [simp] of_nat_add_of_nat of_nat_mul_of_nat neg_of_nat_zero neg_of_nat_of_succ
@@ -189,7 +189,7 @@ begin
   exact H _ rfl
 end
 
-private lemma sub_nat_nat_add_left {m n : ℕ} :
+lemma sub_nat_nat_add_left {m n : ℕ} :
   sub_nat_nat (m + n) m = of_nat n :=
 begin
   dunfold sub_nat_nat,
@@ -199,24 +199,24 @@ begin
   apply nat.le_add_right
 end
 
-private lemma sub_nat_nat_add_right {m n : ℕ} :
+lemma sub_nat_nat_add_right {m n : ℕ} :
   sub_nat_nat m (m + n + 1) = neg_succ_of_nat n :=
 calc sub_nat_nat._match_1 m (m + n + 1) (m + n + 1 - m) =
         sub_nat_nat._match_1 m (m + n + 1) (m + (n + 1) - m) : by rw [nat.add_assoc]
   ... = sub_nat_nat._match_1 m (m + n + 1) (n + 1) : by rw [nat.add_sub_cancel_left]
   ... = neg_succ_of_nat n : rfl
 
-private lemma sub_nat_nat_add_add (m n k : ℕ) : sub_nat_nat (m + k) (n + k) = sub_nat_nat m n :=
+lemma sub_nat_nat_add_add (m n k : ℕ) : sub_nat_nat (m + k) (n + k) = sub_nat_nat m n :=
 sub_nat_nat_elim m n (λm n i, sub_nat_nat (m + k) (n + k) = i)
   (assume i n, have n + i + k = (n + k) + i, by simp [nat.add_comm, nat.add_left_comm],
     begin rw [this], exact sub_nat_nat_add_left end)
   (assume i m, have m + i + 1 + k = (m + k) + i + 1, by simp [nat.add_comm, nat.add_left_comm],
     begin rw [this], exact sub_nat_nat_add_right end)
 
-private lemma sub_nat_nat_of_ge {m n : ℕ} (h : m ≥ n) : sub_nat_nat m n = of_nat (m - n) :=
+lemma sub_nat_nat_of_ge {m n : ℕ} (h : m ≥ n) : sub_nat_nat m n = of_nat (m - n) :=
 sub_nat_nat_of_sub_eq_zero (sub_eq_zero_of_le h)
 
-private lemma sub_nat_nat_of_lt {m n : ℕ} (h : m < n) : sub_nat_nat m n = -[1+ pred (n - m)] :=
+lemma sub_nat_nat_of_lt {m n : ℕ} (h : m < n) : sub_nat_nat m n = -[1+ pred (n - m)] :=
 have n - m = succ (pred (n - m)), from eq.symm (succ_pred_eq_of_pos (nat.sub_pos_of_lt h)),
 by rewrite sub_nat_nat_of_sub_eq_succ this
 
@@ -337,15 +337,15 @@ protected lemma add_zero : ∀ a : ℤ, a + 0 = a
 protected lemma zero_add (a : ℤ) : 0 + a = a :=
 int.add_comm a 0 ▸ int.add_zero a
 
-private lemma sub_nat_nat_sub {m n : ℕ} (h : m ≥ n) (k : ℕ) :
+lemma sub_nat_nat_sub {m n : ℕ} (h : m ≥ n) (k : ℕ) :
   sub_nat_nat (m - n) k = sub_nat_nat m (k + n) :=
 calc
   sub_nat_nat (m - n) k = sub_nat_nat (m - n + n) (k + n) : by rewrite [sub_nat_nat_add_add]
                     ... = sub_nat_nat m (k + n)           : by rewrite [nat.sub_add_cancel h]
 
-private lemma sub_nat_nat_add (m n k : ℕ) : sub_nat_nat (m + n) k = of_nat m + sub_nat_nat n k :=
+lemma sub_nat_nat_add (m n k : ℕ) : sub_nat_nat (m + n) k = of_nat m + sub_nat_nat n k :=
 begin
-  have h := le_or_gt k n,
+  have h := decidable.le_or_lt k n,
   cases h with h' h',
   { rw [sub_nat_nat_of_ge h'],
     have h₂ : k ≤ m + n, exact (le_trans h' (le_add_left _ _)),
@@ -356,10 +356,10 @@ begin
   apply sub_nat_nat_add_add
 end
 
-private lemma sub_nat_nat_add_neg_succ_of_nat (m n k : ℕ) :
+lemma sub_nat_nat_add_neg_succ_of_nat (m n k : ℕ) :
     sub_nat_nat m n + -[1+ k] = sub_nat_nat m (n + succ k) :=
 begin
-  have h := le_or_gt n m,
+  have h := decidable.le_or_lt n m,
   cases h with h' h',
   { rw [sub_nat_nat_of_ge h'], simp, rw [sub_nat_nat_sub h', nat.add_comm] },
   have h₂ : m < n + succ k, exact nat.lt_of_lt_of_le h' (le_add_right _ _),
@@ -369,12 +369,12 @@ begin
   rw [nat.add_comm n, nat.add_sub_assoc (le_of_lt h')]
 end
 
-private lemma add_assoc_aux1 (m n : ℕ) :
+lemma add_assoc_aux1 (m n : ℕ) :
     ∀ c : ℤ, of_nat m + of_nat n + c = of_nat m + (of_nat n + c)
 | (of_nat k) := by simp [nat.add_assoc]
 | -[1+ k]    := by simp [sub_nat_nat_add]
 
-private lemma add_assoc_aux2 (m n k : ℕ) :
+lemma add_assoc_aux2 (m n k : ℕ) :
   -[1+ m] + -[1+ n] + of_nat k = -[1+ m] + (-[1+ n] + of_nat k) :=
 begin
   simp [add_succ], rw [int.add_comm, sub_nat_nat_add_neg_succ_of_nat], simp [add_succ, succ_add, nat.add_comm]
@@ -396,7 +396,7 @@ protected lemma add_assoc : ∀ a b c : ℤ, a + b + c = a + (b + c)
 
 /- negation -/
 
-private lemma sub_nat_self : ∀ n, sub_nat_nat n n = 0
+lemma sub_nat_self : ∀ n, sub_nat_nat n n = 0
 | 0        := rfl
 | (succ m) := begin rw [sub_nat_nat_of_sub_eq_zero, nat.sub_self, of_nat_zero], rw nat.sub_self end
 
@@ -418,21 +418,21 @@ protected lemma mul_comm : ∀ a b : ℤ, a * b = b * a
 | -[1+ m]    (of_nat n) := by simp [nat.mul_comm]
 | -[1+ m]    -[1+ n]    := by simp [nat.mul_comm]
 
-private lemma of_nat_mul_neg_of_nat (m : ℕ) :
+lemma of_nat_mul_neg_of_nat (m : ℕ) :
    ∀ n, of_nat m * neg_of_nat n = neg_of_nat (m * n)
 | 0        := rfl
 | (succ n) := begin unfold neg_of_nat, simp end
 
-private lemma neg_of_nat_mul_of_nat (m n : ℕ) :
+lemma neg_of_nat_mul_of_nat (m n : ℕ) :
     neg_of_nat m * of_nat n = neg_of_nat (m * n) :=
 begin rw int.mul_comm, simp [of_nat_mul_neg_of_nat, nat.mul_comm] end
 
-private lemma neg_succ_of_nat_mul_neg_of_nat (m : ℕ) :
+lemma neg_succ_of_nat_mul_neg_of_nat (m : ℕ) :
   ∀ n, -[1+ m] * neg_of_nat n = of_nat (succ m * n)
 | 0        := rfl
 | (succ n) := begin unfold neg_of_nat, simp end
 
-private lemma neg_of_nat_mul_neg_succ_of_nat (m n : ℕ) :
+lemma neg_of_nat_mul_neg_succ_of_nat (m n : ℕ) :
   neg_of_nat n * -[1+ m] = of_nat (n * succ m) :=
 begin rw int.mul_comm, simp [neg_succ_of_nat_mul_neg_of_nat, nat.mul_comm] end
 
@@ -456,15 +456,15 @@ protected lemma mul_zero : ∀ (a : ℤ), a * 0 = 0
 protected lemma zero_mul (a : ℤ) : 0 * a = 0 :=
 int.mul_comm a 0 ▸ int.mul_zero a
 
-private lemma neg_of_nat_eq_sub_nat_nat_zero : ∀ n, neg_of_nat n = sub_nat_nat 0 n
+lemma neg_of_nat_eq_sub_nat_nat_zero : ∀ n, neg_of_nat n = sub_nat_nat 0 n
 | 0        := rfl
 | (succ n) := rfl
 
-private lemma of_nat_mul_sub_nat_nat (m n k : ℕ) :
+lemma of_nat_mul_sub_nat_nat (m n k : ℕ) :
   of_nat m * sub_nat_nat n k = sub_nat_nat (m * n) (m * k) :=
 begin
   have h₀ : m > 0 ∨ 0 = m,
-    exact lt_or_eq_of_le (zero_le _),
+    exact decidable.lt_or_eq_of_le (zero_le _),
   cases h₀ with h₀ h₀,
   { have h := nat.lt_or_ge n k,
     cases h with h h,
@@ -483,7 +483,7 @@ begin
   subst h₀, simp [h₂, int.zero_mul, nat.zero_mul]
 end
 
-private lemma neg_of_nat_add (m n : ℕ) :
+lemma neg_of_nat_add (m n : ℕ) :
   neg_of_nat m + neg_of_nat n = neg_of_nat (m + n) :=
 begin
   cases m,
@@ -495,7 +495,7 @@ begin
   simp [nat.succ_add], reflexivity
 end
 
-private lemma neg_succ_of_nat_mul_sub_nat_nat (m n k : ℕ) :
+lemma neg_succ_of_nat_mul_sub_nat_nat (m n k : ℕ) :
   -[1+ m] * sub_nat_nat n k = sub_nat_nat (succ m * k) (succ m * n) :=
 begin
   have h := nat.lt_or_ge n k,
@@ -505,7 +505,7 @@ begin
     rw [sub_nat_nat_of_lt h, sub_nat_nat_of_ge (le_of_lt h')],
     simp [succ_pred_eq_of_pos (nat.sub_pos_of_lt h), nat.mul_sub_left_distrib]},
   have h' : n > k ∨ k = n,
-    exact lt_or_eq_of_le h,
+    exact decidable.lt_or_eq_of_le h,
   cases h' with h' h',
   { have h₁ : succ m * n > succ m * k,
       exact nat.mul_lt_mul_of_pos_left h' (nat.succ_pos m),

--- a/library/init/data/int/order.lean
+++ b/library/init/data/int/order.lean
@@ -10,7 +10,7 @@ import init.data.int.basic init.data.ordering.basic
 
 namespace int
 
-private def nonneg (a : ℤ) : Prop := int.cases_on a (assume n, true) (assume n, false)
+def nonneg (a : ℤ) : Prop := int.cases_on a (assume n, true) (assume n, false)
 
 protected def le (a b : ℤ) : Prop := nonneg (b - a)
 
@@ -20,7 +20,7 @@ protected def lt (a b : ℤ) : Prop := (a + 1) ≤ b
 
 instance : has_lt int := ⟨int.lt⟩
 
-private def decidable_nonneg (a : ℤ) : decidable (nonneg a) :=
+def decidable_nonneg (a : ℤ) : decidable (nonneg a) :=
 int.cases_on a (assume a, decidable.true) (assume a, decidable.false)
 
 instance decidable_le (a b : ℤ) : decidable (a ≤ b) := decidable_nonneg _
@@ -29,10 +29,10 @@ instance decidable_lt (a b : ℤ) : decidable (a < b) := decidable_nonneg _
 
 lemma lt_iff_add_one_le (a b : ℤ) : a < b ↔ a + 1 ≤ b := iff.refl _
 
-private lemma nonneg.elim {a : ℤ} : nonneg a → ∃ n : ℕ, a = n :=
+lemma nonneg.elim {a : ℤ} : nonneg a → ∃ n : ℕ, a = n :=
 int.cases_on a (assume n H, exists.intro n rfl) (assume n', false.elim)
 
-private lemma nonneg_or_nonneg_neg (a : ℤ) : nonneg a ∨ nonneg (-a) :=
+lemma nonneg_or_nonneg_neg (a : ℤ) : nonneg a ∨ nonneg (-a) :=
 int.cases_on a (assume n, or.inl trivial) (assume n, or.inr trivial)
 
 lemma le.intro_sub {a b : ℤ} {n : ℕ} (h : b - a = n) : a ≤ b :=
@@ -938,9 +938,9 @@ theorem sign_eq_zero_iff_zero (a : ℤ) : sign a = 0 ↔ a = 0 :=
 
 protected lemma eq_zero_or_eq_zero_of_mul_eq_zero
         {a b : ℤ} (h : a * b = 0) : a = 0 ∨ b = 0 :=
-match lt_trichotomy 0 a with
+match decidable.lt_trichotomy 0 a with
 | or.inl hlt₁          :=
-  match lt_trichotomy 0 b with
+  match decidable.lt_trichotomy 0 b with
   | or.inl hlt₂          :=
     have 0 < a * b, from int.mul_pos hlt₁ hlt₂,
     begin rw h at this, exact absurd this (lt_irrefl _) end
@@ -951,7 +951,7 @@ match lt_trichotomy 0 a with
   end
 | or.inr (or.inl heq₁) := or.inl heq₁.symm
 | or.inr (or.inr hgt₁) :=
-  match lt_trichotomy 0 b with
+  match decidable.lt_trichotomy 0 b with
   | or.inl hlt₂          :=
     have 0 > a * b, from int.mul_neg_of_neg_of_pos hgt₁ hlt₂,
     begin rw h at this, exact absurd this (lt_irrefl _)  end

--- a/library/init/data/nat/lemmas.lean
+++ b/library/init/data/nat/lemmas.lean
@@ -966,7 +966,9 @@ suffices ∀m k, n ≤ k + m → acc lbp k, from λa, this _ _ (nat.le_add_left 
 protected def find_x : {n // p n ∧ ∀m < n, ¬p m} :=
 @well_founded.fix _ (λk, (∀n < k, ¬p n) → {n // p n ∧ ∀m < n, ¬p m}) lbp wf_lbp
 (λm IH al, if pm : p m then ⟨m, pm, al⟩ else
-    have ∀ n ≤ m, ¬p n, from λn h, or.elim (lt_or_eq_of_le h) (al n) (λe, by rw e; exact pm),
+    have ∀ n ≤ m, ¬p n, from λn h,
+      if e : n = m then by rw e; exact pm else
+      al n (nat.lt_of_le_and_ne h e),
     IH _ ⟨rfl, this⟩ (λn h, this n $ nat.le_of_succ_le_succ h))
 0 (λn h, absurd h (nat.not_lt_zero _))
 

--- a/library/init/data/nat/lemmas.lean
+++ b/library/init/data/nat/lemmas.lean
@@ -979,7 +979,7 @@ protected theorem find_spec : p nat.find := nat.find_x.2.left
 protected theorem find_min : ∀ {m : ℕ}, m < nat.find → ¬p m := nat.find_x.2.right
 
 protected theorem find_min' {m : ℕ} (h : p m) : nat.find ≤ m :=
-le_of_not_gt (λ l, find_min l h)
+(nat.lt_or_ge _ _).resolve_left (λ l, find_min l h)
 
 end find
 


### PR DESCRIPTION
This PR removes usage of the axiom of choice from the basic nat and int lemmas. It also removes `private` from the internal lemmas about int (it is a pain to prove properties about `int.sub_nat_nat` when the library is locked up), and moves the `decidable.*` order theorems from mathlib. (While I think we should move order theory out of core, that is a separate PR, and if and when that happens these theorems can move back to mathlib. But for now they should be treated as dependents of the `nat.lemmas` file, and can migrate with it.)