### PR TITLE
[Merged by Bors] - fix(pp): bug in addresses of ∃ (x > 0), x = x

### DIFF
--- a/src/frontends/lean/pp.cpp
+++ b/src/frontends/lean/pp.cpp
@@ -1049,12 +1049,12 @@ T pretty_fn<T>::pp_binders(buffer<subexpr> const & locals) {
     T r;
     for (unsigned i = 1; i < num; i++) {
         expr local = locals[i].first;
-        address la = locals[i].second;
-        address_scope scope(*this, la);
         if (!bi.is_inst_implicit() && mlocal_type(local) == type && local_info(local) == bi) {
             names.push_back(mlocal_pp_name(local));
         } else {
+            address_scope scope(*this, la);
             r += group(compose(line(), pp_binder_block(names, type, bi)));
+            la = locals[i].second;
             names.clear();
             type = mlocal_type(local);
             bi   = local_info(local);

--- a/tests/lean/pp_tagged.lean
+++ b/tests/lean/pp_tagged.lean
@@ -21,3 +21,10 @@ constant bar [inhabited ℕ] [inhabited ℕ] : ℕ → ℤ
 constant foo (α : Type) [inhabited ℕ] [inhabited ℕ] : ℕ → ℤ
 #eval (sf.of_eformat <$> tactic.pp_tagged `((int.of_nat = bar))) >>= tactic.trace
 #eval (sf.of_eformat <$> tactic.pp_tagged `((int.of_nat = (foo nat)))) >>= tactic.trace
+
+#eval (sf.of_eformat <$> tactic.pp_tagged `(∃ (x : nat), x = x)) >>= tactic.trace
+#eval (sf.of_eformat <$> tactic.pp_tagged `(∃ (x y z: nat), x = x)) >>= tactic.trace
+
+#eval (sf.of_eformat <$> tactic.pp_tagged `(∃ (x > 0), x = x)) >>= tactic.trace
+#eval (sf.of_eformat <$> tactic.pp_tagged `(λ (x > 0), x = x)) >>= tactic.trace
+#eval (sf.of_eformat <$> tactic.pp_tagged `(Π (x > 0), x = x)) >>= tactic.trace

--- a/tests/lean/pp_tagged.lean.expected.out
+++ b/tests/lean/pp_tagged.lean.expected.out
@@ -69,3 +69,136 @@
   (tag_expr [app_fn, app_fn, app_fn] `(foo) "foo")
   "\n"
   (tag_expr [app_fn, app_fn, app_arg] `(nat) "ℕ"))
+"∃"
+""
+"\n"
+""
+"("
+"x"
+" "
+":"
+"\n"
+(tag_expr [app_arg, lam_var_type] `(nat) "ℕ")
+")"
+","
+"\n"
+(tag_expr [app_arg, lam_body]
+  `(eq.{1} nat x x)
+  (tag_expr [app_fn, app_arg] `(x) "x")
+  " ="
+  "\n"
+  (tag_expr [app_arg] `(x) "x"))
+"∃"
+""
+"\n"
+""
+"("
+"x"
+" "
+"y"
+" "
+"z"
+" "
+":"
+"\n"
+(tag_expr [app_arg, lam_var_type] `(nat) "ℕ")
+")"
+","
+"\n"
+(tag_expr [app_arg, lam_body, app_arg, lam_body, app_arg, lam_body]
+  `(eq.{1} nat x x)
+  (tag_expr [app_fn, app_arg] `(x) "x")
+  " ="
+  "\n"
+  (tag_expr [app_arg] `(x) "x"))
+"∃"
+""
+"\n"
+""
+"("
+"x"
+" "
+":"
+"\n"
+(tag_expr [app_arg, lam_var_type] `(nat) "ℕ")
+")"
+"\n"
+""
+"("
+"H"
+" "
+":"
+"\n"
+(tag_expr [app_arg, lam_body, app_arg, lam_var_type]
+  `(gt.{0} nat nat.has_lt x (has_zero.zero.{0} nat nat.has_zero))
+  (tag_expr [app_fn, app_arg] `(x) "x")
+  " >"
+  "\n"
+  (tag_expr [app_arg] `(has_zero.zero.{0} nat nat.has_zero) "0"))
+")"
+","
+"\n"
+(tag_expr [app_arg, lam_body, app_arg, lam_body]
+  `(eq.{1} nat x x)
+  (tag_expr [app_fn, app_arg] `(x) "x")
+  " ="
+  "\n"
+  (tag_expr [app_arg] `(x) "x"))
+"λ"
+""
+"\n"
+""
+"("
+"x"
+" "
+":"
+"\n"
+(tag_expr [lam_var_type] `(nat) "ℕ")
+")"
+"\n"
+""
+"("
+"H"
+" "
+":"
+"\n"
+(tag_expr [lam_body, lam_var_type]
+  `(gt.{0} nat nat.has_lt x (has_zero.zero.{0} nat nat.has_zero))
+  (tag_expr [app_fn, app_arg] `(x) "x")
+  " >"
+  "\n"
+  (tag_expr [app_arg] `(has_zero.zero.{0} nat nat.has_zero) "0"))
+")"
+","
+"\n"
+(tag_expr [lam_body, lam_body]
+  `(eq.{1} nat x x)
+  (tag_expr [app_fn, app_arg] `(x) "x")
+  " ="
+  "\n"
+  (tag_expr [app_arg] `(x) "x"))
+"∀"
+""
+"\n"
+""
+"("
+"x"
+" "
+":"
+"\n"
+(tag_expr [pi_var_type] `(nat) "ℕ")
+")"
+","
+"\n"
+(tag_expr [pi_body]
+  `((gt.{0} nat nat.has_lt x (has_zero.zero.{0} nat nat.has_zero)) -> (eq.{1} nat x x))
+  (tag_expr [pi_var_type]
+    `(gt.{0} nat nat.has_lt x (has_zero.zero.{0} nat nat.has_zero))
+    (tag_expr [app_fn, app_arg] `(x) "x")
+    " >"
+    "\n"
+    (tag_expr [app_arg] `(has_zero.zero.{0} nat nat.has_zero) "0"))
+  " "
+  "→"
+  "\n"
+  (tag_expr [pi_body] `(eq.{1} nat x x) (tag_expr [app_fn, app_arg] `(x) "x") " =" "\n" (tag_expr [app_arg] `(x) "x")))


### PR DESCRIPTION
The pretty printer was getting the addresses for a special notation binder wrong because of a bug in pp_binders.

See also https://github.com/leanprover-community/mathlib/pull/5440