### PR TITLE
[Merged by Bors] - refactor(init/algebra/order): add `decidable_*` assumptions to `linear_order`

### DIFF
--- a/library/data/buffer.lean
+++ b/library/data/buffer.lean
@@ -71,7 +71,7 @@ have h₁ : 1 > 0, from dec_trivial,
 nat.sub_lt h h₁
 
 lemma lt_aux_3 {n i} (h : i + 1 < n) : n - 2 - i < n  :=
-have n > 0,     from lt.trans (nat.zero_lt_succ i) h,
+have n > 0,     from lt_trans (nat.zero_lt_succ i) h,
 have n - 2 < n, from nat.sub_lt this (dec_trivial),
 lt_of_le_of_lt (nat.sub_le _ _) this
 

--- a/library/init/algebra/functions.lean
+++ b/library/init/algebra/functions.lean
@@ -9,12 +9,12 @@ import init.algebra.order init.meta
 
 universe u
 
-definition min {α : Type u} [decidable_linear_order α] (a b : α) : α := if a ≤ b then a else b
-definition max {α : Type u} [decidable_linear_order α] (a b : α) : α := if b ≤ a then a else b
+definition min {α : Type u} [linear_order α] (a b : α) : α := if a ≤ b then a else b
+definition max {α : Type u} [linear_order α] (a b : α) : α := if b ≤ a then a else b
 
 section
 open decidable tactic
-variables {α : Type u} [decidable_linear_order α]
+variables {α : Type u} [linear_order α]
 
 private meta def min_tac_step : tactic unit :=
 solve1 $ intros

--- a/library/init/algebra/order.lean
+++ b/library/init/algebra/order.lean
@@ -15,6 +15,13 @@ universe u
 variables {α : Type u}
 
 set_option auto_param.check_exists false
+
+section preorder
+
+/-!
+### Definition of `preorder` and lemmas about types with a `preorder`
+-/
+
 /-- A preorder is a reflexive, transitive relation `≤` with `a < b` defined in the obvious way. -/
 class preorder (α : Type u) extends has_le α, has_lt α :=
 (le_refl : ∀ a : α, a ≤ a)
@@ -22,176 +29,90 @@ class preorder (α : Type u) extends has_le α, has_lt α :=
 (lt := λ a b, a ≤ b ∧ ¬ b ≤ a)
 (lt_iff_le_not_le : ∀ a b : α, a < b ↔ (a ≤ b ∧ ¬ b ≤ a) . order_laws_tac)
 
-/-- A partial order is a reflexive, transitive, antisymmetric relation `≤`. -/
-class partial_order (α : Type u) extends preorder α :=
-(le_antisymm : ∀ a b : α, a ≤ b → b ≤ a → a = b)
-
-/-- A linear order is reflexive, transitive, antisymmetric and total relation `≤`.-/
-class linear_order (α : Type u) extends partial_order α :=
-(le_total : ∀ a b : α, a ≤ b ∨ b ≤ a)
+variables [preorder α]
 
 /-- The relation `≤` on a preorder is reflexive. -/
-@[refl] lemma le_refl [preorder α] : ∀ a : α, a ≤ a :=
+@[refl] lemma le_refl : ∀ a : α, a ≤ a :=
 preorder.le_refl
 
 /-- The relation `≤` on a preorder is transitive. -/
-@[trans] lemma le_trans [preorder α] : ∀ {a b c : α}, a ≤ b → b ≤ c → a ≤ c :=
+@[trans] lemma le_trans : ∀ {a b c : α}, a ≤ b → b ≤ c → a ≤ c :=
 preorder.le_trans
 
-lemma lt_iff_le_not_le [preorder α] : ∀ {a b : α}, a < b ↔ (a ≤ b ∧ ¬ b ≤ a) :=
+lemma lt_iff_le_not_le : ∀ {a b : α}, a < b ↔ (a ≤ b ∧ ¬ b ≤ a) :=
 preorder.lt_iff_le_not_le
 
-lemma lt_of_le_not_le [preorder α] : ∀ {a b : α}, a ≤ b → ¬ b ≤ a → a < b
+lemma lt_of_le_not_le : ∀ {a b : α}, a ≤ b → ¬ b ≤ a → a < b
 | a b hab hba := lt_iff_le_not_le.mpr ⟨hab, hba⟩
 
-lemma le_not_le_of_lt [preorder α] : ∀ {a b : α}, a < b → a ≤ b ∧ ¬ b ≤ a
+lemma le_not_le_of_lt : ∀ {a b : α}, a < b → a ≤ b ∧ ¬ b ≤ a
 | a b hab := lt_iff_le_not_le.mp hab
 
-lemma le_antisymm [partial_order α] : ∀ {a b : α}, a ≤ b → b ≤ a → a = b :=
-partial_order.le_antisymm
-
-lemma le_of_eq [preorder α] {a b : α} : a = b → a ≤ b :=
+lemma le_of_eq {a b : α} : a = b → a ≤ b :=
 λ h, h ▸ le_refl a
 
-lemma le_antisymm_iff [partial_order α] {a b : α} : a = b ↔ a ≤ b ∧ b ≤ a :=
-⟨λe, ⟨le_of_eq e, le_of_eq e.symm⟩, λ⟨h1, h2⟩, le_antisymm h1 h2⟩
-
-@[trans] lemma ge_trans [preorder α] : ∀ {a b c : α}, a ≥ b → b ≥ c → a ≥ c :=
+@[trans] lemma ge_trans : ∀ {a b c : α}, a ≥ b → b ≥ c → a ≥ c :=
 λ a b c h₁ h₂, le_trans h₂ h₁
 
-lemma le_total [linear_order α] : ∀ a b : α, a ≤ b ∨ b ≤ a :=
-linear_order.le_total
-
-lemma le_of_not_ge [linear_order α] {a b : α} : ¬ a ≥ b → a ≤ b :=
-or.resolve_left (le_total b a)
-
-lemma le_of_not_le [linear_order α] {a b : α} : ¬ a ≤ b → b ≤ a :=
-or.resolve_left (le_total a b)
-
-lemma lt_irrefl [preorder α] : ∀ a : α, ¬ a < a
+lemma lt_irrefl : ∀ a : α, ¬ a < a
 | a haa := match le_not_le_of_lt haa with
   | ⟨h1, h2⟩ := false.rec _ (h2 h1)
   end
 
-lemma gt_irrefl [preorder α] : ∀ a : α, ¬ a > a :=
+lemma gt_irrefl : ∀ a : α, ¬ a > a :=
 lt_irrefl
 
-@[trans] lemma lt_trans [preorder α] : ∀ {a b c : α}, a < b → b < c → a < c
+@[trans] lemma lt_trans : ∀ {a b c : α}, a < b → b < c → a < c
 | a b c hab hbc :=
   match le_not_le_of_lt hab, le_not_le_of_lt hbc with
   | ⟨hab, hba⟩, ⟨hbc, hcb⟩ := lt_of_le_not_le (le_trans hab hbc) (λ hca, hcb (le_trans hca hab))
   end
 
-def lt.trans := @lt_trans
-
-@[trans] lemma gt_trans [preorder α] : ∀ {a b c : α}, a > b → b > c → a > c :=
+@[trans] lemma gt_trans : ∀ {a b c : α}, a > b → b > c → a > c :=
 λ a b c h₁ h₂, lt_trans h₂ h₁
 
-def gt.trans := @gt_trans
-
-lemma ne_of_lt [preorder α] {a b : α} (h : a < b) : a ≠ b :=
+lemma ne_of_lt {a b : α} (h : a < b) : a ≠ b :=
 λ he, absurd h (he ▸ lt_irrefl a)
 
-lemma ne_of_gt [preorder α] {a b : α} (h : a > b) : a ≠ b :=
+lemma ne_of_gt {a b : α} (h : a > b) : a ≠ b :=
 λ he, absurd h (he ▸ lt_irrefl a)
 
-lemma lt_asymm [preorder α] {a b : α} (h : a < b) : ¬ b < a :=
+lemma lt_asymm {a b : α} (h : a < b) : ¬ b < a :=
 λ h1 : b < a, lt_irrefl a (lt_trans h h1)
 
-lemma not_lt_of_gt [linear_order α] {a b : α} (h : a > b) : ¬ a < b :=
-lt_asymm h
-
-lemma le_of_lt [preorder α] : ∀ {a b : α}, a < b → a ≤ b
+lemma le_of_lt : ∀ {a b : α}, a < b → a ≤ b
 | a b hab := (le_not_le_of_lt hab).left
 
-@[trans] lemma lt_of_lt_of_le [preorder α] : ∀ {a b c : α}, a < b → b ≤ c → a < c
+@[trans] lemma lt_of_lt_of_le : ∀ {a b c : α}, a < b → b ≤ c → a < c
 | a b c hab hbc :=
   let ⟨hab, hba⟩ := le_not_le_of_lt hab in
   lt_of_le_not_le (le_trans hab hbc) $ λ hca, hba (le_trans hbc hca)
 
-@[trans] lemma lt_of_le_of_lt [preorder α] : ∀ {a b c : α}, a ≤ b → b < c → a < c
+@[trans] lemma lt_of_le_of_lt : ∀ {a b c : α}, a ≤ b → b < c → a < c
 | a b c hab hbc :=
   let ⟨hbc, hcb⟩ := le_not_le_of_lt hbc in
   lt_of_le_not_le (le_trans hab hbc) $ λ hca, hcb (le_trans hca hab)
 
-@[trans] lemma gt_of_gt_of_ge [preorder α] {a b c : α} (h₁ : a > b) (h₂ : b ≥ c) : a > c :=
+@[trans] lemma gt_of_gt_of_ge {a b c : α} (h₁ : a > b) (h₂ : b ≥ c) : a > c :=
 lt_of_le_of_lt h₂ h₁
 
-@[trans] lemma gt_of_ge_of_gt [preorder α] {a b c : α} (h₁ : a ≥ b) (h₂ : b > c) : a > c :=
+@[trans] lemma gt_of_ge_of_gt {a b c : α} (h₁ : a ≥ b) (h₂ : b > c) : a > c :=
 lt_of_lt_of_le h₂ h₁
 
-lemma not_le_of_gt [preorder α] {a b : α} (h : a > b) : ¬ a ≤ b :=
+lemma not_le_of_gt {a b : α} (h : a > b) : ¬ a ≤ b :=
 (le_not_le_of_lt h).right
 
-lemma not_lt_of_ge [preorder α] {a b : α} (h : a ≥ b) : ¬ a < b :=
+lemma not_lt_of_ge {a b : α} (h : a ≥ b) : ¬ a < b :=
 λ hab, not_le_of_gt hab h
 
-lemma lt_or_eq_of_le [partial_order α] : ∀ {a b : α}, a ≤ b → a < b ∨ a = b
-| a b hab := classical.by_cases
-  (λ hba : b ≤ a, or.inr (le_antisymm hab hba))
-  (λ hba, or.inl (lt_of_le_not_le hab hba))
-
-lemma le_of_lt_or_eq [preorder α] : ∀ {a b : α}, (a < b ∨ a = b) → a ≤ b
+lemma le_of_lt_or_eq : ∀ {a b : α}, (a < b ∨ a = b) → a ≤ b
 | a b (or.inl hab) := le_of_lt hab
 | a b (or.inr hab) := hab ▸ le_refl _
 
-lemma le_iff_lt_or_eq [partial_order α] : ∀ {a b : α}, a ≤ b ↔ a < b ∨ a = b
-| a b := ⟨lt_or_eq_of_le, le_of_lt_or_eq⟩
-
-lemma lt_of_le_of_ne [partial_order α] {a b : α} : a ≤ b → a ≠ b → a < b :=
-λ h₁ h₂, lt_of_le_not_le h₁ $ mt (le_antisymm h₁) h₂
-
-lemma lt_trichotomy [linear_order α] (a b : α) : a < b ∨ a = b ∨ b < a :=
-or.elim (le_total a b)
-  (λ h : a ≤ b, or.elim (lt_or_eq_of_le h)
-    (λ h : a < b, or.inl h)
-    (λ h : a = b, or.inr (or.inl h)))
-  (λ h : b ≤ a, or.elim (lt_or_eq_of_le h)
-    (λ h : b < a, or.inr (or.inr h))
-    (λ h : b = a, or.inr (or.inl h.symm)))
-
-lemma le_of_not_gt [linear_order α] {a b : α} (h : ¬ a > b) : a ≤ b :=
-match lt_trichotomy a b with
-| or.inl hlt          := le_of_lt hlt
-| or.inr (or.inl heq) := heq ▸ le_refl a
-| or.inr (or.inr hgt) := absurd hgt h
-end
-
-lemma lt_of_not_ge [linear_order α] {a b : α} (h : ¬ a ≥ b) : a < b :=
-lt_of_le_not_le ((le_total _ _).resolve_right h) h
-
-lemma lt_or_ge [linear_order α] (a b : α) : a < b ∨ a ≥ b :=
-match lt_trichotomy a b with
-| or.inl hlt          := or.inl hlt
-| or.inr (or.inl heq) := or.inr (heq ▸ le_refl a)
-| or.inr (or.inr hgt) := or.inr (le_of_lt hgt)
-end
-
-lemma le_or_gt [linear_order α] (a b : α) : a ≤ b ∨ a > b :=
-or.swap (lt_or_ge b a)
-
-lemma lt_or_gt_of_ne [linear_order α] {a b : α} (h : a ≠ b) : a < b ∨ a > b :=
-match lt_trichotomy a b with
-| or.inl hlt          := or.inl hlt
-| or.inr (or.inl heq) := absurd heq h
-| or.inr (or.inr hgt) := or.inr hgt
-end
-
-lemma le_of_eq_or_lt [preorder α] {a b : α} (h : a = b ∨ a < b) : a ≤ b :=
+lemma le_of_eq_or_lt {a b : α} (h : a = b ∨ a < b) : a ≤ b :=
 or.elim h le_of_eq le_of_lt
 
-lemma ne_iff_lt_or_gt [linear_order α] {a b : α} : a ≠ b ↔ a < b ∨ a > b :=
-⟨lt_or_gt_of_ne, λo, or.elim o ne_of_lt ne_of_gt⟩
-
-lemma lt_iff_not_ge [linear_order α] (x y : α) : x < y ↔ ¬ x ≥ y :=
-⟨not_le_of_gt, lt_of_not_ge⟩
-
-@[simp] lemma not_lt [linear_order α] {a b : α} : ¬ a < b ↔ b ≤ a := ⟨le_of_not_gt, not_lt_of_ge⟩
-
-@[simp] lemma not_le [linear_order α] {a b : α} : ¬ a ≤ b ↔ b < a := (lt_iff_not_ge _ _).symm
-
-instance decidable_lt_of_decidable_le [preorder α]
-  [decidable_rel ((≤) : α → α → Prop)] :
+instance decidable_lt_of_decidable_le [decidable_rel ((≤) : α → α → Prop)] :
   decidable_rel ((<) : α → α → Prop)
 | a b :=
   if hab : a ≤ b then
@@ -202,8 +123,38 @@ instance decidable_lt_of_decidable_le [preorder α]
   else
     is_false $ λ hab', hab (le_of_lt hab')
 
-instance decidable_eq_of_decidable_le [partial_order α]
-  [decidable_rel ((≤) : α → α → Prop)] :
+end preorder
+
+section partial_order
+
+/-!
+### Definition of `partial_order` and lemmas about types with a partial order
+-/
+
+/-- A partial order is a reflexive, transitive, antisymmetric relation `≤`. -/
+class partial_order (α : Type u) extends preorder α :=
+(le_antisymm : ∀ a b : α, a ≤ b → b ≤ a → a = b)
+
+variables [partial_order α]
+
+lemma le_antisymm : ∀ {a b : α}, a ≤ b → b ≤ a → a = b :=
+partial_order.le_antisymm
+
+lemma le_antisymm_iff {a b : α} : a = b ↔ a ≤ b ∧ b ≤ a :=
+⟨λe, ⟨le_of_eq e, le_of_eq e.symm⟩, λ⟨h1, h2⟩, le_antisymm h1 h2⟩
+
+lemma lt_or_eq_of_le : ∀ {a b : α}, a ≤ b → a < b ∨ a = b
+| a b hab := classical.by_cases
+  (λ hba : b ≤ a, or.inr (le_antisymm hab hba))
+  (λ hba, or.inl (lt_of_le_not_le hab hba))
+
+lemma le_iff_lt_or_eq : ∀ {a b : α}, a ≤ b ↔ a < b ∨ a = b
+| a b := ⟨lt_or_eq_of_le, le_of_lt_or_eq⟩
+
+lemma lt_of_le_of_ne {a b : α} : a ≤ b → a ≠ b → a < b :=
+λ h₁ h₂, lt_of_le_not_le h₁ $ mt (le_antisymm h₁) h₂
+
+instance decidable_eq_of_decidable_le [decidable_rel ((≤) : α → α → Prop)] :
   decidable_eq α
 | a b :=
   if hab : a ≤ b then
@@ -214,35 +165,109 @@ instance decidable_eq_of_decidable_le [partial_order α]
   else
     is_false (λ heq, hab (heq ▸ le_refl _))
 
-class decidable_linear_order (α : Type u) extends linear_order α :=
+end partial_order
+
+section linear_order
+
+/-!
+### Definition of `linear_order` and lemmas about types with a linear order
+-/
+
+/-- A linear order is reflexive, transitive, antisymmetric and total relation `≤`.
+We assume that every linear ordered type has decidable `(≤)`, `(<)`, and `(=)`. -/
+class linear_order (α : Type u) extends partial_order α :=
+(le_total : ∀ a b : α, a ≤ b ∨ b ≤ a)
 (decidable_le : decidable_rel (≤))
 (decidable_eq : decidable_eq α := @decidable_eq_of_decidable_le _ _ decidable_le)
 (decidable_lt : decidable_rel ((<) : α → α → Prop) :=
     @decidable_lt_of_decidable_le _ _ decidable_le)
 
-instance [decidable_linear_order α] (a b : α) : decidable (a < b) :=
-decidable_linear_order.decidable_lt a b
+variables [linear_order α]
 
-instance [decidable_linear_order α] (a b : α) : decidable (a ≤ b) :=
-decidable_linear_order.decidable_le a b
+lemma le_total : ∀ a b : α, a ≤ b ∨ b ≤ a :=
+linear_order.le_total
 
-instance [decidable_linear_order α] (a b : α) : decidable (a = b) :=
-decidable_linear_order.decidable_eq a b
+lemma le_of_not_ge {a b : α} : ¬ a ≥ b → a ≤ b :=
+or.resolve_left (le_total b a)
 
-lemma eq_or_lt_of_not_lt [decidable_linear_order α] {a b : α} (h : ¬ a < b) : a = b ∨ b < a :=
+lemma le_of_not_le {a b : α} : ¬ a ≤ b → b ≤ a :=
+or.resolve_left (le_total a b)
+
+lemma not_lt_of_gt {a b : α} (h : a > b) : ¬ a < b :=
+lt_asymm h
+
+lemma lt_trichotomy (a b : α) : a < b ∨ a = b ∨ b < a :=
+or.elim (le_total a b)
+  (λ h : a ≤ b, or.elim (lt_or_eq_of_le h)
+    (λ h : a < b, or.inl h)
+    (λ h : a = b, or.inr (or.inl h)))
+  (λ h : b ≤ a, or.elim (lt_or_eq_of_le h)
+    (λ h : b < a, or.inr (or.inr h))
+    (λ h : b = a, or.inr (or.inl h.symm)))
+
+lemma le_of_not_gt {a b : α} (h : ¬ a > b) : a ≤ b :=
+match lt_trichotomy a b with
+| or.inl hlt          := le_of_lt hlt
+| or.inr (or.inl heq) := heq ▸ le_refl a
+| or.inr (or.inr hgt) := absurd hgt h
+end
+
+lemma lt_of_not_ge {a b : α} (h : ¬ a ≥ b) : a < b :=
+lt_of_le_not_le ((le_total _ _).resolve_right h) h
+
+lemma lt_or_ge (a b : α) : a < b ∨ a ≥ b :=
+match lt_trichotomy a b with
+| or.inl hlt          := or.inl hlt
+| or.inr (or.inl heq) := or.inr (heq ▸ le_refl a)
+| or.inr (or.inr hgt) := or.inr (le_of_lt hgt)
+end
+
+lemma le_or_gt (a b : α) : a ≤ b ∨ a > b :=
+or.swap (lt_or_ge b a)
+
+lemma lt_or_gt_of_ne {a b : α} (h : a ≠ b) : a < b ∨ a > b :=
+match lt_trichotomy a b with
+| or.inl hlt          := or.inl hlt
+| or.inr (or.inl heq) := absurd heq h
+| or.inr (or.inr hgt) := or.inr hgt
+end
+
+lemma ne_iff_lt_or_gt {a b : α} : a ≠ b ↔ a < b ∨ a > b :=
+⟨lt_or_gt_of_ne, λo, or.elim o ne_of_lt ne_of_gt⟩
+
+lemma lt_iff_not_ge (x y : α) : x < y ↔ ¬ x ≥ y :=
+⟨not_le_of_gt, lt_of_not_ge⟩
+
+@[simp] lemma not_lt {a b : α} : ¬ a < b ↔ b ≤ a := ⟨le_of_not_gt, not_lt_of_ge⟩
+
+@[simp] lemma not_le {a b : α} : ¬ a ≤ b ↔ b < a := (lt_iff_not_ge _ _).symm
+
+instance (a b : α) : decidable (a < b) :=
+linear_order.decidable_lt a b
+
+instance (a b : α) : decidable (a ≤ b) :=
+linear_order.decidable_le a b
+
+instance (a b : α) : decidable (a = b) :=
+linear_order.decidable_eq a b
+
+lemma eq_or_lt_of_not_lt {a b : α} (h : ¬ a < b) : a = b ∨ b < a :=
 if h₁ : a = b then or.inl h₁
 else or.inr (lt_of_not_ge (λ hge, h (lt_of_le_of_ne hge h₁)))
 
-instance [decidable_linear_order α] : is_total_preorder α (≤) :=
+instance : is_total_preorder α (≤) :=
 {trans := @le_trans _ _, total := le_total}
 
 /- TODO(Leo): decide whether we should keep this instance or not -/
-instance is_strict_weak_order_of_decidable_linear_order [decidable_linear_order α] : is_strict_weak_order α (<) :=
+instance is_strict_weak_order_of_linear_order : is_strict_weak_order α (<) :=
 is_strict_weak_order_of_is_total_preorder lt_iff_not_ge
 
 /- TODO(Leo): decide whether we should keep this instance or not -/
-instance is_strict_total_order_of_decidable_linear_order [decidable_linear_order α] : is_strict_total_order α (<) :=
+instance is_strict_total_order_of_linear_order : is_strict_total_order α (<) :=
 { trichotomous := lt_trichotomy }
+
+end linear_order
+
 
 namespace decidable
 
@@ -256,35 +281,35 @@ lemma eq_or_lt_of_le [partial_order α] [@decidable_rel α (≤)] {a b : α} (ha
 lemma le_iff_lt_or_eq [partial_order α] [@decidable_rel α (≤)] {a b : α} : a ≤ b ↔ a < b ∨ a = b :=
 ⟨lt_or_eq_of_le, le_of_lt_or_eq⟩
 
-lemma le_of_not_lt [decidable_linear_order α] {a b : α} (h : ¬ b < a) : a ≤ b :=
+lemma le_of_not_lt [linear_order α] {a b : α} (h : ¬ b < a) : a ≤ b :=
 decidable.by_contradiction $ λ h', h $ lt_of_le_not_le ((le_total _ _).resolve_right h') h'
 
-lemma not_lt [decidable_linear_order α] {a b : α} : ¬ a < b ↔ b ≤ a :=
+lemma not_lt [linear_order α] {a b : α} : ¬ a < b ↔ b ≤ a :=
 ⟨le_of_not_lt, not_lt_of_ge⟩
 
-lemma lt_or_le [decidable_linear_order α] (a b : α) : a < b ∨ b ≤ a :=
+lemma lt_or_le [linear_order α] (a b : α) : a < b ∨ b ≤ a :=
 if hba : b ≤ a then or.inr hba else or.inl $ lt_of_not_ge hba
 
-lemma le_or_lt [decidable_linear_order α] (a b : α) : a ≤ b ∨ b < a :=
+lemma le_or_lt [linear_order α] (a b : α) : a ≤ b ∨ b < a :=
 (lt_or_le b a).swap
 
-lemma lt_trichotomy [decidable_linear_order α] (a b : α) : a < b ∨ a = b ∨ b < a :=
+lemma lt_trichotomy [linear_order α] (a b : α) : a < b ∨ a = b ∨ b < a :=
 (lt_or_le _ _).imp_right $ λ h, (eq_or_lt_of_le h).imp_left eq.symm
 
-lemma lt_or_gt_of_ne [decidable_linear_order α] {a b : α} (h : a ≠ b) : a < b ∨ b < a :=
+lemma lt_or_gt_of_ne [linear_order α] {a b : α} (h : a ≠ b) : a < b ∨ b < a :=
 (lt_trichotomy a b).imp_right $ λ h', h'.resolve_left h
 
 /-- Perform a case-split on the ordering of `x` and `y` in a decidable linear order. -/
-def lt_by_cases [decidable_linear_order α] (x y : α) {P : Sort*}
+def lt_by_cases [linear_order α] (x y : α) {P : Sort*}
   (h₁ : x < y → P) (h₂ : x = y → P) (h₃ : y < x → P) : P :=
 if h : x < y then h₁ h else
 if h' : y < x then h₃ h' else
 h₂ (le_antisymm (le_of_not_gt h') (le_of_not_gt h))
 
-lemma ne_iff_lt_or_gt [decidable_linear_order α] {a b : α} : a ≠ b ↔ a < b ∨ b < a :=
+lemma ne_iff_lt_or_gt [linear_order α] {a b : α} : a ≠ b ↔ a < b ∨ b < a :=
 ⟨lt_or_gt_of_ne, λo, o.elim ne_of_lt ne_of_gt⟩
 
-lemma le_imp_le_of_lt_imp_lt {β} [preorder α] [decidable_linear_order β]
+lemma le_imp_le_of_lt_imp_lt {β} [preorder α] [linear_order β]
   {a b : α} {c d : β} (H : d < c → b < a) (h : a ≤ b) : c ≤ d :=
 le_of_not_lt $ λ h', not_le_of_gt (H h') h
 

--- a/library/init/data/fin/ops.lean
+++ b/library/init/data/fin/ops.lean
@@ -19,7 +19,7 @@ def of_nat {n : nat} (a : nat) : fin (succ n) :=
 private lemma mlt {n b : nat} : ∀ {a}, n > a → b % n < n
 | 0     h := nat.mod_lt _ h
 | (a+1) h :=
-  have n > 0, from lt.trans (nat.zero_lt_succ _) h,
+  have n > 0, from lt_trans (nat.zero_lt_succ _) h,
   nat.mod_lt _ this
 
 protected def add : fin n → fin n → fin n
@@ -40,7 +40,7 @@ begin
   {simp [mod_zero], assumption},
   {have h : a % (succ b) < succ b,
    apply nat.mod_lt _ (nat.zero_lt_succ _),
-   exact lt.trans h h₂}
+   exact lt_trans h h₂}
 end
 
 protected def mod : fin n → fin n → fin n

--- a/library/init/data/int/order.lean
+++ b/library/init/data/int/order.lean
@@ -187,7 +187,7 @@ simp [int.lt_iff_le_and_ne], split; intro h,
   { intro h, simp [*] at * } }
 end
 
-instance : decidable_linear_order int :=
+instance : linear_order int :=
 { le              := int.le,
   le_refl         := int.le_refl,
   le_trans        := @int.le_trans,

--- a/library/init/data/nat/lemmas.lean
+++ b/library/init/data/nat/lemmas.lean
@@ -175,7 +175,10 @@ instance : linear_order ℕ :=
   le_antisymm := @nat.le_antisymm,
   le_total := @nat.le_total,
   lt := nat.lt,
-  lt_iff_le_not_le := @nat.lt_iff_le_not_le }
+  lt_iff_le_not_le := @nat.lt_iff_le_not_le,
+  decidable_lt               := nat.decidable_lt,
+  decidable_le               := nat.decidable_le,
+  decidable_eq               := nat.decidable_eq }
 
 lemma eq_zero_of_le_zero {n : nat} (h : n ≤ 0) : n = 0 :=
 le_antisymm h (zero_le _)
@@ -287,18 +290,6 @@ nat.lt_of_lt_of_le (nat.lt_add_of_pos_right hk) (mul_succ k n ▸ nat.mul_le_mul
 
 protected lemma mul_lt_mul_of_pos_right {n m k : ℕ} (h : n < m) (hk : k > 0) : n * k < m * k :=
 nat.mul_comm k m ▸ nat.mul_comm k n ▸ nat.mul_lt_mul_of_pos_left h hk
-
-instance : decidable_linear_order nat :=
-{ lt                         := nat.lt,
-  le                         := nat.le,
-  le_refl                    := nat.le_refl,
-  le_trans                   := @nat.le_trans,
-  le_antisymm                := @nat.le_antisymm,
-  le_total                   := @nat.le_total,
-  lt_iff_le_not_le           := @lt_iff_le_not_le _ _,
-  decidable_lt               := nat.decidable_lt,
-  decidable_le               := nat.decidable_le,
-  decidable_eq               := nat.decidable_eq }
 
 protected lemma le_of_mul_le_mul_left {a b c : ℕ} (h : c * a ≤ c * b) (hc : c > 0) : a ≤ b :=
 decidable.not_lt.1

--- a/tests/lean/extra/lt_rec.lean
+++ b/tests/lean/extra/lt_rec.lean
@@ -12,5 +12,5 @@ lt_succ (lt.base a)  := lt.base (succ a),
 lt_succ (lt.step h)  := lt.step (lt_succ h)
 
 definition lt_of_succ : ∀ {a b : nat}, succ a < b → a < b,
-lt_of_succ (lt.base (succ a)) := lt.trans (lt.base a) (lt.base (succ a)),
+lt_of_succ (lt.base (succ a)) := lt_trans (lt.base a) (lt.base (succ a)),
 lt_of_succ (lt.step h₂)       := lt.step (lt_of_succ h₂)

--- a/tests/lean/run/order_defaults.lean
+++ b/tests/lean/run/order_defaults.lean
@@ -17,4 +17,5 @@ example : linear_order unit := {
     le_trans := λ _ _ _ _ _, trivial,
     le_antisymm := by intros a b; intros; cases a; cases b; refl,
     le_total := λ _ _, or.inl trivial,
+    decidable_le := infer_instance
 }

--- a/tests/lean/run/term_app2.lean
+++ b/tests/lean/run/term_app2.lean
@@ -10,7 +10,7 @@ end
 lemma nat.lt_one_add_of_lt {a b : nat} : a < b → a < 1 + b :=
 begin
   intro h,
-  have aux := lt.trans h (nat.lt_succ_self _),
+  have aux := lt_trans h (nat.lt_succ_self _),
   rwa [<- nat.add_one, nat.add_comm] at aux
 end
 


### PR DESCRIPTION
See [Zulip discussion](https://leanprover.zulipchat.com/#narrow/stream/116395-maths/topic/decidable.20linear.20order).

Other changes:
* drop `decidable_linear_order`;
* sort lemmas in `init/algebra/order` by typeclass assumption;
* remove `lt.trans` and `gt.trans`: they were not useful for dot
  syntax anyway.


----

Is it possible to make a fake release so that github CI will be able
to build `mathlib` with this Lean?