### PR TITLE
[Merged by Bors] - feat(init/meta/tactic): by_contradiction tweaks

### DIFF
--- a/library/init/meta/interactive.lean
+++ b/library/init/meta/interactive.lean
@@ -1577,15 +1577,17 @@ meta def funext : parse ident_* → tactic unit
 | hs := funext_lst hs >> skip
 
 /--
-If the target of the main goal is a proposition `p`, `by_contradiction h` reduces the goal to proving `false` using the additional hypothesis `h : ¬ p`. If `h` is omitted, a name is generated automatically.
+If the target of the main goal is a proposition `p`, `by_contradiction` reduces the goal to proving `false` using the additional hypothesis `h : ¬ p`. `by_contradiction h` can be used to name the hypothesis `h : ¬ p`.
 
-This tactic requires that `p` is decidable. To ensure that all propositions are decidable via classical reasoning, use  `local attribute [instance] classical.prop_decidable`.
+This tactic will attempt to use decidability of `p` if available, and will otherwise fall back on classical reasoning.
 -/
 meta def by_contradiction (n : parse ident?) : tactic unit :=
-tactic.by_contradiction n >> return ()
+tactic.by_contradiction (n.get_or_else `h) $> ()
 
 /--
-An abbreviation for `by_contradiction`.
+If the target of the main goal is a proposition `p`, `by_contra` reduces the goal to proving `false` using the additional hypothesis `h : ¬ p`. `by_contra h` can be used to name the hypothesis `h : ¬ p`.
+
+This tactic will attempt to use decidability of `p` if available, and will otherwise fall back on classical reasoning.
 -/
 meta def by_contra (n : parse ident?) : tactic unit :=
 by_contradiction n

--- a/tests/lean/by_contradiction.lean
+++ b/tests/lean/by_contradiction.lean
@@ -12,23 +12,13 @@ by do
 example (a b : nat) : ¬¬ a = b → a = b :=
 by do
   intros,
-  by_contradiction `H,
+  by_contradiction,
   trace_state,
   contradiction
 
 #print "-------"
 
 example (p q : Prop) : ¬¬ p → p :=
-by do
-  intros,
-  by_contradiction `H, -- should fail
-  trace_state
-
-#print "-------"
-
-local attribute [instance] classical.prop_decidable -- Now all propositions are decidable
-
-example (p q : Prop) : ¬¬p → p :=
 by do
   intros,
   by_contradiction `H,

--- a/tests/lean/by_contradiction.lean
+++ b/tests/lean/by_contradiction.lean
@@ -12,7 +12,7 @@ by do
 example (a b : nat) : ¬¬ a = b → a = b :=
 by do
   intros,
-  by_contradiction,
+  by_contradiction `H,
   trace_state,
   contradiction
 

--- a/tests/lean/by_contradiction.lean.expected.out
+++ b/tests/lean/by_contradiction.lean.expected.out
@@ -8,12 +8,6 @@ a_1 : ¬¬a = b,
 H : ¬a = b
 ⊢ false
 -------
-by_contradiction.lean:22:3: error: tactic by_contradiction failed, target is not a negation nor a decidable proposition (remark: when 'local attribute [instance] classical.prop_decidable' is used, all propositions are decidable)
-state:
-p q : Prop,
-a : ¬¬p
-⊢ p
--------
 p q : Prop,
 a : ¬¬p,
 H : ¬p


### PR DESCRIPTION
This adds support for classical `by_contradiction`, as well as always using
`intro` instead of `intro1` (which picks up the binder variable of `not`,
which is never meaningful), instead using `h` as default name.