### PR TITLE
fix(init/meta/converter/interactive): Do not ignore errors in `for` and `find`

### DIFF
--- a/library/init/meta/converter/interactive.lean
+++ b/library/init/meta/converter/interactive.lean
@@ -7,7 +7,7 @@ Converter monad for building simplifiers.
 -/
 prelude
 import init.meta.interactive
-imoort init.meta.converter.conv
+import init.meta.converter.conv
 import init.meta.tactic
 
 namespace conv

--- a/library/init/meta/converter/interactive.lean
+++ b/library/init/meta/converter/interactive.lean
@@ -8,7 +8,6 @@ Converter monad for building simplifiers.
 prelude
 import init.meta.interactive
 import init.meta.converter.conv
-import init.meta.tactic
 
 namespace conv
 meta def save_info (p : pos) : conv unit :=

--- a/library/init/meta/converter/interactive.lean
+++ b/library/init/meta/converter/interactive.lean
@@ -91,7 +91,7 @@ do (r, lhs, _) ← tactic.target_lhs_rhs,
          guard (not found),
          matched ← (tactic.match_pattern pat e >> return tt) <|> return ff,
          guard matched,
-         res ← capture (c.convert e r),
+         res ← tactic.capture (c.convert e r),
          -- If an error occurs in conversion, capture it; `ext_simplify_core` will not
          -- propagate it.
          match res with
@@ -102,7 +102,7 @@ do (r, lhs, _) ← tactic.target_lhs_rhs,
        end)
      (λ a s r p e, tactic.failed)
      r lhs,
-  found ← unwrap found_result,
+  found ← tactic.unwrap found_result,
   when (not found) $ tactic.fail "find converter failed, pattern was not found",
   update_lhs new_lhs pr
 
@@ -124,7 +124,7 @@ do (r, lhs, _) ← tactic.target_lhs_rhs,
          do matched ← (tactic.match_pattern pat e >> return tt) <|> return ff,
             guard matched,
             if i ∈ occs then do
-              res ← capture (c.convert e r),
+              res ← tactic.capture (c.convert e r),
               -- If an error occurs in conversion, capture it; `ext_simplify_core` will not
               -- propagate it.
               match res with
@@ -139,7 +139,7 @@ do (r, lhs, _) ← tactic.target_lhs_rhs,
      (λ a s r p e, tactic.failed)
      r lhs,
   -- Re-throw any error captured inside `ext_simplify_core`
-  unwrap found_result,
+  tactic.unwrap found_result,
   update_lhs new_lhs pr
 
 meta def simp (no_dflt : parse only_flag) (hs : parse tactic.simp_arg_list) (attr_names : parse with_ident_list)

--- a/library/init/meta/converter/interactive.lean
+++ b/library/init/meta/converter/interactive.lean
@@ -77,16 +77,16 @@ meta def find (p : parse parser.pexpr) (c : itactic) : conv unit :=
 do (r, lhs, _) ← tactic.target_lhs_rhs,
    pat ← tactic.pexpr_to_pattern p,
    s   ← simp_lemmas.mk_default, -- to be able to use congruence lemmas @[congr]
+   -- we have to thread the tactic state through `ext_simplify_core` manually
    st ← tactic.read,
    (found_result, new_lhs, pr) ← tactic.ext_simplify_core
-     (success ff st)  -- loop counter, and whether the conversion tactic failed
+     (success ff st)  -- loop counter
      {zeta := ff, beta := ff, single_pass := tt, eta := ff, proj := ff,
       fail_if_unchanged := ff, memoize := ff}
      s
      (λ u, return u)
      (λ found_result s r p e, do
-       -- if the previous conversion failed, then rethrow the failure immediately
-       found ← tactic.unwrap found_result,
+       found ← tactic.resume found_result,
        guard (not found),
        matched ← (tactic.match_pattern pat e >> return tt) <|> return ff,
        guard matched,
@@ -99,7 +99,7 @@ do (r, lhs, _) ← tactic.target_lhs_rhs,
        end)
      (λ a s r p e, tactic.failed)
      r lhs,
-  found ← tactic.unwrap found_result,
+  found ← tactic.resume found_result,
   when (not found) $ tactic.fail "find converter failed, pattern was not found",
   update_lhs new_lhs pr
 
@@ -107,6 +107,7 @@ meta def for (p : parse parser.pexpr) (occs : parse (list_of small_nat)) (c : it
 do (r, lhs, _) ← tactic.target_lhs_rhs,
    pat ← tactic.pexpr_to_pattern p,
    s   ← simp_lemmas.mk_default, -- to be able to use congruence lemmas @[congr]
+   -- we have to thread the tactic state through `ext_simplify_core` manually
    st ← tactic.read,
    (found_result, new_lhs, pr) ← tactic.ext_simplify_core
      (success 1 st)  -- loop counter, and whether the conversion tactic failed
@@ -115,8 +116,7 @@ do (r, lhs, _) ← tactic.target_lhs_rhs,
      s
      (λ u, return u)
      (λ found_result s r p e, do
-       -- if the previous conversion failed, then rethrow the failure immediately
-       i ← tactic.unwrap found_result,
+       i ← tactic.resume found_result,
        matched ← (tactic.match_pattern pat e >> return tt) <|> return ff,
        guard matched,
        if i ∈ occs then do
@@ -132,8 +132,7 @@ do (r, lhs, _) ← tactic.target_lhs_rhs,
          return (success (i+1) st, e, none, tt))
      (λ a s r p e, tactic.failed)
      r lhs,
-  -- Re-throw any error captured inside `ext_simplify_core`
-  tactic.unwrap found_result,
+  tactic.resume found_result,
   update_lhs new_lhs pr
 
 meta def simp (no_dflt : parse only_flag) (hs : parse tactic.simp_arg_list) (attr_names : parse with_ident_list)

--- a/library/init/meta/converter/interactive.lean
+++ b/library/init/meta/converter/interactive.lean
@@ -30,6 +30,7 @@ open lean
 open lean.parser
 open interactive
 open interactive.types
+open tactic_result
 
 meta def itactic : Type :=
 conv unit
@@ -109,7 +110,7 @@ do (r, lhs, _) ← tactic.target_lhs_rhs,
             if n ∈ occs then 
               (λ s,
                 match (c.convert e r) s with
-                | (success r s')     := success (success (n+1) s',    r.fst, some r.snd, tt) s'
+                | (success r s')     := success (success (n+1) s', r.fst, some r.snd, tt) s'
                 | (exception f p s') := success (exception f p s', e,     none,       tt) s'
                 end
               )

--- a/library/init/meta/converter/interactive.lean
+++ b/library/init/meta/converter/interactive.lean
@@ -94,20 +94,37 @@ meta def for (p : parse parser.pexpr) (occs : parse (list_of small_nat)) (c : it
 do (r, lhs, _) ← tactic.target_lhs_rhs,
    pat ← tactic.pexpr_to_pattern p,
    s   ← simp_lemmas.mk_default, -- to be able to use congruence lemmas @[congr]
-   (found, new_lhs, pr) ←
-     tactic.ext_simplify_core 1 {zeta := ff, beta := ff, single_pass := tt, eta := ff,
-                                 proj := ff, fail_if_unchanged := ff, memoize := ff} s
-       (λ u, return u)
-       (λ i s r p e, do
-         matched ← (tactic.match_pattern pat e >> return tt) <|> return ff,
-         guard matched,
-         if i ∈ occs then do
-           ⟨new_e, pr⟩ ← c.convert e r,
-           return (i+1, new_e, some pr, tt)
-         else return (i+1, e, none, tt))
-       (λ a s r p e, tactic.failed)
-       r lhs,
-  update_lhs new_lhs pr
+   st ← tactic.read,
+   (found, new_lhs, pr) ← tactic.ext_simplify_core
+     (success 1 st)  -- loop counter, and whether the conversion tactic failed
+     {zeta := ff, beta := ff, single_pass := tt, eta := ff, proj := ff,
+      fail_if_unchanged := ff, memoize := ff}
+     s
+     (λ u, return u)
+     (λ i s r p e,
+       match i with
+       | (success n s') :=
+         do matched ← (tactic.match_pattern pat e >> return tt) <|> return ff,
+            guard matched,
+            if n ∈ occs then 
+              (λ s,
+                match (c.convert e r) s with
+                | (success r s')     := success (success (n+1) s',    r.fst, some r.snd, tt) s'
+                | (exception f p s') := success (exception f p s', e,     none,       tt) s'
+                end
+              )
+            else do
+              st ← tactic.read,
+              return (success (n+1) st, e, none, tt)
+       | (exception _ _ _) := tactic.failed
+       end)
+     (λ a s r p e, tactic.failed)
+     r lhs,
+  (λ s, match found with
+  | (success r s') :=  (success r s)
+  | (exception f p s') := (exception f p s)
+  end),
+  conv.update_lhs new_lhs pr
 
 meta def simp (no_dflt : parse only_flag) (hs : parse tactic.simp_arg_list) (attr_names : parse with_ident_list)
               (cfg : tactic.simp_config_ext := {})

--- a/library/init/meta/simp_tactic.lean
+++ b/library/init/meta/simp_tactic.lean
@@ -332,8 +332,9 @@ The method returns `(a,e,pr)` where
 Note that `ext_simplify_core` will succeed even if `pre` and `post` fail, as failures are used to indicate that the method should move on to the next subterm.
 If it is desirable to propagate errors from `pre`, they can be propagated through the "user data".
 An easy way to do this is to call `tactic.capture (do ...)` in the parts of `pre`/`post` where errors matter, and then use `tactic.unwrap a` on the result.
-An example of this can be found in `conv.interactive.find` and `conv.interactive.for`.
 
+Additionally, `ext_simplify_core` does not propagate changes made to the tactic state by `pre` and `post.
+If it is desirable to propagate changes to the tactic state in addition to errors, use `tactic.resume` instead of `tactic.unwrap`.
 -/
 meta constant ext_simplify_core
   {α : Type}

--- a/library/init/meta/simp_tactic.lean
+++ b/library/init/meta/simp_tactic.lean
@@ -329,6 +329,11 @@ The method returns `(a,e,pr)` where
  - `e` is the new expression
  - `pr` is the proof that the given expression equals the input expression.
 
+Note that `ext_simplify_core` will succeed even if `pre` and `post` fail, as failures are used to indicate that the method should move on to the next subterm.
+If it is desirable to propagate errors from `pre`, they can be propagated through the "user data".
+An easy way to do this is to call `tactic.capture (do ...)` in the parts of `pre`/`post` where errors matter, and then use `tactic.unwrap a` on the result.
+An example of this can be found in `conv.interactive.find` and `conv.interactive.for`.
+
 -/
 meta constant ext_simplify_core
   {α : Type}

--- a/library/init/meta/tactic.lean
+++ b/library/init/meta/tactic.lean
@@ -154,6 +154,31 @@ match t s with
 | (success _ s') := success () s'
 end
 
+/--
+`capture t` acts like `t`, but succeeds with a result containing either the returned value
+or the exception.
+
+The result can be used to inspect the error message, or passed to `unwrap` to rethrow the
+failure later.
+-/
+meta def capture (t : tactic α) : tactic (tactic_result α) :=
+t <$> read
+
+/--
+`unwrap r` unwraps a result previously obtained using `capture`.
+
+If the previous result was a success, this produces its wrapped value.
+If the previous result was an exception, this "rethrows" the exception as if it came
+from where it originated.
+
+`do r ← t, unwrap r` is identical to `t`, but allows for intermediate tactics to be inserted.
+-/
+meta def unwrap {α : Type*} (t : tactic_result α) : tactic α :=
+match t with
+| (success r s') := return r
+| e := λ s, e
+end
+
 meta def try_lst : list (tactic unit) → tactic unit
 | []            := failed
 | (tac :: tacs) := λ s,

--- a/library/init/meta/tactic.lean
+++ b/library/init/meta/tactic.lean
@@ -171,7 +171,7 @@ If the previous result was a success, this produces its wrapped value.
 If the previous result was an exception, this "rethrows" the exception as if it came
 from where it originated.
 
-`do r ← t, unwrap r` is identical to `t`, but allows for intermediate tactics to be inserted.
+`do r ← capture t, unwrap r` is identical to `t`, but allows for intermediate tactics to be inserted.
 -/
 meta def unwrap {α : Type*} (t : tactic_result α) : tactic α :=
 match t with

--- a/library/init/meta/tactic.lean
+++ b/library/init/meta/tactic.lean
@@ -273,6 +273,7 @@ meta def decorate_ex (msg : format) (t : tactic α) : tactic α :=
 /--
 `capture t` acts like `t`, but succeeds with a result containing either the returned value
 or the exception.
+Changes made by `t` to the `tactic_state` are preserved in both cases.
 
 The result can be used to inspect the error message, or passed to `unwrap` to rethrow the
 failure later.
@@ -297,6 +298,14 @@ match t with
 | (success r s') := return r
 | e := λ s, e
 end
+
+/--
+`resume r` continues execution from a result previously obtained using `capture`.
+
+This is like `unwrap`, but the `tactic_state` is rolled back to point of capture even upon success. 
+-/
+meta def unwrap {α : Type*} (t : tactic_result α) : tactic α :=
+λ s, t
 
 meta def get_options : tactic options :=
 do s ← read, return s.get_options

--- a/library/init/meta/tactic.lean
+++ b/library/init/meta/tactic.lean
@@ -278,7 +278,10 @@ The result can be used to inspect the error message, or passed to `unwrap` to re
 failure later.
 -/
 meta def capture (t : tactic α) : tactic (tactic_result α) :=
-t <$> read
+λ s, match t s with
+| (success r s') := success (success r s') s'
+| (exception f p s') := success (exception f p s') s'
+end
 
 /--
 `unwrap r` unwraps a result previously obtained using `capture`.

--- a/library/init/meta/tactic.lean
+++ b/library/init/meta/tactic.lean
@@ -304,7 +304,7 @@ end
 
 This is like `unwrap`, but the `tactic_state` is rolled back to point of capture even upon success. 
 -/
-meta def unwrap {α : Type*} (t : tactic_result α) : tactic α :=
+meta def resume {α : Type*} (t : tactic_result α) : tactic α :=
 λ s, t
 
 meta def get_options : tactic options :=

--- a/library/init/meta/tactic.lean
+++ b/library/init/meta/tactic.lean
@@ -154,31 +154,6 @@ match t s with
 | (success _ s') := success () s'
 end
 
-/--
-`capture t` acts like `t`, but succeeds with a result containing either the returned value
-or the exception.
-
-The result can be used to inspect the error message, or passed to `unwrap` to rethrow the
-failure later.
--/
-meta def capture (t : tactic α) : tactic (tactic_result α) :=
-t <$> read
-
-/--
-`unwrap r` unwraps a result previously obtained using `capture`.
-
-If the previous result was a success, this produces its wrapped value.
-If the previous result was an exception, this "rethrows" the exception as if it came
-from where it originated.
-
-`do r ← capture t, unwrap r` is identical to `t`, but allows for intermediate tactics to be inserted.
--/
-meta def unwrap {α : Type*} (t : tactic_result α) : tactic α :=
-match t with
-| (success r s') := return r
-| e := λ s, e
-end
-
 meta def try_lst : list (tactic unit) → tactic unit
 | []            := failed
 | (tac :: tacs) := λ s,
@@ -294,6 +269,31 @@ meta def decorate_ex (msg : format) (t : tactic α) : tactic α :=
 /-- Get the tactic_state. -/
 @[inline] meta def read : tactic tactic_state :=
 λ s, success s s
+
+/--
+`capture t` acts like `t`, but succeeds with a result containing either the returned value
+or the exception.
+
+The result can be used to inspect the error message, or passed to `unwrap` to rethrow the
+failure later.
+-/
+meta def capture (t : tactic α) : tactic (tactic_result α) :=
+t <$> read
+
+/--
+`unwrap r` unwraps a result previously obtained using `capture`.
+
+If the previous result was a success, this produces its wrapped value.
+If the previous result was an exception, this "rethrows" the exception as if it came
+from where it originated.
+
+`do r ← capture t, unwrap r` is identical to `t`, but allows for intermediate tactics to be inserted.
+-/
+meta def unwrap {α : Type*} (t : tactic_result α) : tactic α :=
+match t with
+| (success r s') := return r
+| e := λ s, e
+end
 
 meta def get_options : tactic options :=
 do s ← read, return s.get_options

--- a/tests/lean/fail/conv_for.lean
+++ b/tests/lean/fail/conv_for.lean
@@ -1,0 +1,7 @@
+example {a b c : ℕ} : (a * b) * c = (a * b) * c := begin
+  conv {
+    for (_ * _) [1] {
+      rw does_not_exist,
+    },
+  },
+end


### PR DESCRIPTION
An example of the type of code that used to work and now fails:
```lean
import algebra.ring

example {a b c : ℕ} : (a * b) * c = (a * b) * c :=  begin
  conv {
    for (_ * _) [1] {
      rw this_isnt_a_lemma,  -- no error message?
    },
  },
end

example {a b c : ℕ} : (a * b) * c = (a * b) * c :=  begin
  conv {
    find (_ * _) {
      rw this_isnt_a_lemma,  -- no error message?
    },  -- error: pattern not found (not true!)
  },
end
```
Without this PR, users like me get no information on why their tactic failed, which is a very frustrating experience.

The problem here is that `ext_simplify_core` ignores all failures in its `pre` and `post` arguments - failures are treated as "there was nothing to simplify here, move on to the next one". In `find` and `for`, we need to distinguish the cases of failing due to the pattern not matching and failuring due to an error in the user-provided tactic.

This PR adds two new tactic primitives, `tactic.capture` and `tactic.unwrap`, inspired by the python functions [from the `trio-outcome` package](https://outcome.readthedocs.io/en/latest/api.html) with the same name. `capture` can be used to run the user-provided tactic and keep track of any errors that occured. `unwrap` is then used to re-throw the error once `ext_simplify_core` is done.

CI run: https://github.com/eric-wieser/lean/actions/runs/297777454 (This repo isn't set up to run CI on PRs, so that's the best I can do.)

---

An alternative that I deliberately avoided would be to change  `ext_simplify_core`. This would be an API change, making the result type of the `pre` and `post` arguments `tactic (option ...)` instead of `tactic ...`, where a result of `none` would have the semantics currently occupied by `tactic.failed`. I didn't want to do this because:
* It's written in C++
* It requires an API change that would require adjusting every single caller of `ext_simplify_core`. In its simplest form, this would mean replacing `guard p, ...` calls with `if not p then return none else ...`. Great care would need to be taken to work out which failures should become `none` and which ones shouldn't.