### PR TITLE
[Merged by Bors] - feat(simp): record simplification lemmas and export them to tactic.simplify

### DIFF
--- a/library/init/meta/converter/interactive.lean
+++ b/library/init/meta/converter/interactive.lean
@@ -140,7 +140,7 @@ meta def simp (no_dflt : parse only_flag) (hs : parse tactic.simp_arg_list) (att
               : conv unit :=
 do (s, u) ← tactic.mk_simp_set no_dflt attr_names hs,
    (r, lhs, rhs) ← tactic.target_lhs_rhs,
-   (new_lhs, pr) ← tactic.simplify s u lhs cfg.to_simp_config r cfg.discharger,
+   (new_lhs, pr, lms) ← tactic.simplify s u lhs cfg.to_simp_config r cfg.discharger,
    update_lhs new_lhs pr,
    return ()
 

--- a/library/init/meta/interactive.lean
+++ b/library/init/meta/interactive.lean
@@ -1231,7 +1231,7 @@ open interactive interactive.types expr
 meta def simp_core_aux (cfg : simp_config) (discharger : tactic unit) (s : simp_lemmas) (u : list name) (hs : list expr) (tgt : bool) : tactic unit :=
 do to_remove ← hs.mfilter $ λ h, do {
          h_type ← infer_type h,
-         (do (new_h_type, pr) ← simplify s u h_type cfg `eq discharger,
+         (do (new_h_type, pr, lms) ← simplify s u h_type cfg `eq discharger,
              assert h.local_pp_name new_h_type,
              mk_eq_mp pr h >>= tactic.exact >> return tt)
          <|>

--- a/library/init/meta/rb_map.lean
+++ b/library/init/meta/rb_map.lean
@@ -196,6 +196,9 @@ meta constant size           : name_set → nat
 meta constant empty          : name_set → bool
 meta constant fold {α :Type} : name_set → α → (name → α → α) → α
 
+meta def union (l r : name_set) : name_set :=
+r.fold l (λ ns n, name_set.insert n ns)
+
 meta def to_list (s : name_set) : list name :=
 s.fold [] list.cons
 

--- a/library/init/meta/simp_tactic.lean
+++ b/library/init/meta/simp_tactic.lean
@@ -553,7 +553,7 @@ private meta def loop (cfg : simp_config) (discharger : tactic unit) (to_unfold 
   else do
     add_new_hyps r,
     (lms, target_changed) ← (simp_target s to_unfold cfg discharger >>= λ ns, return (ns, tt)) <|>
-                            (return (name_set.of_list [], ff)),
+                            (return (mk_name_set, ff)),
     guard (cfg.fail_if_unchanged = ff ∨ target_changed ∨ r.any (λ e, e.pr ≠ none)) <|> fail "simp_all tactic failed to simplify",
     clear_old_hyps r,
     return lms
@@ -569,7 +569,7 @@ private meta def loop (cfg : simp_config) (discharger : tactic unit) (to_unfold 
      if new_h_type = `(false) then do
        tgt         ← target,
        to_expr ``(@false.rec %%tgt %%new_fact_pr) >>= exact,
-       return (name_set.of_list [])
+       return (mk_name_set)
      else do
        h0_type     ← infer_type h,
        let new_fact_pr := mk_id_proof new_h_type new_fact_pr,

--- a/library/init/meta/simp_tactic.lean
+++ b/library/init/meta/simp_tactic.lean
@@ -286,7 +286,7 @@ structure simp_config :=
    and projection applications that should be unfolded.
 -/
 meta constant simplify (s : simp_lemmas) (to_unfold : list name := []) (e : expr) (cfg : simp_config := {}) (r : name := `eq)
-                       (discharger : tactic unit := failed) : tactic (expr × expr × (list name))
+                       (discharger : tactic unit := failed) : tactic (expr × expr × name_set)
 
 meta def simp_target (s : simp_lemmas) (to_unfold : list name := []) (cfg : simp_config := {}) (discharger : tactic unit := failed) : tactic unit :=
 do t ← target >>= instantiate_mvars,

--- a/library/init/meta/smt/interactive.lean
+++ b/library/init/meta/smt/interactive.lean
@@ -243,7 +243,7 @@ open tactic
 /-- Simplify the target type of the main goal. -/
 meta def simp (use_iota_eqn : parse $ (tk "!")?) (no_dflt : parse only_flag) (hs : parse simp_arg_list)
               (attr_names : parse with_ident_list) (cfg : simp_config_ext := {}) : smt_tactic unit :=
-tactic.interactive.simp use_iota_eqn no_dflt hs attr_names (loc.ns [none]) cfg
+tactic.interactive.simp use_iota_eqn none no_dflt hs attr_names (loc.ns [none]) cfg
 
 meta def dsimp (no_dflt : parse only_flag) (es : parse simp_arg_list) (attr_names : parse with_ident_list) : smt_tactic unit :=
 tactic.interactive.dsimp no_dflt es attr_names (loc.ns [none])

--- a/src/library/tactic/simp_lemmas.cpp
+++ b/src/library/tactic/simp_lemmas.cpp
@@ -1534,7 +1534,7 @@ static simp_result simp_lemma_rewrite_core(type_context_old & ctx, simp_lemma co
     }
 
     for (unsigned i = 0; i < sl.get_num_umeta(); i++) {
-        if (!tmp_ctx.is_uassigned(i)) return simp_result(e);
+        if (!tmp_ctx.is_uassigned(i)) { tout() << "\nBOO!!\n"; return simp_result(e); }
     }
 
     expr new_lhs = tmp_ctx.instantiate_mvars(sl.get_lhs());
@@ -1548,7 +1548,7 @@ static simp_result simp_lemma_rewrite_core(type_context_old & ctx, simp_lemma co
     }
 
     expr pf = tmp_ctx.instantiate_mvars(sl.get_proof());
-    return simp_result(new_rhs, pf);
+    return simp_result(new_rhs, pf, sl.get_id());
 }
 
 static vm_obj simp_lemmas_rewrite_core(transparency_mode const & m, simp_lemmas const & sls, vm_obj const & prove_fn,

--- a/src/library/tactic/simp_lemmas.cpp
+++ b/src/library/tactic/simp_lemmas.cpp
@@ -1534,7 +1534,7 @@ static simp_result simp_lemma_rewrite_core(type_context_old & ctx, simp_lemma co
     }
 
     for (unsigned i = 0; i < sl.get_num_umeta(); i++) {
-        if (!tmp_ctx.is_uassigned(i)) { tout() << "\nBOO!!\n"; return simp_result(e); }
+        if (!tmp_ctx.is_uassigned(i)) { return simp_result(e); }
     }
 
     expr new_lhs = tmp_ctx.instantiate_mvars(sl.get_lhs());

--- a/src/library/tactic/simp_result.cpp
+++ b/src/library/tactic/simp_result.cpp
@@ -12,8 +12,7 @@ namespace lean {
 simp_result finalize(type_context_old & tctx, name const & rel, simp_result const & r) {
     if (r.has_proof()) return r;
     expr pf = mk_refl(tctx, rel, r.get_new());
-    buffer<name> lms = r.get_lemmas();
-    return simp_result(r.get_new(), pf, lms);
+    return simp_result(r.get_new(), pf, r.get_lemmas());
 }
 
 simp_result join(type_context_old & tctx, name const & rel, simp_result const & r1, simp_result const & r2) {
@@ -22,15 +21,15 @@ simp_result join(type_context_old & tctx, name const & rel, simp_result const & 
         return r2;
     } else if (!r2.has_proof()) {
         lean_assert(r1.has_proof());
-        buffer<name> lms = r1.get_lemmas();
-        lms.append(r2.get_lemmas());
+        name_set lms = r1.get_lemmas();
+        lms.merge(r2.get_lemmas());
         return simp_result(r2.get_new(), r1.get_proof(), lms);
     } else {
         /* If they both have proofs, we need to glue them together with transitivity. */
         lean_assert(r1.has_proof() && r2.has_proof());
         expr trans = mk_trans(tctx, rel, r1.get_proof(), r2.get_proof());
-        buffer<name> lms = r1.get_lemmas();
-        lms.append(r2.get_lemmas());
+        name_set lms = r1.get_lemmas();
+        lms.merge(r2.get_lemmas());
         return simp_result(r2.get_new(), trans, lms);
     }
 }
@@ -38,8 +37,7 @@ simp_result join(type_context_old & tctx, name const & rel, simp_result const & 
 simp_result finalize_eq(abstract_type_context & tctx, simp_result const & r) {
     if (r.has_proof()) return r;
     expr pf = mk_eq_refl(tctx, r.get_new());
-    buffer<name> lms = r.get_lemmas();
-    return simp_result(r.get_new(), pf, lms);
+    return simp_result(r.get_new(), pf, r.get_lemmas());
 }
 
 simp_result join_eq(abstract_type_context & tctx, simp_result const & r1, simp_result const & r2) {
@@ -47,14 +45,14 @@ simp_result join_eq(abstract_type_context & tctx, simp_result const & r1, simp_r
         return r2;
     } else if (!r2.has_proof()) {
         lean_assert(r1.has_proof());
-        buffer<name> lms = r1.get_lemmas();
-        lms.append(r2.get_lemmas());
+        name_set lms = r1.get_lemmas();
+        lms.merge(r2.get_lemmas());
         return simp_result(r2.get_new(), r1.get_proof(), lms);
     } else {
         lean_assert(r1.has_proof() && r2.has_proof());
         expr trans = mk_eq_trans(tctx, r1.get_proof(), r2.get_proof());
-        buffer<name> lms = r1.get_lemmas();
-        lms.append(r2.get_lemmas());
+        name_set lms = r1.get_lemmas();
+        lms.merge(r2.get_lemmas());
         return simp_result(r2.get_new(), trans, lms);
     }
 }

--- a/src/library/tactic/simp_result.cpp
+++ b/src/library/tactic/simp_result.cpp
@@ -19,14 +19,12 @@ simp_result join(type_context_old & tctx, name const & rel, simp_result const & 
     /* Assumes that both simp_results are with respect to the same relation */
     if (!r1.has_proof()) {
         name_set lms = r1.get_lemmas();
-        tout() << "Ja" << lms.size() << r2.get_lemmas().size();
         lms.merge(r2.get_lemmas());
         return r2; // simp_result(r2.get_new(), r2.get_proof(), lms);
     } else if (!r2.has_proof()) {
         lean_assert(r1.has_proof());
         name_set lms = r1.get_lemmas();
         lms.merge(r2.get_lemmas());
-        tout() << "Jb" << lms.size();
         return simp_result(r2.get_new(), r1.get_proof(), lms);
     } else {
         /* If they both have proofs, we need to glue them together with transitivity. */
@@ -34,7 +32,6 @@ simp_result join(type_context_old & tctx, name const & rel, simp_result const & 
         expr trans = mk_trans(tctx, rel, r1.get_proof(), r2.get_proof());
         name_set lms = r1.get_lemmas();
         lms.merge(r2.get_lemmas());
-        tout() << "Jc" << lms.size();
         return simp_result(r2.get_new(), trans, lms);
     }
 }

--- a/src/library/tactic/simp_result.cpp
+++ b/src/library/tactic/simp_result.cpp
@@ -18,11 +18,15 @@ simp_result finalize(type_context_old & tctx, name const & rel, simp_result cons
 simp_result join(type_context_old & tctx, name const & rel, simp_result const & r1, simp_result const & r2) {
     /* Assumes that both simp_results are with respect to the same relation */
     if (!r1.has_proof()) {
-        return r2;
+        name_set lms = r1.get_lemmas();
+        tout() << "Ja" << lms.size() << r2.get_lemmas().size();
+        lms.merge(r2.get_lemmas());
+        return r2; // simp_result(r2.get_new(), r2.get_proof(), lms);
     } else if (!r2.has_proof()) {
         lean_assert(r1.has_proof());
         name_set lms = r1.get_lemmas();
         lms.merge(r2.get_lemmas());
+        tout() << "Jb" << lms.size();
         return simp_result(r2.get_new(), r1.get_proof(), lms);
     } else {
         /* If they both have proofs, we need to glue them together with transitivity. */
@@ -30,6 +34,7 @@ simp_result join(type_context_old & tctx, name const & rel, simp_result const & 
         expr trans = mk_trans(tctx, rel, r1.get_proof(), r2.get_proof());
         name_set lms = r1.get_lemmas();
         lms.merge(r2.get_lemmas());
+        tout() << "Jc" << lms.size();
         return simp_result(r2.get_new(), trans, lms);
     }
 }

--- a/src/library/tactic/simp_result.cpp
+++ b/src/library/tactic/simp_result.cpp
@@ -20,7 +20,7 @@ simp_result join(type_context_old & tctx, name const & rel, simp_result const & 
     if (!r1.has_proof()) {
         name_set lms = r1.get_lemmas();
         lms.merge(r2.get_lemmas());
-        return r2; // simp_result(r2.get_new(), r2.get_proof(), lms);
+        return r2;
     } else if (!r2.has_proof()) {
         lean_assert(r1.has_proof());
         name_set lms = r1.get_lemmas();

--- a/src/library/tactic/simp_result.cpp
+++ b/src/library/tactic/simp_result.cpp
@@ -12,7 +12,8 @@ namespace lean {
 simp_result finalize(type_context_old & tctx, name const & rel, simp_result const & r) {
     if (r.has_proof()) return r;
     expr pf = mk_refl(tctx, rel, r.get_new());
-    return simp_result(r.get_new(), pf);
+    buffer<name> lms = r.get_lemmas();
+    return simp_result(r.get_new(), pf, lms);
 }
 
 simp_result join(type_context_old & tctx, name const & rel, simp_result const & r1, simp_result const & r2) {
@@ -21,19 +22,24 @@ simp_result join(type_context_old & tctx, name const & rel, simp_result const & 
         return r2;
     } else if (!r2.has_proof()) {
         lean_assert(r1.has_proof());
-        return simp_result(r2.get_new(), r1.get_proof());
+        buffer<name> lms = r1.get_lemmas();
+        lms.append(r2.get_lemmas());
+        return simp_result(r2.get_new(), r1.get_proof(), lms);
     } else {
         /* If they both have proofs, we need to glue them together with transitivity. */
         lean_assert(r1.has_proof() && r2.has_proof());
         expr trans = mk_trans(tctx, rel, r1.get_proof(), r2.get_proof());
-        return simp_result(r2.get_new(), trans);
+        buffer<name> lms = r1.get_lemmas();
+        lms.append(r2.get_lemmas());
+        return simp_result(r2.get_new(), trans, lms);
     }
 }
 
 simp_result finalize_eq(abstract_type_context & tctx, simp_result const & r) {
     if (r.has_proof()) return r;
     expr pf = mk_eq_refl(tctx, r.get_new());
-    return simp_result(r.get_new(), pf);
+    buffer<name> lms = r.get_lemmas();
+    return simp_result(r.get_new(), pf, lms);
 }
 
 simp_result join_eq(abstract_type_context & tctx, simp_result const & r1, simp_result const & r2) {
@@ -41,11 +47,15 @@ simp_result join_eq(abstract_type_context & tctx, simp_result const & r1, simp_r
         return r2;
     } else if (!r2.has_proof()) {
         lean_assert(r1.has_proof());
-        return simp_result(r2.get_new(), r1.get_proof());
+        buffer<name> lms = r1.get_lemmas();
+        lms.append(r2.get_lemmas());
+        return simp_result(r2.get_new(), r1.get_proof(), lms);
     } else {
         lean_assert(r1.has_proof() && r2.has_proof());
         expr trans = mk_eq_trans(tctx, r1.get_proof(), r2.get_proof());
-        return simp_result(r2.get_new(), trans);
+        buffer<name> lms = r1.get_lemmas();
+        lms.append(r2.get_lemmas());
+        return simp_result(r2.get_new(), trans, lms);
     }
 }
 

--- a/src/library/tactic/simp_result.h
+++ b/src/library/tactic/simp_result.h
@@ -5,7 +5,6 @@ Author: Daniel Selsam
 */
 #pragma once
 #include "library/type_context.h"
-#include "library/trace.h"
 
 namespace lean {
 
@@ -22,18 +21,18 @@ struct simp_result {
     bool m_done{false};
 public:
     simp_result() {}
-    simp_result(expr const & e): m_new(e) { tout() << "A"; }
-    simp_result(expr const & e, expr const & proof, bool done = false): m_new(e), m_proof(proof), m_done(done) { tout() << "B"; }
-    simp_result(expr const & e, optional<expr> const & proof): m_new(e), m_proof(proof) { tout() << "C"; }
-    simp_result(pair<expr, optional<expr>> const & r): m_new(r.first), m_proof(r.second) { tout() << "D"; }
+    simp_result(expr const & e): m_new(e) {}
+    simp_result(expr const & e, expr const & proof, bool done = false): m_new(e), m_proof(proof), m_done(done) {}
+    simp_result(expr const & e, optional<expr> const & proof): m_new(e), m_proof(proof) {}
+    simp_result(pair<expr, optional<expr>> const & r): m_new(r.first), m_proof(r.second) {}
     simp_result(expr const & e, name_set const & lemmas, bool done = false):
-      m_new(e), m_lemmas(lemmas), m_done(done) { tout() << "E" << lemmas.size() << "!\n"; }
+      m_new(e), m_lemmas(lemmas), m_done(done) {}
     simp_result(expr const & e, expr const & proof, name_set const & lemmas, bool done = false):
-      m_new(e), m_proof(proof), m_lemmas(lemmas), m_done(done) { tout() << "F" << lemmas.size() << "!\n"; }
+      m_new(e), m_proof(proof), m_lemmas(lemmas), m_done(done) {}
     simp_result(expr const & e, expr const & proof, name const & lem, bool done = false):
-      m_new(e), m_proof(proof), m_done(done) { m_lemmas.insert(lem); tout() << "G!\n"; }
+      m_new(e), m_proof(proof), m_done(done) { m_lemmas.insert(lem); }
     simp_result(expr const & e, name const & lem, bool done = false):
-      m_new(e), m_done(done) { m_lemmas.insert(lem); tout() << "H!\n"; }
+      m_new(e), m_done(done) { m_lemmas.insert(lem); }
 
     bool has_proof() const { return static_cast<bool>(m_proof); }
 

--- a/src/library/tactic/simp_result.h
+++ b/src/library/tactic/simp_result.h
@@ -26,10 +26,14 @@ public:
     simp_result(expr const & e, expr const & proof, bool done = false): m_new(e), m_proof(proof), m_done(done) { tout() << "B"; }
     simp_result(expr const & e, optional<expr> const & proof): m_new(e), m_proof(proof) { tout() << "C"; }
     simp_result(pair<expr, optional<expr>> const & r): m_new(r.first), m_proof(r.second) { tout() << "D"; }
-    simp_result(expr const & e, name_set & lemmas, bool done = false):
+    simp_result(expr const & e, name_set const & lemmas, bool done = false):
       m_new(e), m_lemmas(lemmas), m_done(done) { tout() << "E" << lemmas.size() << "!\n"; }
     simp_result(expr const & e, expr const & proof, name_set const & lemmas, bool done = false):
       m_new(e), m_proof(proof), m_lemmas(lemmas), m_done(done) { tout() << "F" << lemmas.size() << "!\n"; }
+    simp_result(expr const & e, expr const & proof, name const & lem, bool done = false):
+      m_new(e), m_proof(proof), m_done(done) { m_lemmas.insert(lem); tout() << "G!\n"; }
+    simp_result(expr const & e, name const & lem, bool done = false):
+      m_new(e), m_done(done) { m_lemmas.insert(lem); tout() << "H!\n"; }
 
     bool has_proof() const { return static_cast<bool>(m_proof); }
 

--- a/src/library/tactic/simp_result.h
+++ b/src/library/tactic/simp_result.h
@@ -5,6 +5,7 @@ Author: Daniel Selsam
 */
 #pragma once
 #include "library/type_context.h"
+#include "library/trace.h"
 
 namespace lean {
 
@@ -15,19 +16,30 @@ struct simp_result {
     /* If proof is not provided, it is assumed to be reflexivity */
     optional<expr> m_proof;
 
+    /* The list of simplification lemmas used in the proof */
+    buffer<name> m_lemmas;
+
     bool m_done{false};
 public:
     simp_result() {}
-    simp_result(expr const & e): m_new(e) {}
-    simp_result(expr const & e, expr const & proof, bool done = false): m_new(e), m_proof(proof), m_done(done) {}
-    simp_result(expr const & e, optional<expr> const & proof): m_new(e), m_proof(proof) {}
-    simp_result(pair<expr, optional<expr>> const & r): m_new(r.first), m_proof(r.second) {}
+    simp_result(expr const & e): m_new(e) { tout() << "A"; }
+    simp_result(expr const & e, expr const & proof, bool done = false): m_new(e), m_proof(proof), m_done(done) { tout() << "B"; }
+    simp_result(expr const & e, optional<expr> const & proof): m_new(e), m_proof(proof) { tout() << "C"; }
+    simp_result(pair<expr, optional<expr>> const & r): m_new(r.first), m_proof(r.second) { tout() << "D"; }
+    simp_result(expr const & e, buffer<name> & lemmas, bool done = false):
+      m_new(e), m_lemmas(lemmas), m_done(done) { tout() << "E" << lemmas.size() << "!\n"; }
+    simp_result(expr const & e, expr const & proof, buffer<name> & lemmas, bool done = false):
+      m_new(e), m_proof(proof), m_lemmas(lemmas), m_done(done) { tout() << "F" << lemmas.size() << "!\n"; }
 
     bool has_proof() const { return static_cast<bool>(m_proof); }
 
     expr const & get_new() const { return m_new; }
     expr const & get_proof() const { lean_assert(m_proof); return *m_proof; }
     optional<expr> const & get_optional_proof() const { return m_proof; }
+    buffer<name> const & get_lemmas() const { return m_lemmas; }
+
+    /* Push a lemma name to the buffer of simplification lemmas used in the proof */
+    void push_lemma(name const & lem) { m_lemmas.push_back(lem); }
 
     /* The following assumes that [e] and [m_new] are definitionally equal */
     void update(expr const & e) { m_new = e; }

--- a/src/library/tactic/simp_result.h
+++ b/src/library/tactic/simp_result.h
@@ -16,8 +16,8 @@ struct simp_result {
     /* If proof is not provided, it is assumed to be reflexivity */
     optional<expr> m_proof;
 
-    /* The list of simplification lemmas used in the proof */
-    buffer<name> m_lemmas;
+    /* The set of simplification lemmas used in the proof */
+    name_set m_lemmas;
 
     bool m_done{false};
 public:
@@ -26,9 +26,9 @@ public:
     simp_result(expr const & e, expr const & proof, bool done = false): m_new(e), m_proof(proof), m_done(done) { tout() << "B"; }
     simp_result(expr const & e, optional<expr> const & proof): m_new(e), m_proof(proof) { tout() << "C"; }
     simp_result(pair<expr, optional<expr>> const & r): m_new(r.first), m_proof(r.second) { tout() << "D"; }
-    simp_result(expr const & e, buffer<name> & lemmas, bool done = false):
+    simp_result(expr const & e, name_set & lemmas, bool done = false):
       m_new(e), m_lemmas(lemmas), m_done(done) { tout() << "E" << lemmas.size() << "!\n"; }
-    simp_result(expr const & e, expr const & proof, buffer<name> & lemmas, bool done = false):
+    simp_result(expr const & e, expr const & proof, name_set const & lemmas, bool done = false):
       m_new(e), m_proof(proof), m_lemmas(lemmas), m_done(done) { tout() << "F" << lemmas.size() << "!\n"; }
 
     bool has_proof() const { return static_cast<bool>(m_proof); }
@@ -36,10 +36,10 @@ public:
     expr const & get_new() const { return m_new; }
     expr const & get_proof() const { lean_assert(m_proof); return *m_proof; }
     optional<expr> const & get_optional_proof() const { return m_proof; }
-    buffer<name> const & get_lemmas() const { return m_lemmas; }
+    name_set const & get_lemmas() const { return m_lemmas; }
 
-    /* Push a lemma name to the buffer of simplification lemmas used in the proof */
-    void push_lemma(name const & lem) { m_lemmas.push_back(lem); }
+    /* Insert a lemma name to the set of simplification lemmas used in the proof */
+    void insert_lemma(name const & lem) { m_lemmas.insert(lem); }
 
     /* The following assumes that [e] and [m_new] are definitionally equal */
     void update(expr const & e) { m_new = e; }

--- a/src/library/tactic/simplify.cpp
+++ b/src/library/tactic/simplify.cpp
@@ -40,6 +40,7 @@ Author: Daniel Selsam, Leonardo de Moura
 #include "library/vm/vm_list.h"
 #include "library/vm/vm_nat.h"
 #include "library/vm/vm_name.h"
+#include "library/vm/vm_rb_map.h"
 #include "library/tactic/eqn_lemmas.h"
 #include "library/tactic/tactic_state.h"
 #include "library/tactic/app_builder_tactics.h"
@@ -140,8 +141,7 @@ bool simplify_core_fn::instantiate_emetas(tmp_type_context & tmp_ctx, list <expr
 simp_result simplify_core_fn::lift_from_eq(simp_result const & r_eq) {
     if (!r_eq.has_proof()) return r_eq;
     expr new_pr = ::lean::lift_from_eq(m_ctx, m_rel, r_eq.get_proof());
-    buffer<name> lms = r_eq.get_lemmas();
-    return simp_result(r_eq.get_new(), new_pr, lms);
+    return simp_result(r_eq.get_new(), new_pr, r_eq.get_lemmas());
 }
 
 simp_lemmas simplify_core_fn::add_to_slss(simp_lemmas const & _slss, buffer<expr> const & ls) {
@@ -438,8 +438,8 @@ optional<simp_result> simplify_core_fn::try_auto_eq_congr(expr const & e) {
 }
 
 simp_result simplify_core_fn::congr_fun_arg(simp_result const & r_f, simp_result const & r_arg) {
-    buffer<name> lms = r_f.get_lemmas();
-    lms.append(r_arg.get_lemmas());
+    name_set lms = r_f.get_lemmas();
+    lms.merge(r_arg.get_lemmas());
     if (!r_f.has_proof() && !r_arg.has_proof()) return simp_result(mk_app(r_f.get_new(), r_arg.get_new()), lms);
     else if (!r_f.has_proof()) return congr_arg(r_f.get_new(), r_arg);
     else if (!r_arg.has_proof()) return congr_fun(r_f, r_arg.get_new());
@@ -451,8 +451,8 @@ simp_result simplify_core_fn::congr(simp_result const & r_f, simp_result const &
     // theorem congr {A B : Type} {f₁ f₂ : A → B} {a₁ a₂ : A} (H₁ : f₁ = f₂) (H₂ : a₁ = a₂) : f₁ a₁ = f₂ a₂
     expr e  = mk_app(r_f.get_new(), r_arg.get_new());
     expr pf = mk_congr(m_ctx, r_f.get_proof(), r_arg.get_proof());
-    buffer<name> lms = r_f.get_lemmas();
-    lms.append(r_arg.get_lemmas());
+    name_set lms = r_f.get_lemmas();
+    lms.merge(r_arg.get_lemmas());
     return simp_result(e, pf, lms);
 }
 
@@ -474,7 +474,7 @@ simp_result simplify_core_fn::congr_arg(expr const & f, simp_result const & r_ar
 
 simp_result simplify_core_fn::congr_funs(simp_result const & r_f, buffer<expr> const & args) {
     expr e = r_f.get_new();
-    buffer<name> lms = r_f.get_lemmas();
+    name_set lms = r_f.get_lemmas();
     for (unsigned i = 0; i < args.size(); ++i) {
         e  = mk_app(e, args[i]);
     }
@@ -503,7 +503,7 @@ simp_result simplify_core_fn::rewrite(expr const & e) {
                 lean_simp_trace_d(m_ctx, name({"simplify", "rewrite"}),
                                 tout() << "[" << lemma.get_id() << "]: "
                                 << e << " ==> " << r.get_new() << "\n";);
-                r.push_lemma(lemma.get_id());
+                r.insert_lemma(lemma.get_id());
                 return r;
             }
         } catch (ext_exception & ex) {
@@ -629,7 +629,7 @@ simp_result simplify_core_fn::propext_rewrite(expr const & e) {
     simp_result r = rewrite(e);
     if (!r.has_proof()) return r;
     expr new_pr = mk_app(m_ctx, get_propext_name(), r.get_proof());
-    buffer<name> lms = r.get_lemmas();
+    name_set lms = r.get_lemmas();
     return simp_result(r.get_new(), new_pr, lms);
 }
 
@@ -1248,7 +1248,7 @@ meta constant simplify
   (c : simp_config)
   (r : name)
   (prove : tactic unit) :
-  tactic (expr × expr × (list name))
+  tactic (expr × expr × name_set)
 */
 vm_obj tactic_simplify(vm_obj const & slss, vm_obj const & u, vm_obj const & e, vm_obj const & c, vm_obj const & rel,
                        vm_obj const & prove, vm_obj const & _s) {

--- a/tests/lean/run/dunfold3.lean
+++ b/tests/lean/run/dunfold3.lean
@@ -2,7 +2,7 @@ open tactic
 
 def g : nat → nat := λ x, x + 5
 
--- set_option pp.all true
+set_option pp.all true
 
 example (a b : nat) (p : nat → Prop) (h : p (g (nat.succ (nat.succ a)))) : p (g (a + 2)) :=
 begin

--- a/tests/lean/run/dunfold3.lean
+++ b/tests/lean/run/dunfold3.lean
@@ -2,7 +2,7 @@ open tactic
 
 def g : nat → nat := λ x, x + 5
 
-set_option pp.all true
+-- set_option pp.all true
 
 example (a b : nat) (p : nat → Prop) (h : p (g (nat.succ (nat.succ a)))) : p (g (a + 2)) :=
 begin

--- a/tests/lean/run/pathsimp.lean
+++ b/tests/lean/run/pathsimp.lean
@@ -22,9 +22,14 @@ by intro; induction h; assumption
 
 open tactic expr
 
+-- ↓↓ remove this
+set_option trace.simplify.rewrite true
+
 meta def path_simp_target (sls : simp_lemmas) := do
 tgt ← target,
-(tgt', prf) ← simplify sls [] tgt {lift_eq:=ff} `path,
+(tgt', prf, lms) ← simplify sls [] tgt {lift_eq:=ff} `path,
+-- ↓↓  remove this
+trace lms,
 prf ← mk_mapp `path.symm [none, tgt, tgt', prf],
 mk_mapp `path.mp [tgt', tgt, prf] >>= apply
 

--- a/tests/lean/run/pathsimp.lean
+++ b/tests/lean/run/pathsimp.lean
@@ -22,14 +22,9 @@ by intro; induction h; assumption
 
 open tactic expr
 
--- ↓↓ remove this
-set_option trace.simplify.rewrite true
-
 meta def path_simp_target (sls : simp_lemmas) := do
 tgt ← target,
 (tgt', prf, lms) ← simplify sls [] tgt {lift_eq:=ff} `path,
--- ↓↓  remove this
-trace lms,
 prf ← mk_mapp `path.symm [none, tgt, tgt', prf],
 mk_mapp `path.mp [tgt', tgt, prf] >>= apply
 

--- a/tests/lean/run/simplifier_custom_relations.lean
+++ b/tests/lean/run/simplifier_custom_relations.lean
@@ -23,12 +23,12 @@ attribute [congr] Hf Hg Hh
 #print [simp] default
 #print [congr] default
 
-meta definition relsimp_core (e : expr) : tactic (expr × expr) :=
+meta definition relsimp_core (e : expr) : tactic (expr × expr × name_set) :=
 do S         ← simp_lemmas.mk_default,
    e_type    ← infer_type e >>= whnf,
    simplify S [] e {} `rel
 
 example : rel (h (f x)) z :=
 by do e₁ ← to_expr ```(h (f x)),
-      (e₁', pf) ← relsimp_core e₁,
+      (e₁', pf, _) ← relsimp_core e₁,
       exact pf


### PR DESCRIPTION
This patch modifies the simplifier, so that it keeps track of a `name_set` of
simplification lemmas that are used.
It then exposes this name_set via `tactic.simplify`.
We modify the interactive `simp` tactic, so that `simp?` traces
a message of the form `Try this: simp only [foo, bar, quux]`.

Big thanks to @gebner and @digama0 for all the help along the way.