### PR TITLE
[Merged by Bors] - fix(tactic/resolve_constant): `parameters` are no longer a problem

### DIFF
--- a/library/init/meta/tactic.lean
+++ b/library/init/meta/tactic.lean
@@ -896,9 +896,6 @@ meta def intron_with
 
 /-- Returns n fully qualified if it refers to a constant, or else fails. -/
 meta def resolve_constant (n : name) : tactic name :=
--- do (expr.const n _) ← resolve_name n,
---    pure n
-
 do e ← resolve_name n,
    match e with
    | expr.const n _ := pure n

--- a/library/init/meta/tactic.lean
+++ b/library/init/meta/tactic.lean
@@ -901,7 +901,8 @@ do e ← resolve_name n,
    | expr.const n _ := pure n
    | _ := do
      e ← to_expr e tt ff,
-     pure $ e.get_app_fn.const_name
+     expr.const n _ ← pure $ e.get_app_fn,
+     pure n
    end
 
 meta def to_expr_strict (q : pexpr) : tactic expr :=

--- a/library/init/meta/tactic.lean
+++ b/library/init/meta/tactic.lean
@@ -896,8 +896,16 @@ meta def intron_with
 
 /-- Returns n fully qualified if it refers to a constant, or else fails. -/
 meta def resolve_constant (n : name) : tactic name :=
-do (expr.const n _) ← resolve_name n,
-   pure n
+-- do (expr.const n _) ← resolve_name n,
+--    pure n
+
+do e ← resolve_name n,
+   match e with
+   | expr.const n _ := pure n
+   | _ := do
+     e ← to_expr e tt ff,
+     pure $ e.get_app_fn.const_name
+   end
 
 meta def to_expr_strict (q : pexpr) : tactic expr :=
 to_expr q

--- a/tests/lean/run/resolve_name_bug.lean
+++ b/tests/lean/run/resolve_name_bug.lean
@@ -25,3 +25,14 @@ by simp [f_lemma1, f_lemma2]
 
 end bla
 end foo
+
+section param
+
+parameters x y : ℤ
+
+lemma my_ext (s s' : set ℤ) (h : x ∈ s ↔ y ∈ s') : true := trivial
+
+run_cmd tactic.resolve_constant `my_ext
+
+
+end param

--- a/tests/lean/run/resolve_name_bug.lean
+++ b/tests/lean/run/resolve_name_bug.lean
@@ -30,9 +30,12 @@ section param
 
 parameters x y : ℤ
 
-lemma my_ext (s s' : set ℤ) (h : x ∈ s ↔ y ∈ s') : true := trivial
+lemma foo.my_ext (s s' : set ℤ) (h : x ∈ s ↔ y ∈ s') : true := trivial
 
-run_cmd tactic.resolve_constant `my_ext
+open foo
 
+run_cmd do
+n ← tactic.resolve_constant `my_ext,
+guard $ n = `foo.my_ext
 
 end param


### PR DESCRIPTION
Moved PR from https://github.com/leanprover-community/mathlib/pull/4032