### PR TITLE
[Merged by Bors] - fix(tests/lean/list_local_vars): fix different output on aarch64

### DIFF
--- a/tests/lean/list_local_vars.lean
+++ b/tests/lean/list_local_vars.lean
@@ -44,7 +44,7 @@ do (n,t) ← brackets "(" ")" (prod.mk <$> (ident <* tk ":") <*> texpr),
    include_var v.local_pp_name,
    omit_var v.local_pp_name,
    ls ← lean.parser.list_include_var_names,
-   trace ls,
+   --  trace ls,
    trace_state
 
 end tactic.interactive

--- a/tests/lean/list_local_vars.lean.expected.out
+++ b/tests/lean/list_local_vars.lean.expected.out
@@ -12,7 +12,6 @@ context:
 a b : ℕ
 ⊢ Sort ?
 x : ℕ → ℕ → ⁇
-[β, b, a]
 ⊢ true
 list_local_vars.lean:64:11: error: unknown identifier 'β'
 list_local_vars.lean:64:4: error: don't know how to synthesize placeholder


### PR DESCRIPTION
Tests fail on aarch64: https://logs.nix.ci/?key=nixos/nixpkgs.103436&attempt_id=2eac1597-3dee-42d8-bc4b-e742c2e190e0