### PR TITLE
[Merged by Bors] - fix(library/init/wf): `well_founded.recursion` should be a `def`

### DIFF
--- a/library/init/wf.lean
+++ b/library/init/wf.lean
@@ -35,7 +35,7 @@ local infix `≺`:50    := r
 
 parameter hwf : well_founded r
 
-lemma recursion {C : α → Sort v} (a : α) (h : Π x, (Π y, y ≺ x → C y) → C x) : C a :=
+def recursion {C : α → Sort v} (a : α) (h : Π x, (Π y, y ≺ x → C y) → C x) : C a :=
 acc.rec_on (apply hwf a) (λ x₁ ac₁ ih, h x₁ ih)
 
 lemma induction {C : α → Prop} (a : α) (h : ∀ x, (∀ y, y ≺ x → C y) → C x) : C a :=


### PR DESCRIPTION
This declaration returns a `Sort` but is defined as a `lemma`, which causes "cannot generate vm code" errors when you try to use it. And also mathlib's linter doesn't like it.

Zulip thread: https://leanprover.zulipchat.com/#narrow/stream/113488-general/topic/Sholdn't.20.60well_founded.2Erecursion.60.20be.20a.20.60def.60.3F