### PR TITLE
[Merged by Bors] - perf(library/type_context): enable type class cache in nested resolution problems

### DIFF
--- a/src/library/context_cache.cpp
+++ b/src/library/context_cache.cpp
@@ -16,6 +16,9 @@ context_cache::context_cache(options const & o):
     context_cacheless(o) {
 }
 
+context_cache::context_cache(abstract_context_cache const & c, bool) :
+    context_cacheless(c, true) {}
+
 context_cache::~context_cache() {
 }
 

--- a/src/library/context_cache.h
+++ b/src/library/context_cache.h
@@ -108,6 +108,10 @@ class context_cache : public context_cacheless {
 public:
     context_cache();
     context_cache(options const & o);
+    /* Faster version of `context_cache(c.get_options())`.
+       The bool parameter is not used. It is here just to make sure we don't confuse
+       this constructor with the copy constructor. */
+    context_cache(abstract_context_cache const &, bool);
     context_cache(context_cache const &) = delete;
     context_cache(context_cache &&) = default;
     virtual ~context_cache();

--- a/src/library/type_context.cpp
+++ b/src/library/type_context.cpp
@@ -33,6 +33,7 @@ Author: Leonardo de Moura
 #include "library/num.h"
 #include "library/quote.h"
 #include "library/check.h"
+#include "library/context_cache.h"
 
 namespace lean {
 bool is_at_least_semireducible(transparency_mode m) {
@@ -2387,8 +2388,7 @@ optional<expr> type_context_old::mk_class_instance_at(local_context const & lctx
             return r;
         }
     } else {
-        // TODO(gabriel): allow local caching
-        context_cacheless tmp_cache(*m_cache, true);
+        context_cache tmp_cache(*m_cache, true);
         type_context_old tmp_ctx(env(), m_mctx, lctx, tmp_cache, m_transparency_mode);
         auto r = tmp_ctx.mk_class_instance(type);
         if (r)
@@ -2415,8 +2415,7 @@ bool type_context_old::mk_nested_instance(expr const & m, expr const & m_type) {
 
         // HACK(gabriel): do not reuse type-class cache for nested resolution problems
         // For one example that easily breaks, see the default field values in `init/control/lawful.lean`
-        // TODO(gabriel): allow local caching
-        context_cacheless tmp_cache(*m_cache, true);
+        context_cache tmp_cache(*m_cache, true);
         type_context_old tmp_ctx(env(), m_mctx, mdecl->get_context(), tmp_cache, m_transparency_mode);
         inst = tmp_ctx.mk_class_instance(m_type);
         if (inst) m_mctx = tmp_ctx.mctx();

--- a/tests/lean/run/tc_cache2.lean
+++ b/tests/lean/run/tc_cache2.lean
@@ -1,0 +1,27 @@
+class succeeds_w_cache (α : Type) := (a : α)
+class fails_quickly_w_cache (α : Type) extends succeeds_w_cache α
+class loops_wo_cache (α : Type) := (a : α)
+class has_no_inst (α : Type)
+
+instance loops_wo_cache.loop {α} [loops_wo_cache α] [inhabited α] :
+    loops_wo_cache α :=
+‹loops_wo_cache α›
+
+instance inhabited.to_loops_wo_cache {α} [inhabited α] : loops_wo_cache α :=
+{a := default _}
+
+instance loops_wo_cache.to_fails_quickly_w_cache {α} [has_no_inst α] [loops_wo_cache α] :
+    fails_quickly_w_cache α :=
+{a := loops_wo_cache.a}
+
+@[priority 1] instance inhabited.to_succeeds_w_cache {α} [inhabited α] :
+    succeeds_w_cache α :=
+{a := default _}
+
+#check (by apply_instance : succeeds_w_cache ℕ)
+
+open tactic
+#eval do
+x ← to_expr ``(succeeds_w_cache.a),
+infer_type x >>= unify `(nat),
+unify `(nat.zero) x


### PR DESCRIPTION
Fixes #504.

Well, not completely.  The cache is still reset between different nested resolution problems during unification.  But at least it makes diamonds much less of a problem.