### PR TITLE
[Merged by Bors] - fix(init/meta/well_founded_tactics): alternate mutual sizeof

### DIFF
--- a/library/init/meta/well_founded_tactics.lean
+++ b/library/init/meta/well_founded_tactics.lean
@@ -170,7 +170,8 @@ do `(%%lhs < %%rhs) ← target,
      target_pr  ← to_expr ``(congr (congr_arg (<) %%lhs_pr) %%rhs_pr),
      new_target ← to_expr ``(%%new_lhs < %%new_rhs),
      replace_target new_target target_pr,
-     `[apply nat.add_lt_add_left] <|> `[apply nat.lt_add_of_zero_lt_left]
+     `[apply nat.add_lt_add_left] <|> `[apply nat.lt_add_of_zero_lt_left] <|>
+     fail "cancel_nat_add_lt failed"
 
 meta def check_target_is_value_lt : tactic unit :=
 do `(%%lhs < %%rhs) ← target,

--- a/library/init/meta/well_founded_tactics.lean
+++ b/library/init/meta/well_founded_tactics.lean
@@ -170,8 +170,7 @@ do `(%%lhs < %%rhs) ← target,
      target_pr  ← to_expr ``(congr (congr_arg (<) %%lhs_pr) %%rhs_pr),
      new_target ← to_expr ``(%%new_lhs < %%new_rhs),
      replace_target new_target target_pr,
-     `[apply nat.add_lt_add_left] <|> `[apply nat.lt_add_of_zero_lt_left] <|>
-     fail "cancel_nat_add_lt failed"
+     `[apply nat.add_lt_add_left] <|> `[apply nat.lt_add_of_zero_lt_left]
 
 meta def check_target_is_value_lt : tactic unit :=
 do `(%%lhs < %%rhs) ← target,
@@ -199,7 +198,9 @@ do clear_internals,
    -- The next line was adapted from code in mathlib by Scott Morrison.
    -- Because `unfold_sizeof` could actually discharge the goal, add a test
    -- using `done` to detect this.
-   process_lex (unfold_sizeof >> (done <|> (cancel_nat_add_lt >> trivial_nat_lt)))
+   process_lex (unfold_sizeof >> (done <|> (cancel_nat_add_lt >> trivial_nat_lt))) <|>
+   -- Clean up the goal state but not too much before printing the error
+   (unfold_sizeof >> fail "default_dec_tac failed")
 
 end well_founded_tactics
 

--- a/tests/lean/1917.lean.expected.out
+++ b/tests/lean/1917.lean.expected.out
@@ -5,7 +5,7 @@ Possible solutions:
   - The default decreasing tactic uses the 'assumption' tactic, thus hints (aka local proofs) can be provided using 'have'-expressions.
 The nested exception contains the failure state for the decreasing tactic.
 nested exception message:
-failed
+default_dec_tac failed
 state:
 foo : ℕ → false,
 x y : ℕ

--- a/tests/lean/add_defn_eqns.lean.expected.out
+++ b/tests/lean/add_defn_eqns.lean.expected.out
@@ -18,7 +18,7 @@ Possible solutions:
   - The default decreasing tactic uses the 'assumption' tactic, thus hints (aka local proofs) can be provided using 'have'-expressions.
 The nested exception contains the failure state for the decreasing tactic.
 nested exception message:
-cancel_nat_add_lt failed
+default_dec_tac failed
 state:
 a b : bool,
 mm : bool → bool

--- a/tests/lean/add_defn_eqns.lean.expected.out
+++ b/tests/lean/add_defn_eqns.lean.expected.out
@@ -18,10 +18,7 @@ Possible solutions:
   - The default decreasing tactic uses the 'assumption' tactic, thus hints (aka local proofs) can be provided using 'have'-expressions.
 The nested exception contains the failure state for the decreasing tactic.
 nested exception message:
-invalid apply tactic, failed to unify
-  1 < 1
-with
-  ?m_1 < ?m_1 + ?m_2
+cancel_nat_add_lt failed
 state:
 a b : bool,
 mm : bool → bool

--- a/tests/lean/eqn_hole.lean.expected.out
+++ b/tests/lean/eqn_hole.lean.expected.out
@@ -16,7 +16,7 @@ Possible solutions:
   - The default decreasing tactic uses the 'assumption' tactic, thus hints (aka local proofs) can be provided using 'have'-expressions.
 The nested exception contains the failure state for the decreasing tactic.
 nested exception message:
-failed
+default_dec_tac failed
 state:
 g : ℕ → ℕ,
 n : ℕ

--- a/tests/lean/nested_match.lean.expected.out
+++ b/tests/lean/nested_match.lean.expected.out
@@ -12,13 +12,13 @@ n m : ℕ
 ⊢ m < n
 nested_match.lean:25:7: error: failed to prove recursive application is decreasing, well founded relation
   @has_well_founded.r (psum ℕ ℕ)
-    (@has_well_founded_of_has_sizeof (psum ℕ ℕ) (@psum.has_sizeof ℕ ℕ nat.has_sizeof nat.has_sizeof))
+    (@has_well_founded_of_has_sizeof (psum ℕ ℕ) (@psum.has_sizeof_alt ℕ ℕ nat.has_sizeof nat.has_sizeof))
 Possible solutions: 
   - Use 'using_well_founded' keyword in the end of your definition to specify tactics for synthesizing well founded relations and decreasing proofs.
   - The default decreasing tactic uses the 'assumption' tactic, thus hints (aka local proofs) can be provided using 'have'-expressions.
 The nested exception contains the failure state for the decreasing tactic.
 nested exception message:
-failed
+cancel_nat_add_lt failed
 state:
 n : ℕ
-⊢ 1 < 1
+⊢ n < n

--- a/tests/lean/nested_match.lean.expected.out
+++ b/tests/lean/nested_match.lean.expected.out
@@ -5,7 +5,7 @@ Possible solutions:
   - The default decreasing tactic uses the 'assumption' tactic, thus hints (aka local proofs) can be provided using 'have'-expressions.
 The nested exception contains the failure state for the decreasing tactic.
 nested exception message:
-failed
+default_dec_tac failed
 state:
 f : ℕ → ℕ,
 n m : ℕ
@@ -18,7 +18,7 @@ Possible solutions:
   - The default decreasing tactic uses the 'assumption' tactic, thus hints (aka local proofs) can be provided using 'have'-expressions.
 The nested exception contains the failure state for the decreasing tactic.
 nested exception message:
-cancel_nat_add_lt failed
+default_dec_tac failed
 state:
 n : ℕ
 ⊢ n < n

--- a/tests/lean/run/mutual_sizeof.lean
+++ b/tests/lean/run/mutual_sizeof.lean
@@ -1,0 +1,18 @@
+inductive tree : Type
+| node : list tree → tree
+
+mutual def g, f, h
+with g : list tree → ℕ
+| [] := 0
+| (x :: xs) := f x + g xs
+with f : tree → ℕ
+| (tree.node children) := 1 + g children
+with h : ℕ → ℕ
+| x := x
+
+mutual def f1, f2, f3, f4, f5
+with f1 : ℕ → unit | (n+1) := f5 n | _ := ()
+with f2 : ℕ → unit | (n+1) := f3 n | _ := ()
+with f3 : ℕ → unit | (n+1) := f3 n | _ := ()
+with f4 : ℕ → unit | (n+1) := f1 n | _ := ()
+with f5 : ℕ → unit | (n+1) := f4 n | _ := ()

--- a/tests/lean/run/psum_wf_rec.lean
+++ b/tests/lean/run/psum_wf_rec.lean
@@ -1,9 +1,9 @@
-def psum.alt.sizeof {α β} [has_sizeof α] [has_sizeof β] : psum α β → nat
+def psum.alt'.sizeof {α β} [has_sizeof α] [has_sizeof β] : psum α β → nat
 | (psum.inl a) := 2*sizeof a + 2
 | (psum.inr b) := 2*sizeof b + 1
 
 def sum_has_sizeof_2 {α β} [has_sizeof α] [has_sizeof β] : has_sizeof (psum α β) :=
-⟨psum.alt.sizeof⟩
+⟨psum.alt'.sizeof⟩
 
 local attribute [instance] sum_has_sizeof_2
 local attribute [simp] nat.add_comm nat.add_left_comm nat.add_assoc nat.mul_assoc nat.mul_comm nat.one_mul


### PR DESCRIPTION
This fixes an issue in which mutual recursions cannot call other
functions if they have an index too large, because the default sizeof
instance for psum penalizes lots of `psum.inr` constructors.

Zulip: https://leanprover.zulipchat.com/#narrow/stream/113488-general/topic/well.20founded.20relation.20problem.20with.203.20mutual.20recursion/near/215578029