### PR TITLE
[Merged by Bors] - fix(widget): docstring demo doesn't work

### DIFF
--- a/library/init/meta/widget/basic.lean
+++ b/library/init/meta/widget/basic.lean
@@ -241,8 +241,13 @@ meta def ignore_action : component π α → component π β
 meta def ignore_props : component unit α → component π α
 | c := with_should_update (λ a b, ff) $ component.map_props (λ p, ()) c
 
-meta instance : has_coe (component π empty) (component π α)
-:= ⟨component.filter_map_action (λ p x, none)⟩
+meta instance : has_coe (component π empty) (component π α) :=
+⟨component.filter_map_action (λ p x, none)⟩
+
+meta instance : has_coe_to_fun (component π α) :=
+{ F := λ c, π → html α
+, coe := λ c p, html.of_component p c
+}
 
 meta def stateful {π α : Type}
      (β σ : Type)

--- a/library/init/meta/widget/basic.lean
+++ b/library/init/meta/widget/basic.lean
@@ -245,9 +245,8 @@ meta instance : has_coe (component π empty) (component π α) :=
 ⟨component.filter_map_action (λ p x, none)⟩
 
 meta instance : has_coe_to_fun (component π α) :=
-{ F := λ c, π → html α
-, coe := λ c p, html.of_component p c
-}
+{ F := λ c, π → html α,
+  coe := λ c p, html.of_component p c }
 
 meta def stateful {π α : Type}
      (β σ : Type)

--- a/tests/lean/html_cmd.lean
+++ b/tests/lean/html_cmd.lean
@@ -1,0 +1,7 @@
+open widget
+
+variables {α:Type}
+
+meta def Hello : component string α := component.pure (λ s, ["hello, ", s, ", good day!"])
+
+#html (Hello "lean") -- renders "hello, lean, good day!"

--- a/tests/lean/html_cmd.lean.expected.out
+++ b/tests/lean/html_cmd.lean.expected.out
@@ -1,0 +1,1 @@
+successfully rendered widget


### PR DESCRIPTION
fixes #512

Adds a new coercion `component π α → (π → html α)`.