### PR TITLE
[Merged by Bors] - feat(init/meta/interactive): check let bindings in guard_hyp

### DIFF
--- a/library/init/meta/interactive.lean
+++ b/library/init/meta/interactive.lean
@@ -4,7 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Leonardo de Moura, Jannis Limperg
 -/
 prelude
-import init.meta.tactic init.meta.rewrite_tactic init.meta.simp_tactic
+import init.meta.tactic init.meta.type_context init.meta.rewrite_tactic init.meta.simp_tactic
 import init.meta.smt.congruence_closure init.control.combinators
 import init.meta.interactive_base init.meta.derive init.meta.match_tactic
 import init.meta.congr_tactic init.meta.case_tag
@@ -1527,8 +1527,24 @@ do t ← target, guard_expr_eq t p
 `guard_hyp h : t` fails if the hypothesis `h` does not have type `t`.
 We use this tactic for writing tests.
 -/
-meta def guard_hyp (n : parse ident) (p : parse $ tk ":" *> texpr) : tactic unit :=
-do h ← get_local n >>= infer_type, guard_expr_eq h p
+meta def guard_hyp (n : parse ident)
+  (ty : parse (tk ":" *> texpr)?)
+  (val : parse (tk ":=" *> texpr)?) : tactic unit := do
+  h ← get_local n,
+  ldecl ← tactic.unsafe.type_context.run (do
+    lctx ← unsafe.type_context.get_local_context,
+    pure $ lctx.get_local_decl h.local_uniq_name),
+  ldecl ← ldecl | fail format!"hypothesis {h} not found",
+  match ty with
+  | some p := guard_expr_eq ldecl.type p
+  | none := skip
+  end,
+  match ldecl.value, val with
+  | none, some _ := fail format!"{h} is not a let binding"
+  | some _, none := fail format!"{h} is a let binding"
+  | some hval, some val := guard_expr_eq hval val
+  | none, none := skip
+  end
 
 /--
 `match_target t` fails if target does not match pattern `t`.

--- a/library/init/meta/type_context.lean
+++ b/library/init/meta/type_context.lean
@@ -1,5 +1,5 @@
 prelude
-import init.control init.meta.local_context init.meta.tactic init.meta.fun_info
+import init.control.monad init.meta.local_context init.meta.tactic init.meta.fun_info
 namespace tactic.unsafe
 /-- A monad that exposes the functionality of the C++ class `type_context_old`.
 The idea is that the methods to `type_context` are more powerful but _unsafe_ in the


### PR DESCRIPTION
A follow on to #445.  Support the syntax `guard_hyp h : t := val` for checking let bindings (and make `guard_hyp h : t` also ensure that `h` is *not* a let binding).