### PR TITLE
[Merged by Bors] - chore(library/init/data/punit): fix universe levels

### DIFF
--- a/library/init/data/punit.lean
+++ b/library/init/data/punit.lean
@@ -9,14 +9,14 @@ import init.logic
 lemma punit_eq (a b : punit) : a = b :=
 punit.rec_on a (punit.rec_on b rfl)
 
-lemma punit_eq_punit (a : punit) : a = () :=
-punit_eq a ()
+lemma punit_eq_star (a : punit) : a = punit.star :=
+punit_eq a punit.star
 
 instance : subsingleton punit :=
 subsingleton.intro punit_eq
 
 instance : inhabited punit :=
-⟨()⟩
+⟨punit.star⟩
 
 instance : decidable_eq punit :=
 λ a b, is_true (punit_eq a b)


### PR DESCRIPTION
Some instances and lemmas were using `unit`, not `punit.{u}` because of `()`.

----

#