### PR TITLE
fix(bin/leanpkg): replace `readlink -f`

### DIFF
--- a/bin/leanpkg
+++ b/bin/leanpkg
@@ -1,6 +1,17 @@
-#!/usr/bin/env bash
+#!/usr/bin/env sh
 
-REALPATH=realpath
+if command -v realpath >/dev/null 2>&1; then
+     REALPATH=realpath
+else
+     unamestr=`uname`
+     # OS X
+     if [[ "$unamestr" == 'Darwin' ]]; then
+         echo "Cannot find 'realpath' command, please install 'realpath'. If you use 'brew', you can install 'greadlink' using 'brew install coreutils'"
+         exit 1
+     else
+         REALPATH="readlink -f"
+     fi
+fi
 
 leandir=$(dirname "$($REALPATH "$0")")/..
 leandir=$($REALPATH "$leandir")

--- a/bin/leanpkg
+++ b/bin/leanpkg
@@ -1,21 +1,9 @@
 #!/usr/bin/env bash
 
-unamestr=`uname`
-if [[ "$unamestr" == 'Darwin' ]]; then
-    # OSX
-    if command -v greadlink >/dev/null 2>&1; then
-        # macOS readlink doesn't support -f option
-        READLINK=greadlink
-    else
-        echo "OSX 'readlink' command does not support option '-f', please install 'greadlink'. If you use 'brew', you can install 'greadlink' using 'brew install coreutils'"
-        exit 1
-    fi
-else
-    READLINK=readlink
-fi
+REALPATH=realpath
 
-leandir=$(dirname "$($READLINK -f "$0")")/..
-leandir=$($READLINK -f "$leandir")
+leandir=$(dirname "$($REALPATH "$0")")/..
+leandir=$($REALPATH "$leandir")
 
 librarydir="$leandir/lib/lean"
 test -d "$librarydir" || librarydir="$leandir"

--- a/bin/leanpkg
+++ b/bin/leanpkg
@@ -6,7 +6,7 @@ else
      unamestr=`uname`
      # OS X
      if [[ "$unamestr" == 'Darwin' ]]; then
-         echo "Cannot find 'realpath' command, please install 'realpath'. If you use 'brew', you can install 'greadlink' using 'brew install coreutils'"
+         echo "Cannot find 'realpath' command, please install 'realpath'. If you use 'brew', you can install 'realpath' using 'brew install coreutils'"
          exit 1
      else
          REALPATH="readlink -f"


### PR DESCRIPTION
`realpath` behaves more uniformly than `readlink -f` across platforms, which eliminates the mundane test for checking availability of `greadlink` on OS X. Noting that `realpath` is not exchangeable everywhere with `readlink -f` but in this simple case it is suffice. Since `realpath` has been available from GNU coreutils since v8.15, most users shouldn't be affected by this change.