### PR TITLE
[Merged by Bors] - feat(library/init/util): `try_for_time` interruption function

### DIFF
--- a/library/init/meta/tactic.lean
+++ b/library/init/meta/tactic.lean
@@ -1648,7 +1648,7 @@ match _root_.try_for max (tac s) with
 | none   := mk_exception "try_for tactic failed, timeout" none s
 end
 
-/-- Execute tac for 'max' milliseconds. Useful due to variance
+/-- Execute `tac` for `max` milliseconds. Useful due to variance
     in the number of heartbeats taken by various tactics. -/
 meta def try_for_time {α} (max : nat) (tac : tactic α) : tactic α :=
 λ s,

--- a/library/init/meta/tactic.lean
+++ b/library/init/meta/tactic.lean
@@ -1648,6 +1648,16 @@ match _root_.try_for max (tac s) with
 | none   := mk_exception "try_for tactic failed, timeout" none s
 end
 
+/-- Execute tac for 'max' milliseconds. Useful due to variance
+    in the number of heartbeats taken by various tactics. -/
+meta def try_for_time {α} (max : nat) (tac : tactic α) : tactic α :=
+λ s,
+match _root_.try_for_time max (tac s) with
+| some r := r
+| none   := mk_exception "try_for_time tactic failed, timeout" none s
+end
+
+
 meta def updateex_env (f : environment → exceptional environment) : tactic unit :=
 do env ← get_env,
    env ← returnex $ f env,

--- a/library/init/util.lean
+++ b/library/init/util.lean
@@ -37,7 +37,7 @@ some (f ())
 
 /--
   This function has a native implementation where
-  the thunk is interrupted if it takes more than 'max' milliseconds to compute it.
+  the thunk is interrupted if it takes more than `max` milliseconds to compute it.
   This is useful due to the variance in the number of heartbeats used by tactics. -/
 meta def try_for_time {α : Type u} (max : ℕ) (f : thunk α) : option α :=
 some (f ())

--- a/library/init/util.lean
+++ b/library/init/util.lean
@@ -34,6 +34,14 @@ f ()
   This is a deterministic way of interrupting long running tasks. -/
 meta def try_for {α : Type u} (max : nat) (f : thunk α) : option α :=
 some (f ())
+
+/--
+  This function has a native implementation where
+  the thunk is interrupted if it takes more than 'max' milliseconds to compute it.
+  This is useful due to the variance in the number of heartbeats used by tactics. -/
+meta def try_for_time {α : Type u} (max : ℕ) (f : thunk α) : option α :=
+some (f ())
+
 /-- Throws an exception when it is evaluated.  -/
 meta constant undefined_core {α : Sort u} (message : string) : α
 

--- a/src/library/vm/vm.cpp
+++ b/src/library/vm/vm.cpp
@@ -2389,8 +2389,24 @@ optional<vm_obj> vm_state::try_invoke_catch(vm_obj const & fn, unsigned nargs, v
             while (m_call_stack.size() > call_stack_sz) m_call_stack.pop_back();
         }
         return optional<vm_obj>();
+    } catch (lean::interrupted) {
+        m_code           = code;
+        m_fn_idx         = fn_idx;
+        m_pc             = pc;
+        m_bp             = bp;
+        m_next_frame_idx = next_frame_idx;
+        m_stack.resize(stack_sz);
+        m_stack_info.resize(stack_info_sz);
+        if (m_profiling) {
+            unique_lock<mutex> lk(m_call_stack_mtx);
+            while (m_call_stack.size() > call_stack_sz) m_call_stack.pop_back();
+        } else {
+            while (m_call_stack.size() > call_stack_sz) m_call_stack.pop_back();
+        }
+        return optional<vm_obj>();
     }
 }
+
 
 vm_obj native_invoke(vm_obj const & fn, vm_obj const & a1);
 vm_obj native_invoke(vm_obj const & fn, vm_obj const & a1, vm_obj const & a2);

--- a/src/library/vm/vm.cpp
+++ b/src/library/vm/vm.cpp
@@ -2389,7 +2389,7 @@ optional<vm_obj> vm_state::try_invoke_catch(vm_obj const & fn, unsigned nargs, v
             while (m_call_stack.size() > call_stack_sz) m_call_stack.pop_back();
         }
         return optional<vm_obj>();
-    } catch (lean::interrupted) {
+    } catch (lean::interrupted &) {
         m_code           = code;
         m_fn_idx         = fn_idx;
         m_pc             = pc;

--- a/src/library/vm/vm_aux.cpp
+++ b/src/library/vm/vm_aux.cpp
@@ -57,6 +57,7 @@ vm_obj vm_try_for(vm_obj const &, vm_obj const & n, vm_obj const & thunk) {
 }
 
 vm_obj vm_try_for_time (vm_obj const &, vm_obj const & n, vm_obj const & thunk) {
+#if defined(LEAN_MULTI_THREAD)
   size_t max = static_cast<size_t> (force_to_unsigned(n)); // n = # millisecs, max = # millisecs
   auto ctok = mk_cancellation_token(global_cancellation_token());
   condition_variable wake_up_killer;

--- a/src/library/vm/vm_aux.cpp
+++ b/src/library/vm/vm_aux.cpp
@@ -80,6 +80,9 @@ vm_obj vm_try_for_time (vm_obj const &, vm_obj const & n, vm_obj const & thunk) 
   wake_up_killer.notify_one();
   killer.join();
   return result;
+#else
+  return mk_vm_none();
+#endif
 }
 
 

--- a/tests/lean/try_for_time.lean
+++ b/tests/lean/try_for_time.lean
@@ -1,0 +1,16 @@
+run_cmd do {
+  (tactic.try_for_time 1000 (tactic.sleep 5000 *> tactic.sleep 5000 *> tactic.trace "NOT OKAY")) <|> tactic.trace "OKAY"
+}
+
+run_cmd do {
+  tactic.try_for_time 1000 (tactic.try_for 1000 (tactic.sleep 3000 *> tactic.trace "NOT OKAY")) <|> tactic.trace "OKAY"
+}
+
+run_cmd do {
+  (tactic.try_for_time 10000 $ tactic.try_for 1 $
+  tactic.using_new_ref (0 : ℕ) $
+    λ r, tactic.iterate_at_most' 500000
+      (do val ← tactic.read_ref r,
+          tactic.write_ref r (val + 1),
+          (guard (val < 300) <|> tactic.trace format! "GUARD FAILED, VALUE IS {val}"))) <|> tactic.trace "OKAY"
+}

--- a/tests/lean/try_for_time.lean.expected.out
+++ b/tests/lean/try_for_time.lean.expected.out
@@ -1,0 +1,3 @@
+OKAY
+OKAY
+OKAY


### PR DESCRIPTION
Exposes `try_for_time`, which is similar to `try_for` except that it will interrupt after `max` milliseconds have passed. This is useful because there is quite a bit of variance in the number of heartbeats used by hanging/looping tactics.

Co-author: @gebner 