### PR TITLE
[Merged by Bors] - fix(init/control/state): flip typeclass args for monad_state_trans

### DIFF
--- a/library/init/control/state.lean
+++ b/library/init/control/state.lean
@@ -99,7 +99,7 @@ variables {σ : Type u} {m : Type u → Type v}
 
 -- NOTE: The ordering of the following two instances determines that the top-most `state_t` monad layer
 -- will be picked first
-instance monad_state_trans {n : Type u → Type w} [has_monad_lift m n] [monad_state σ m] : monad_state σ n :=
+instance monad_state_trans {n : Type u → Type w} [monad_state σ m] [has_monad_lift m n] : monad_state σ n :=
 ⟨λ α x, monad_lift (monad_state.lift x : m α)⟩
 
 instance [monad m] : monad_state σ (state_t σ m) :=


### PR DESCRIPTION
As of 3.7.0c, typeclass resolution solves instance arguments from right-to-left (via #139). #139 also explicitly flips the typeclass arguments of definitions like monad_reader_trans, but does not flip the typeclass arguments of monad_state_trans, causing the following example:

```
def ex1 : option_t (state_t string id) string :=
  do
    s <- get,
    option_t.mk $ return s
```

to return the error: `maximum class-instance resolution depth has been reached`. Flipping the typeclass arguments for monad_state_trans fixes this particular issue.

Closes #460