### PR TITLE
[Merged by Bors] - fix(library/init/meta/tactic): fix inaccurate failure messages in focus and focus'

### DIFF
--- a/library/init/meta/tactic.lean
+++ b/library/init/meta/tactic.lean
@@ -1156,11 +1156,11 @@ first $ map solve1 ts
 
 private meta def focus_aux {α} : list (tactic α) → list expr → list expr → tactic (list α)
 | []       []      rs := set_goals rs *> pure []
-| (t::ts)  []      rs := fail "focus' tactic failed, insufficient number of goals"
+| (t::ts)  []      rs := fail "focus tactic failed, insufficient number of goals"
 | tts      (g::gs) rs :=
   mcond (is_assigned g) (focus_aux tts gs rs) $
     do set_goals [g],
-       t::ts ← pure tts | fail "focus' tactic failed, insufficient number of tactics",
+       t::ts ← pure tts | fail "focus tactic failed, insufficient number of tactics",
        a ← t,
        rs' ← get_goals,
        as ← focus_aux ts gs (rs ++ rs'),
@@ -1175,11 +1175,11 @@ do gs ← get_goals, focus_aux ts gs []
 
 private meta def focus'_aux : list (tactic unit) → list expr → list expr → tactic unit
 | []       []      rs := set_goals rs
-| (t::ts)  []      rs := fail "focus tactic failed, insufficient number of goals"
+| (t::ts)  []      rs := fail "focus' tactic failed, insufficient number of goals"
 | tts      (g::gs) rs :=
   mcond (is_assigned g) (focus'_aux tts gs rs) $
     do set_goals [g],
-       t::ts ← pure tts | fail "focus tactic failed, insufficient number of tactics",
+       t::ts ← pure tts | fail "focus' tactic failed, insufficient number of tactics",
        t,
        rs' ← get_goals,
        focus'_aux ts gs (rs ++ rs')

--- a/tests/lean/andthen_focus_error_message.lean.expected.out
+++ b/tests/lean/andthen_focus_error_message.lean.expected.out
@@ -1,16 +1,16 @@
-andthen_focus_error_message.lean:3:14: error: focus' tactic failed, insufficient number of goals
+andthen_focus_error_message.lean:3:14: error: focus tactic failed, insufficient number of goals
 state:
 a b c : ℕ
 ⊢ b = b
-andthen_focus_error_message.lean:9:13: error: focus' tactic failed, insufficient number of goals
+andthen_focus_error_message.lean:9:13: error: focus tactic failed, insufficient number of goals
 state:
 a b c : ℕ
 ⊢ b = b
-andthen_focus_error_message.lean:16:14: error: focus' tactic failed, insufficient number of tactics
+andthen_focus_error_message.lean:16:14: error: focus tactic failed, insufficient number of tactics
 state:
 a : ℕ
 ⊢ a = a
-andthen_focus_error_message.lean:22:14: error: focus' tactic failed, insufficient number of tactics
+andthen_focus_error_message.lean:22:14: error: focus tactic failed, insufficient number of tactics
 state:
 a : ℕ
 ⊢ a = a


### PR DESCRIPTION
Not a big deal, the error messages are just backwards here - when `focus` fails the error says that `focus'` failed, and vice versa.