### PR TITLE
[Merged by Bors] - feat(src/library/tlean_exporter): export textual .tlean files

### DIFF
--- a/.github/workflows/on-push.yml
+++ b/.github/workflows/on-push.yml
@@ -42,6 +42,9 @@ jobs:
         with:
           name: lean-nightly-linux-${{ matrix.build_type }}
           path: ./build/lean-*
+      - name: Generate tleans
+        run: ../bin/lean --tlean --recursive .
+        working-directory: ./library
       - name: Test
         run: ctest -j2 --output-on-failure
         working-directory: ./build
@@ -59,6 +62,9 @@ jobs:
       - name: Build
         run: make -j2
         working-directory: ./build
+      - name: Generate tleans
+        run: ../bin/lean --tlean --recursive .
+        working-directory: ./library
       - name: Test
         run: ctest -j2 --output-on-failure
         working-directory: ./build
@@ -97,6 +103,9 @@ jobs:
         with:
           name: lean-nightly-macos-${{ matrix.build_type }}
           path: ./build/lean-*
+      - name: Generate tleans
+        run: ../bin/lean --tlean --recursive .
+        working-directory: ./library
       - name: Test
         run: ctest -j2 --output-on-failure
         working-directory: ./build
@@ -140,6 +149,9 @@ jobs:
         with:
           name: lean-nightly-windows-${{ matrix.build_type }}
           path: ./build/lean-*
+      - name: Generate tleans
+        run: ../bin/lean --tlean --recursive .
+        working-directory: ./library
       - name: Test
         run: |
           ctest -j2 --output-on-failure

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 \#*
 .#*
 *.olean
+*.tlean
 *.lock
 build
 GPATH

--- a/script/mk_all.sh
+++ b/script/mk_all.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+# Usage: ./script/mk_all.sh [subdirectory]
+#
+# Examples:
+#   ./script/mk_all.sh
+#   ./script/mk_all.sh data/
+#
+# Makes a ./library/$directory/all.lean importing all files inside $directory.
+# If $directory is omitted, creates `./library/all.lean`.
+
+cd "$( dirname "${BASH_SOURCE[0]}" )"/../library
+if [[ $# = 1 ]]; then
+  dir="$1"
+else
+  dir="."
+fi
+
+find "$dir" -name \*.lean -not -name all.lean \
+  | sed 's,^\./,,;s,\.lean$,,;s,/,.,g;s,^,import ,' \
+  | sort >"$dir"/all.lean

--- a/script/rm_all.sh
+++ b/script/rm_all.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+# Usage: ./script/rm_all.sh
+# Removes all files named all.lean in the ./library/ directory
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+find $DIR/../library/ -name 'all.lean' -delete -o -name 'all.olean' -delete -o -name 'all.tlean' -delete

--- a/src/frontends/lean/parser_config.cpp
+++ b/src/frontends/lean/parser_config.cpp
@@ -123,7 +123,7 @@ struct token_config {
         } else {
             x.out() << " " << "NONE";
         }
-        x.out() << std::endl;
+        x.out() << "\n";
     }
 
     static entry read_entry(deserializer & d) {
@@ -370,7 +370,7 @@ struct notation_config {
                 prec = rule_prec;
             }
 
-            x.out() << "#MIXFIX " << kind << " " << fni << " " << prec << " " << t.get_pp_token().get_string() << std::endl;
+            x.out() << "#MIXFIX " << kind << " " << fni << " " << prec << " " << t.get_pp_token().get_string() << "\n";
         }
     }
 

--- a/src/frontends/lean/parser_config.cpp
+++ b/src/frontends/lean/parser_config.cpp
@@ -358,19 +358,23 @@ struct notation_config {
 
             auto token_prec_opt = get_expr_precedence(get_token_table(x.env()), t.get_token().get_string());
             auto token_prec = token_prec_opt ? *token_prec_opt : 0;
-            auto rule_prec = t.get_action().rbp();
 
             unsigned prec;
 
-            if (kind == "infix") {
-                // if (k == mixfix_kind::infixr) prec = *prec - 1;
-                if (rule_prec + 1 == token_prec) {
-                    kind = "infixr"; prec = token_prec;
-                } else {
-                    kind = "infixl"; prec = rule_prec;
-                }
+            if (kind == "singleton") {
+                prec = get_max_prec();
             } else {
-                prec = rule_prec;
+                auto rule_prec = t.get_action().rbp();
+                if (kind == "infix") {
+                    // if (k == mixfix_kind::infixr) prec = *prec - 1;
+                    if (rule_prec + 1 == token_prec) {
+                        kind = "infixr"; prec = token_prec;
+                    } else {
+                        kind = "infixl"; prec = rule_prec;
+                    }
+                } else {
+                    prec = rule_prec;
+                }
             }
 
             x.out() << "#MIXFIX " << kind << " " << fni << " " << prec << " " << t.get_pp_token().get_string() << "\n";

--- a/src/frontends/lean/parser_config.cpp
+++ b/src/frontends/lean/parser_config.cpp
@@ -364,8 +364,11 @@ struct notation_config {
 
             if (kind == "infix") {
                 // if (k == mixfix_kind::infixr) prec = *prec - 1;
-                if (rule_prec + 1 == token_prec) { kind = "infixr"; prec = token_prec; }
-                else { kind = "infixl"; prec = rule_prec; }
+                if (rule_prec + 1 == token_prec) {
+                    kind = "infixr"; prec = token_prec;
+                } else {
+                    kind = "infixl"; prec = rule_prec;
+                }
             } else {
                 prec = rule_prec;
             }

--- a/src/frontends/lean/parser_config.cpp
+++ b/src/frontends/lean/parser_config.cpp
@@ -356,24 +356,14 @@ struct notation_config {
         if (is_constant(fn)) {
             auto fni = x.export_name(const_name(fn));
 
-            auto token_prec_opt = get_expr_precedence(get_token_table(x.env()), t.get_token().get_string());
-            auto token_prec = token_prec_opt ? *token_prec_opt : 0;
+            auto prec_opt = get_expr_precedence(get_token_table(x.env()), t.get_token().get_string());
+            auto prec = prec_opt ? *prec_opt : 0;
 
-            unsigned prec;
-
-            if (kind == "singleton") {
-                prec = get_max_prec();
-            } else {
-                auto rule_prec = t.get_action().rbp();
-                if (kind == "infix") {
-                    // if (k == mixfix_kind::infixr) prec = *prec - 1;
-                    if (rule_prec + 1 == token_prec) {
-                        kind = "infixr"; prec = token_prec;
-                    } else {
-                        kind = "infixl"; prec = rule_prec;
-                    }
+            if (kind == "infix") {
+                if (t.get_action().rbp() == prec - 1) {
+                    kind = "infixr";
                 } else {
-                    prec = rule_prec;
+                    kind = "infixl";
                 }
             }
 

--- a/src/library/CMakeLists.txt
+++ b/src/library/CMakeLists.txt
@@ -22,7 +22,8 @@ add_library(library OBJECT deep_copy.cpp expr_lt.cpp io_state.cpp
   documentation.cpp check.cpp parray.cpp process.cpp
   pipe.cpp handle.cpp profiling.cpp time_task.cpp abstract_context_cache.cpp
   context_cache.cpp unique_id.cpp persistent_context_cache.cpp elab_context.cpp
-  expr_address.cpp)
+  expr_address.cpp tlean_exporter.cpp
+  )
 if(EMSCRIPTEN)
 add_dependencies(library gmp)
 endif()

--- a/src/library/attribute_manager.cpp
+++ b/src/library/attribute_manager.cpp
@@ -141,6 +141,26 @@ struct attr_config {
         }
     }
 
+    static void textualize_entry(tlean_exporter & x, entry const & e) {
+        unsigned n_attr = x.export_name(e.m_attr);
+        unsigned n_decl = x.export_name(e.m_record.m_decl);
+        x.out() << "#ATTR"
+                << " " << n_attr
+                << " " << e.m_prio
+                << " " << n_decl
+                << " " << e.m_record.deleted()
+                << " ";
+
+        if (!e.m_record.deleted()) {
+            if (is_system_attribute(e.m_attr))
+                get_system_attribute(e.m_attr).textualize_entry(x, *e.m_record.m_data);
+            else
+                // dispatch over the extension, since we can't call get_attribute without an env
+                g_user_attribute_ext->textualize_entry(x, *e.m_record.m_data);
+        }
+        x.out() << std::endl;
+    }
+
     static entry read_entry(deserializer & d) {
         entry e; bool deleted;
         d >> e.m_attr >> e.m_prio >> e.m_record.m_decl >> deleted;

--- a/src/library/attribute_manager.cpp
+++ b/src/library/attribute_manager.cpp
@@ -158,7 +158,7 @@ struct attr_config {
                 // dispatch over the extension, since we can't call get_attribute without an env
                 g_user_attribute_ext->textualize_entry(x, *e.m_record.m_data);
         }
-        x.out() << std::endl;
+        x.out() << "\n";
     }
 
     static entry read_entry(deserializer & d) {

--- a/src/library/aux_recursors.cpp
+++ b/src/library/aux_recursors.cpp
@@ -49,7 +49,7 @@ struct auxrec_modification : public modification {
 
     void textualize(tlean_exporter & x) const override {
         unsigned n = x.export_name(m_decl);
-        x.out() << "#AUXREC " << n << std::endl;;
+        x.out() << "#AUXREC " << n << "\n";
     }
 
     static std::shared_ptr<modification const> deserialize(deserializer & d) {
@@ -77,7 +77,7 @@ struct no_conf_modification : public modification {
 
     void textualize(tlean_exporter & x) const override {
         unsigned n = x.export_name(m_decl);
-        x.out() << "#NOCONF " << n << std::endl;;
+        x.out() << "#NOCONF " << n << "\n";
     }
 
     static std::shared_ptr<modification const> deserialize(deserializer & d) {

--- a/src/library/aux_recursors.cpp
+++ b/src/library/aux_recursors.cpp
@@ -47,6 +47,11 @@ struct auxrec_modification : public modification {
         s << m_decl;
     }
 
+    void textualize(tlean_exporter & x) const override {
+        unsigned n = x.export_name(m_decl);
+        x.out() << "#AUXREC " << n << std::endl;;
+    }
+
     static std::shared_ptr<modification const> deserialize(deserializer & d) {
         return std::make_shared<auxrec_modification>(read_name(d));
     }
@@ -68,6 +73,11 @@ struct no_conf_modification : public modification {
 
     void serialize(serializer & s) const override {
         s << m_decl;
+    }
+
+    void textualize(tlean_exporter & x) const override {
+        unsigned n = x.export_name(m_decl);
+        x.out() << "#NOCONF " << n << std::endl;;
     }
 
     static std::shared_ptr<modification const> deserialize(deserializer & d) {

--- a/src/library/class.cpp
+++ b/src/library/class.cpp
@@ -190,6 +190,44 @@ struct class_config {
         }
     }
 
+    static void  textualize_entry(tlean_exporter & x, entry const & e) {
+        unsigned n_class, n_instance, n_track_attr;
+        switch (e.m_kind) {
+        case class_entry_kind::Class:
+            n_class = x.export_name(e.m_class);
+            x.out() << "#CLASS"
+                    << " " << n_class
+                    << std::endl;
+            break;
+        case class_entry_kind::Instance:
+            n_class    = x.export_name(e.m_class);
+            n_instance = x.export_name(e.m_instance);
+            x.out() << "#CLASS_INSTANCE"
+                    << " " << n_class
+                    << " " << n_instance
+                    << " " << e.m_priority
+                    << std::endl;
+            break;
+        case class_entry_kind::Tracker:
+            n_class      = x.export_name(e.m_class);
+            n_track_attr = x.export_name(e.m_track_attr);
+            x.out() << "#CLASS_TRACK_ATTR"
+                    << " " << n_class
+                    << " " << n_track_attr
+                    << std::endl;
+            break;
+        case class_entry_kind::RemoveInstance:
+            n_class    = x.export_name(e.m_class);
+            n_instance = x.export_name(e.m_instance);
+            x.out() << "#CLASS_RM_INSTANCE"
+                    << " " << n_class
+                    << " " << n_instance
+                    << " " << e.m_priority
+                    << std::endl;
+            break;
+        }
+    }
+
     static entry read_entry(deserializer & d) {
         entry e; char k;
         d >> k;

--- a/src/library/class.cpp
+++ b/src/library/class.cpp
@@ -197,7 +197,7 @@ struct class_config {
             n_class = x.export_name(e.m_class);
             x.out() << "#CLASS"
                     << " " << n_class
-                    << std::endl;
+                    << "\n";
             break;
         case class_entry_kind::Instance:
             n_class    = x.export_name(e.m_class);
@@ -206,7 +206,7 @@ struct class_config {
                     << " " << n_class
                     << " " << n_instance
                     << " " << e.m_priority
-                    << std::endl;
+                    << "\n";
             break;
         case class_entry_kind::Tracker:
             n_class      = x.export_name(e.m_class);
@@ -214,7 +214,7 @@ struct class_config {
             x.out() << "#CLASS_TRACK_ATTR"
                     << " " << n_class
                     << " " << n_track_attr
-                    << std::endl;
+                    << "\n";
             break;
         case class_entry_kind::RemoveInstance:
             n_class    = x.export_name(e.m_class);
@@ -223,7 +223,7 @@ struct class_config {
                     << " " << n_class
                     << " " << n_instance
                     << " " << e.m_priority
-                    << std::endl;
+                    << "\n";
             break;
         }
     }

--- a/src/library/export_decl.cpp
+++ b/src/library/export_decl.cpp
@@ -126,7 +126,7 @@ struct export_decl_modification : public modification {
             x.out() << " " << n_except_name;
         }
 
-        x.out() << std::endl;
+        x.out() << "\n";
     }
 
     static std::shared_ptr<modification const> deserialize(deserializer & d) {

--- a/src/library/inverse.cpp
+++ b/src/library/inverse.cpp
@@ -47,6 +47,20 @@ struct inverse_config {
     static void  write_entry(serializer & s, entry const & e) {
         s << e.m_fn << e.m_info.m_arity << e.m_info.m_inv << e.m_info.m_inv_arity << e.m_info.m_lemma;
     }
+
+    static void  textualize_entry(tlean_exporter & x, entry const & e) {
+        unsigned n_fn    = x.export_name(e.m_fn);
+        unsigned n_inv   = x.export_name(e.m_info.m_inv);
+        unsigned n_lemma = x.export_name(e.m_info.m_lemma);
+        x.out() << "#INVERSE"
+                << " " << n_fn
+                << " " << e.m_info.m_arity
+                << " " << n_inv
+                << " " << e.m_info.m_inv_arity
+                << " " << n_lemma
+                << std::endl;
+    }
+
     static entry read_entry(deserializer & d) {
         entry e;
         d >> e.m_fn >> e.m_info.m_arity >> e.m_info.m_inv >> e.m_info.m_inv_arity >> e.m_info.m_lemma;

--- a/src/library/inverse.cpp
+++ b/src/library/inverse.cpp
@@ -58,7 +58,7 @@ struct inverse_config {
                 << " " << n_inv
                 << " " << e.m_info.m_inv_arity
                 << " " << n_lemma
-                << std::endl;
+                << "\n";
     }
 
     static entry read_entry(deserializer & d) {

--- a/src/library/module.cpp
+++ b/src/library/module.cpp
@@ -175,7 +175,7 @@ struct pos_info_mod : public modification {
         x.out() << "#POS_INFO " << n
                 << " " << m_pos_info.first
                 << " " << m_pos_info.second
-                << std::endl;
+                << "\n";
     }
 
     static std::shared_ptr<modification const> deserialize(deserializer & d) {
@@ -276,7 +276,7 @@ void write_module_tlean(loaded_module const & mod, std::ostream & out) {
         int rel = import.m_relative.has_value() ? *import.m_relative : -1;
         out << import.m_name << " " << rel << " ";
     }
-    out << std::endl;
+    out << "\n";
 
     tlean_exporter x(out, get(mod.m_env));
     for (auto p : mod.m_modifications) {

--- a/src/library/module.cpp
+++ b/src/library/module.cpp
@@ -282,6 +282,8 @@ void write_module_tlean(loaded_module const & mod, std::ostream & out) {
     for (auto p : mod.m_modifications) {
         p->textualize(x);
     }
+
+    out << std::flush;
 }
 
 static task<bool> has_sorry(modification_list const & mods) {

--- a/src/library/module.cpp
+++ b/src/library/module.cpp
@@ -170,6 +170,14 @@ struct pos_info_mod : public modification {
         s << m_decl_name << m_pos_info.first << m_pos_info.second;
     }
 
+    void textualize(tlean_exporter & x) const override {
+        unsigned n = x.export_name(m_decl_name);
+        x.out() << "#POS_INFO " << n
+                << " " << m_pos_info.first
+                << " " << m_pos_info.second
+                << std::endl;
+    }
+
     static std::shared_ptr<modification const> deserialize(deserializer & d) {
         name decl_name; unsigned line, column;
         d >> decl_name >> line >> column;
@@ -261,6 +269,21 @@ void write_module(loaded_module const & mod, std::ostream & out) {
     s2.write_blob(r);
 }
 
+void write_module_tlean(loaded_module const & mod, std::ostream & out) {
+    out << "IMPORT " << static_cast<unsigned>(mod.m_imports.size()) << " ";
+
+    for (auto import : mod.m_imports) {
+        int rel = import.m_relative.has_value() ? *import.m_relative : -1;
+        out << import.m_name << " " << rel << " ";
+    }
+    out << std::endl;
+
+    tlean_exporter x(out, get(mod.m_env));
+    for (auto p : mod.m_modifications) {
+        p->textualize(x);
+    }
+}
+
 static task<bool> has_sorry(modification_list const & mods) {
     std::vector<task<expr>> introduced_exprs;
     for (auto & mod : mods) mod->get_introduced_exprs(introduced_exprs);
@@ -338,6 +361,10 @@ struct decl_modification : public modification {
         s << m_decl << m_trust_lvl;
     }
 
+    void textualize(tlean_exporter & x) const override {
+        x.export_declaration(m_decl);
+    }
+
     static std::shared_ptr<modification const> deserialize(deserializer & d) {
         auto decl = read_declaration(d);
         unsigned trust_lvl; d >> trust_lvl;
@@ -365,7 +392,6 @@ struct inductive_modification : public modification {
     inductive::certified_inductive_decl m_decl;
     unsigned m_trust_lvl = LEAN_BELIEVER_TRUST_LEVEL + 1;
 
-
     inductive_modification(inductive::certified_inductive_decl const & decl, unsigned trust_lvl) :
             m_decl(decl), m_trust_lvl(trust_lvl) {}
 
@@ -384,6 +410,10 @@ struct inductive_modification : public modification {
 
     void serialize(serializer & s) const override {
         s << m_decl << m_trust_lvl;
+    }
+
+    void textualize(tlean_exporter & x) const override {
+        x.export_inductive(m_decl);
     }
 
     static std::shared_ptr<modification const> deserialize(deserializer & d) {

--- a/src/library/module.h
+++ b/src/library/module.h
@@ -18,6 +18,7 @@ Author: Leonardo de Moura
 #include "util/task.h"
 #include "util/rb_map.h"
 #include "library/string.h"
+#include "library/tlean_exporter.h"
 
 namespace lean {
 class corrupted_file_exception : public exception {
@@ -91,6 +92,7 @@ environment add_transient_decl_pos_info(environment const & env, name const & de
 /** \brief Store/Export module using \c env. */
 loaded_module export_module(environment const & env, std::string const & mod_name, unsigned src_hash, unsigned trans_hash);
 void write_module(loaded_module const & mod, std::ostream & out);
+void write_module_tlean(loaded_module const & mod, std::ostream & out);
 
 std::shared_ptr<loaded_module const> cache_preimported_env(
         loaded_module &&, environment const & initial_env,
@@ -119,6 +121,7 @@ public:
     virtual void perform(environment &) const = 0;
     virtual void serialize(serializer &) const = 0;
     virtual void get_task_dependencies(buffer<gtask> &) const {}
+    virtual void textualize(tlean_exporter &) const { return; }
 
     // Used to check for sorrys.
     virtual void get_introduced_exprs(std::vector<task<expr>> &) const {}

--- a/src/library/noncomputable.cpp
+++ b/src/library/noncomputable.cpp
@@ -57,6 +57,11 @@ struct noncomputable_modification : public modification {
         s << m_decl;
     }
 
+    void textualize(tlean_exporter & x) const override {
+        unsigned n = x.export_name(m_decl);
+        x.out() << "#NONCOMPUTABLE " << n << std::endl;
+    }
+
     static std::shared_ptr<modification const> deserialize(deserializer & d) {
         return std::make_shared<noncomputable_modification>(read_name(d));
     }

--- a/src/library/noncomputable.cpp
+++ b/src/library/noncomputable.cpp
@@ -59,7 +59,7 @@ struct noncomputable_modification : public modification {
 
     void textualize(tlean_exporter & x) const override {
         unsigned n = x.export_name(m_decl);
-        x.out() << "#NONCOMPUTABLE " << n << std::endl;
+        x.out() << "#NONCOMPUTABLE " << n << "\n";
     }
 
     static std::shared_ptr<modification const> deserialize(deserializer & d) {

--- a/src/library/private.cpp
+++ b/src/library/private.cpp
@@ -60,7 +60,7 @@ struct private_modification : public modification {
     void textualize(tlean_exporter & x) const override {
         unsigned n_name = x.export_name(m_name);
         unsigned n_real = x.export_name(m_real);
-        x.out() << "#PRIVATE " << n_name << " " << n_real << std::endl;
+        x.out() << "#PRIVATE " << n_name << " " << n_real << "\n";
     }
 
     static std::shared_ptr<modification const> deserialize(deserializer & d) {

--- a/src/library/private.cpp
+++ b/src/library/private.cpp
@@ -57,6 +57,12 @@ struct private_modification : public modification {
         s << m_name << m_real;
     }
 
+    void textualize(tlean_exporter & x) const override {
+        unsigned n_name = x.export_name(m_name);
+        unsigned n_real = x.export_name(m_real);
+        x.out() << "#PRIVATE " << n_name << " " << n_real << std::endl;
+    }
+
     static std::shared_ptr<modification const> deserialize(deserializer & d) {
         name n, h;
         d >> n >> h;

--- a/src/library/projection.cpp
+++ b/src/library/projection.cpp
@@ -67,7 +67,7 @@ struct proj_modification : public modification {
                 << " " << m_info.m_nparams
                 << " " << m_info.m_i
                 << " " << m_info.m_inst_implicit
-                << std::endl;
+                << "\n";
     }
 
     static std::shared_ptr<modification const> deserialize(deserializer & d) {

--- a/src/library/projection.cpp
+++ b/src/library/projection.cpp
@@ -57,6 +57,19 @@ struct proj_modification : public modification {
         s << m_proj << m_info.m_constructor << m_info.m_nparams << m_info.m_i << m_info.m_inst_implicit;
     }
 
+    void textualize(tlean_exporter & x) const override {
+        unsigned n_proj = x.export_name(m_proj);
+        unsigned n_constructor = x.export_name(m_info.m_constructor);
+
+        x.out() << "#PROJECTION"
+                << " " << n_proj
+                << " " << n_constructor
+                << " " << m_info.m_nparams
+                << " " << m_info.m_i
+                << " " << m_info.m_inst_implicit
+                << std::endl;
+    }
+
     static std::shared_ptr<modification const> deserialize(deserializer & d) {
         name p, mk; unsigned nparams, i; bool inst_implicit;
         d >> p >> mk >> nparams >> i >> inst_implicit;

--- a/src/library/protected.cpp
+++ b/src/library/protected.cpp
@@ -46,6 +46,11 @@ struct protected_modification : public modification {
         s << m_name;
     }
 
+    void textualize(tlean_exporter & x) const override {
+        unsigned n = x.export_name(m_name);
+        x.out() << "#PROTECTED " << n << std::endl;
+    }
+
     static std::shared_ptr<modification const> deserialize(deserializer & d) {
         return std::make_shared<protected_modification>(read_name(d));
     }

--- a/src/library/protected.cpp
+++ b/src/library/protected.cpp
@@ -48,7 +48,7 @@ struct protected_modification : public modification {
 
     void textualize(tlean_exporter & x) const override {
         unsigned n = x.export_name(m_name);
-        x.out() << "#PROTECTED " << n << std::endl;
+        x.out() << "#PROTECTED " << n << "\n";
     }
 
     static std::shared_ptr<modification const> deserialize(deserializer & d) {

--- a/src/library/reducible.cpp
+++ b/src/library/reducible.cpp
@@ -16,6 +16,15 @@ Author: Leonardo de Moura
 namespace lean {
 static name * g_reducibility = nullptr;
 
+std::string reducible_status_to_string(reducible_status const & s) {
+    switch (s) {
+    case reducible_status::Reducible:     return "Reducible";
+    case reducible_status::Semireducible: return "Semireducible";
+    case reducible_status::Irreducible:   return "Irreducible";
+    }
+    lean_unreachable();
+}
+
 unsigned get_reducibility_fingerprint(environment const & env) {
     return get_attribute_fingerprint(env, *g_reducibility);
 }
@@ -31,6 +40,11 @@ struct reducibility_attribute_data : public attr_data {
     void write(serializer & s) const {
         s << static_cast<char>(m_status);
     }
+
+    void textualize(tlean_exporter & x) const override {
+        x.out() << reducible_status_to_string(m_status);
+    }
+
     void read(deserializer & d) {
         char c;
         d >> c;

--- a/src/library/relation_manager.cpp
+++ b/src/library/relation_manager.cpp
@@ -181,7 +181,7 @@ struct rel_config {
         x.out() << "#RELATION"
                 << " " << op_kind_to_string(e.m_kind)
                 << " " << n_name
-                << std::endl;
+                << "\n";
     }
 
     static entry read_entry(deserializer & d) {

--- a/src/library/relation_manager.cpp
+++ b/src/library/relation_manager.cpp
@@ -35,6 +35,17 @@ static pair<expr, unsigned> extract_arg_types_core(environment const & env, name
 
 enum class op_kind { Relation, Subst, Trans, Refl, Symm };
 
+std::string op_kind_to_string(op_kind const & k) {
+    switch (k) {
+    case op_kind::Relation: return "Relation";
+    case op_kind::Refl:     return "Refl";
+    case op_kind::Subst:    return "Subst";
+    case op_kind::Trans:    return "Trans";
+    case op_kind::Symm:     return "Symm";
+    }
+    lean_unreachable();
+}
+
 struct rel_entry {
     op_kind m_kind;
     name    m_name;
@@ -160,9 +171,19 @@ struct rel_config {
         }
     }
     static const char * get_serialization_key() { return "REL"; }
+
     static void  write_entry(serializer & s, entry const & e) {
         s << static_cast<char>(e.m_kind) << e.m_name;
     }
+
+    static void  textualize_entry(tlean_exporter & x, entry const & e) {
+        unsigned n_name = x.export_name(e.m_name);
+        x.out() << "#RELATION"
+                << " " << op_kind_to_string(e.m_kind)
+                << " " << n_name
+                << std::endl;
+    }
+
     static entry read_entry(deserializer & d) {
         entry e;
         char cmd;

--- a/src/library/scoped_ext.cpp
+++ b/src/library/scoped_ext.cpp
@@ -118,7 +118,7 @@ struct new_namespace_modification : public modification {
 
     void textualize(tlean_exporter & x) const override {
         unsigned n = x.export_name(m_ns);
-        x.out() << "#NEW_NAMESPACE " << n << std::endl;;
+        x.out() << "#NEW_NAMESPACE " << n << "\n";
     }
 
     static std::shared_ptr<modification const> deserialize(deserializer & d) {

--- a/src/library/scoped_ext.cpp
+++ b/src/library/scoped_ext.cpp
@@ -116,6 +116,11 @@ struct new_namespace_modification : public modification {
         s << m_ns;
     }
 
+    void textualize(tlean_exporter & x) const override {
+        unsigned n = x.export_name(m_ns);
+        x.out() << "#NEW_NAMESPACE " << n << std::endl;;
+    }
+
     static std::shared_ptr<modification const> deserialize(deserializer & d) {
         name n;
         d >> n;

--- a/src/library/scoped_ext.h
+++ b/src/library/scoped_ext.h
@@ -83,6 +83,7 @@ class scoped_ext : public environment_extension {
         Config::add_entry(env, ios, s, e);
     }
     static void  write_entry(serializer & s, entry const & e) { Config::write_entry(s, e); }
+    static void  textualize_entry(tlean_exporter & x, entry const & e) { Config::textualize_entry(x, e); }
     static entry read_entry(deserializer & d) { return Config::read_entry(d); }
     static const char * get_serialization_key() { return Config::get_serialization_key(); }
     static optional<unsigned> get_fingerprint(entry const & e) {
@@ -151,6 +152,10 @@ public:
 
         void serialize(serializer & s) const override {
             write_entry(s, m_entry);
+        }
+
+        void textualize(tlean_exporter & x) const override {
+            textualize_entry(x, m_entry);
         }
 
         static std::shared_ptr<lean::modification const> deserialize(deserializer & d) {

--- a/src/library/tactic/tactic_state.cpp
+++ b/src/library/tactic/tactic_state.cpp
@@ -714,6 +714,12 @@ vm_obj tactic_add_decl(vm_obj const & _d, vm_obj const & _s) {
     tactic_state const & s  = tactic::to_state(_s);
     try {
         declaration d       = to_declaration(_d);
+        unsigned trust_lvl  = LEAN_BELIEVER_TRUST_LEVEL + 1;
+
+        if (trust_lvl > s.env().trust_lvl()) {
+            d = unfold_untrusted_macros(s.env(), d);
+        }
+
         environment new_env = module::add(s.env(), check(s.env(), d));
         new_env = vm_compile(new_env, s.get_options(), d);
         return tactic::mk_success(set_env(s, new_env));

--- a/src/library/tactic/user_attribute.cpp
+++ b/src/library/tactic/user_attribute.cpp
@@ -210,7 +210,7 @@ struct user_attr_modification : public modification {
 
     void textualize(tlean_exporter & x) const override {
         unsigned n = x.export_name(m_name);
-        x.out() << "#USER_ATTR " << n << std::endl;
+        x.out() << "#USER_ATTR " << n << "\n";
     }
 
     static std::shared_ptr<modification const> deserialize(deserializer & d) {

--- a/src/library/tactic/user_attribute.cpp
+++ b/src/library/tactic/user_attribute.cpp
@@ -180,6 +180,11 @@ public:
         static_cast<user_attribute_data const *>(&data)->write(s);
     }
 
+    void textualize_entry(tlean_exporter & x, attr_data const & data) override {
+        lean_assert(dynamic_cast<user_attribute_data const *>(&data));
+        static_cast<user_attribute_data const *>(&data)->textualize(x);
+    }
+
     attr_data_ptr read_entry(deserializer & d) override {
         auto data = new user_attribute_data;
         data->read(d);
@@ -201,6 +206,11 @@ struct user_attr_modification : public modification {
 
     void serialize(serializer & s) const override {
         s << m_name;
+    }
+
+    void textualize(tlean_exporter & x) const override {
+        unsigned n = x.export_name(m_name);
+        x.out() << "#USER_ATTR " << n << std::endl;
     }
 
     static std::shared_ptr<modification const> deserialize(deserializer & d) {

--- a/src/library/tlean_exporter.cpp
+++ b/src/library/tlean_exporter.cpp
@@ -1,0 +1,256 @@
+/*
+Copyright (c) 2015 Microsoft Corporation. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+
+Author: Leonardo de Moura, Daniel Selsam
+*/
+#include <iostream>
+#include "library/tlean_exporter.h"
+#include "library/unfold_macros.h"
+#include "kernel/quotient/quotient.h"
+#include "kernel/for_each_fn.h"
+#include "kernel/instantiate.h"
+#include "kernel/inductive/inductive.h"
+#include "library/module.h"
+#include "library/class.h"
+#include "library/attribute_manager.h"
+
+namespace lean {
+
+unsigned tlean_exporter::export_name(name const & n) {
+    auto it = m_name2idx.find(n);
+    if (it != m_name2idx.end()) {
+        return it->second;
+    }
+
+    unsigned i;
+    if (n.is_anonymous()) {
+        lean_unreachable();
+    } else if (n.is_string()) {
+        unsigned p = export_name(n.get_prefix());
+        i = static_cast<unsigned>(m_name2idx.size());
+        m_out << i << " #NS " << p << " " << n.get_string() << std::endl;
+    } else {
+        unsigned p = export_name(n.get_prefix());
+        i = static_cast<unsigned>(m_name2idx.size());
+        m_out << i << " #NI " << p << " " << n.get_numeral() << std::endl;
+    }
+    m_name2idx[n] = i;
+    return i;
+}
+
+unsigned tlean_exporter::export_level(level const & l) {
+    auto it = m_level2idx.find(l);
+    if (it != m_level2idx.end())
+        return it->second;
+    unsigned i = 0;
+    unsigned l1, l2, n;
+    switch (l.kind()) {
+    case level_kind::Zero:
+        lean_unreachable();
+        break;
+    case level_kind::Succ:
+        l1 = export_level(succ_of(l));
+        i = static_cast<unsigned>(m_level2idx.size());
+        m_out << i << " #US " << l1 << std::endl;
+        break;
+    case level_kind::Max:
+        l1 = export_level(max_lhs(l));
+        l2 = export_level(max_rhs(l));
+        i = static_cast<unsigned>(m_level2idx.size());
+        m_out << i << " #UM " << l1 << " " << l2 << std::endl;
+        break;
+    case level_kind::IMax:
+        l1 = export_level(imax_lhs(l));
+        l2 = export_level(imax_rhs(l));
+        i = static_cast<unsigned>(m_level2idx.size());
+        m_out << i << " #UIM " << l1 << " " << l2 << std::endl;
+        break;
+    case level_kind::Param:
+        n = export_name(param_id(l));
+        i = static_cast<unsigned>(m_level2idx.size());
+        m_out << i << " #UP " << n << std::endl;
+        break;
+    case level_kind::Meta:
+        throw exception("invalid 'export', universe meta-variables cannot be exported");
+    }
+    m_level2idx[l] = i;
+    return i;
+}
+
+void tlean_exporter::export_binder_info(binder_info const & bi) {
+    if (bi.is_implicit())
+        m_out << "#BI";
+    else if (bi.is_strict_implicit())
+        m_out << "#BS";
+    else if (bi.is_inst_implicit())
+        m_out << "#BC";
+    else
+        m_out << "#BD";
+}
+
+unsigned tlean_exporter::export_binding(expr const & e, char const * k) {
+    unsigned n  = export_name(binding_name(e));
+    unsigned e1 = export_expr_core(binding_domain(e));
+    unsigned e2 = export_expr_core(binding_body(e));
+    unsigned i = static_cast<unsigned>(m_expr2idx.size());
+    m_out << i << " " << k << " ";
+    export_binder_info(binding_info(e));
+    m_out << " " << n << " " << e1 << " " << e2 << std::endl;
+    return i;
+}
+
+unsigned tlean_exporter::export_const(expr const & e) {
+    buffer<unsigned> ls;
+    unsigned n = export_name(const_name(e));
+    for (level const & l : const_levels(e))
+        ls.push_back(export_level(l));
+    unsigned i = static_cast<unsigned>(m_expr2idx.size());
+    m_out << i << " #EC " << n;
+    for (unsigned l : ls)
+        m_out << " " << l;
+    m_out << std::endl;
+    return i;
+}
+
+unsigned tlean_exporter::export_expr_core(expr const & e) {
+    auto it = m_expr2idx.find(e);
+    if (it != m_expr2idx.end())
+        return it->second;
+    unsigned i = 0;
+    unsigned l, e1, e2;
+    switch (e.kind()) {
+    case expr_kind::Var:
+        i = static_cast<unsigned>(m_expr2idx.size());
+        m_out << i << " #EV " << var_idx(e) << std::endl;
+        break;
+    case expr_kind::Sort:
+        l = export_level(sort_level(e));
+        i = static_cast<unsigned>(m_expr2idx.size());
+        m_out << i << " #ES " << l << std::endl;
+        break;
+    case expr_kind::Constant:
+        i = export_const(e);
+        break;
+    case expr_kind::App:
+        e1 = export_expr_core(app_fn(e));
+        e2 = export_expr_core(app_arg(e));
+        i = static_cast<unsigned>(m_expr2idx.size());
+        m_out << i << " #EA " << e1 << " " << e2 << std::endl;
+        break;
+    case expr_kind::Let: {
+        auto n = export_name(let_name(e));
+        e1 = export_expr_core(let_type(e));
+        e2 = export_expr_core(let_value(e));
+        auto e3 = export_expr_core(let_body(e));
+        i = static_cast<unsigned>(m_expr2idx.size());
+        m_out << i << " #EZ " << n << " " << e1 << " " << e2 << " " << e3 << std::endl;
+        break;
+    }
+    case expr_kind::Lambda:
+        i = export_binding(e, "#EL");
+        break;
+    case expr_kind::Pi:
+        i = export_binding(e, "#EP");
+        break;
+    case expr_kind::Meta:
+        throw exception("invalid 'export', meta-variables cannot be exported");
+    case expr_kind::Local:
+        throw exception("invalid 'export', local constants cannot be exported");
+    case expr_kind::Macro:
+        throw exception("invalid 'export', macros cannot be exported");
+    }
+    m_expr2idx[e] = i;
+    return i;
+}
+
+unsigned tlean_exporter::export_expr(expr const & e) {
+    return export_expr_core(unfold_all_macros(m_env, e));
+}
+
+void tlean_exporter::export_definition(declaration const & d) {
+    auto hints = d.get_hints();
+    unsigned n = export_name(d.get_name());
+    auto ps = map2<unsigned>(d.get_univ_params(), [&] (name const & p) { return export_name(p); });
+    auto t = export_expr(d.get_type());
+    auto v = export_expr(d.get_value());
+
+    m_out << "#DEF " << n << " " << d.is_theorem() << " ";
+    if (hints.get_kind() == reducibility_hints::kind::Abbreviation) {
+        m_out << "A ";
+    } else if (hints.get_kind() == reducibility_hints::kind::Opaque) {
+        m_out << "O ";
+    } else {
+        m_out << hints.get_height() << " ";
+    }
+
+    m_out << t << " " << v;
+    for (unsigned p : ps)
+        m_out << " " << p;
+    m_out << std::endl;
+}
+
+void tlean_exporter::export_axiom(declaration const & d) {
+    unsigned n = export_name(d.get_name());
+    auto ps = map2<unsigned>(d.get_univ_params(), [&] (name const & p) { return export_name(p); });
+    auto t = export_expr(d.get_type());
+    m_out << "#AX " << n << " " << t;
+    for (unsigned p : ps)
+        m_out << " " << p;
+    m_out << std::endl;
+}
+
+void tlean_exporter::export_declaration(declaration const & d) {
+    if (!d.is_trusted()) return;
+
+    if (d.is_definition()) {
+        export_definition(d);
+    } else {
+        export_axiom(d);
+    }
+}
+
+void tlean_exporter::export_inductive(inductive::certified_inductive_decl const & cdecl) {
+    if (!cdecl.is_trusted()) return;
+    inductive::inductive_decl decl = cdecl.get_decl();
+    for (auto & p : decl.m_level_params)
+        export_name(p);
+
+    export_name(decl.m_name);
+    export_expr(decl.m_type);
+
+    for (auto & c : decl.m_intro_rules) {
+        export_name(inductive::intro_rule_name(c));
+        export_expr(inductive::intro_rule_type(c));
+    }
+
+    m_out << "#IND " << decl.m_num_params << " "
+          << export_name(decl.m_name) << " "
+          << export_expr(decl.m_type) << " "
+          << length(decl.m_intro_rules);
+    for (auto & c : decl.m_intro_rules) {
+        // intro rules are stored as local constants, we split them up so that
+        // the type checkers do not need to implement local constants.
+        m_out << " " << export_name(inductive::intro_rule_name(c))
+              << " " << export_expr(inductive::intro_rule_type(c));
+    }
+    for (name const & p : decl.m_level_params)
+        m_out << " " << export_name(p);
+
+    m_out << std::endl;
+}
+
+tlean_exporter::tlean_exporter(std::ostream & out, environment const & env) : m_out(out), m_env(env) {
+    m_name2idx[{}]  = 0;
+    m_level2idx[{}] = 0;
+}
+
+std::ostream & tlean_exporter::out() {
+    return m_out;
+}
+
+environment & tlean_exporter::env() {
+    return m_env;
+}
+
+}

--- a/src/library/tlean_exporter.cpp
+++ b/src/library/tlean_exporter.cpp
@@ -29,11 +29,11 @@ unsigned tlean_exporter::export_name(name const & n) {
     } else if (n.is_string()) {
         unsigned p = export_name(n.get_prefix());
         i = static_cast<unsigned>(m_name2idx.size());
-        m_out << i << " #NS " << p << " " << n.get_string() << std::endl;
+        m_out << i << " #NS " << p << " " << n.get_string() << "\n";
     } else {
         unsigned p = export_name(n.get_prefix());
         i = static_cast<unsigned>(m_name2idx.size());
-        m_out << i << " #NI " << p << " " << n.get_numeral() << std::endl;
+        m_out << i << " #NI " << p << " " << n.get_numeral() << "\n";
     }
     m_name2idx[n] = i;
     return i;
@@ -52,24 +52,24 @@ unsigned tlean_exporter::export_level(level const & l) {
     case level_kind::Succ:
         l1 = export_level(succ_of(l));
         i = static_cast<unsigned>(m_level2idx.size());
-        m_out << i << " #US " << l1 << std::endl;
+        m_out << i << " #US " << l1 << "\n";
         break;
     case level_kind::Max:
         l1 = export_level(max_lhs(l));
         l2 = export_level(max_rhs(l));
         i = static_cast<unsigned>(m_level2idx.size());
-        m_out << i << " #UM " << l1 << " " << l2 << std::endl;
+        m_out << i << " #UM " << l1 << " " << l2 << "\n";
         break;
     case level_kind::IMax:
         l1 = export_level(imax_lhs(l));
         l2 = export_level(imax_rhs(l));
         i = static_cast<unsigned>(m_level2idx.size());
-        m_out << i << " #UIM " << l1 << " " << l2 << std::endl;
+        m_out << i << " #UIM " << l1 << " " << l2 << "\n";
         break;
     case level_kind::Param:
         n = export_name(param_id(l));
         i = static_cast<unsigned>(m_level2idx.size());
-        m_out << i << " #UP " << n << std::endl;
+        m_out << i << " #UP " << n << "\n";
         break;
     case level_kind::Meta:
         throw exception("invalid 'export', universe meta-variables cannot be exported");
@@ -96,7 +96,7 @@ unsigned tlean_exporter::export_binding(expr const & e, char const * k) {
     unsigned i = static_cast<unsigned>(m_expr2idx.size());
     m_out << i << " " << k << " ";
     export_binder_info(binding_info(e));
-    m_out << " " << n << " " << e1 << " " << e2 << std::endl;
+    m_out << " " << n << " " << e1 << " " << e2 << "\n";
     return i;
 }
 
@@ -109,7 +109,7 @@ unsigned tlean_exporter::export_const(expr const & e) {
     m_out << i << " #EC " << n;
     for (unsigned l : ls)
         m_out << " " << l;
-    m_out << std::endl;
+    m_out << "\n";
     return i;
 }
 
@@ -122,12 +122,12 @@ unsigned tlean_exporter::export_expr_core(expr const & e) {
     switch (e.kind()) {
     case expr_kind::Var:
         i = static_cast<unsigned>(m_expr2idx.size());
-        m_out << i << " #EV " << var_idx(e) << std::endl;
+        m_out << i << " #EV " << var_idx(e) << "\n";
         break;
     case expr_kind::Sort:
         l = export_level(sort_level(e));
         i = static_cast<unsigned>(m_expr2idx.size());
-        m_out << i << " #ES " << l << std::endl;
+        m_out << i << " #ES " << l << "\n";
         break;
     case expr_kind::Constant:
         i = export_const(e);
@@ -136,7 +136,7 @@ unsigned tlean_exporter::export_expr_core(expr const & e) {
         e1 = export_expr_core(app_fn(e));
         e2 = export_expr_core(app_arg(e));
         i = static_cast<unsigned>(m_expr2idx.size());
-        m_out << i << " #EA " << e1 << " " << e2 << std::endl;
+        m_out << i << " #EA " << e1 << " " << e2 << "\n";
         break;
     case expr_kind::Let: {
         auto n = export_name(let_name(e));
@@ -144,7 +144,7 @@ unsigned tlean_exporter::export_expr_core(expr const & e) {
         e2 = export_expr_core(let_value(e));
         auto e3 = export_expr_core(let_body(e));
         i = static_cast<unsigned>(m_expr2idx.size());
-        m_out << i << " #EZ " << n << " " << e1 << " " << e2 << " " << e3 << std::endl;
+        m_out << i << " #EZ " << n << " " << e1 << " " << e2 << " " << e3 << "\n";
         break;
     }
     case expr_kind::Lambda:
@@ -187,7 +187,7 @@ void tlean_exporter::export_definition(declaration const & d) {
     m_out << t << " " << v;
     for (unsigned p : ps)
         m_out << " " << p;
-    m_out << std::endl;
+    m_out << "\n";
 }
 
 void tlean_exporter::export_axiom(declaration const & d) {
@@ -197,7 +197,7 @@ void tlean_exporter::export_axiom(declaration const & d) {
     m_out << "#AX " << n << " " << t;
     for (unsigned p : ps)
         m_out << " " << p;
-    m_out << std::endl;
+    m_out << "\n";
 }
 
 void tlean_exporter::export_declaration(declaration const & d) {
@@ -237,7 +237,7 @@ void tlean_exporter::export_inductive(inductive::certified_inductive_decl const 
     for (name const & p : decl.m_level_params)
         m_out << " " << export_name(p);
 
-    m_out << std::endl;
+    m_out << "\n";
 }
 
 tlean_exporter::tlean_exporter(std::ostream & out, environment const & env) : m_out(out), m_env(env) {

--- a/src/library/tlean_exporter.h
+++ b/src/library/tlean_exporter.h
@@ -1,0 +1,52 @@
+/*
+Copyright (c) 2015 Microsoft Corporation. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+
+Author: Leonardo de Moura, Daniel Selsam
+*/
+#pragma once
+
+#include "kernel/expr_maps.h"
+#include "kernel/inductive/inductive.h"
+#include <unordered_map>
+#include <unordered_set>
+
+namespace lean {
+
+template<typename T>
+using level_map = typename std::unordered_map<level, T, level_hash, level_eq>;
+
+template<typename T>
+using name_hmap = typename std::unordered_map<name, T, name_hash, name_eq>;
+
+class tlean_exporter {
+ private:
+    std::ostream &                      m_out;
+    environment                         m_env;
+    std::unordered_set<name, name_hash> m_exported;
+    name_hmap<unsigned>                 m_name2idx;
+    level_map<unsigned>                 m_level2idx;
+    expr_bi_map<unsigned>               m_expr2idx;
+
+    unsigned export_level(level const & l);
+    void export_binder_info(binder_info const & bi);
+    unsigned export_binding(expr const & e, char const * k);
+    unsigned export_const(expr const & e);
+    unsigned export_expr_core(expr const & e);
+    unsigned export_expr(expr const & e);
+
+    void export_definition(declaration const & d);
+    void export_axiom(declaration const & d);
+    void export_declaration(name const & n);
+
+public:
+    tlean_exporter(std::ostream & out, environment const & env);
+    unsigned export_name(name const & n);
+    void export_declaration(declaration const & d);
+    void export_inductive(inductive::certified_inductive_decl const & d);
+
+    std::ostream & out();
+    environment & env();
+};
+
+}

--- a/src/library/unification_hint.cpp
+++ b/src/library/unification_hint.cpp
@@ -153,7 +153,7 @@ struct unification_hint_config {
         x.out() << "#UNIFICATION_HINT"
                 << " " << n_decl_name
                 << " " << e.m_priority
-                << std::endl;
+                << "\n";
     }
 
     static entry read_entry(deserializer & d) {

--- a/src/library/unification_hint.cpp
+++ b/src/library/unification_hint.cpp
@@ -147,6 +147,15 @@ struct unification_hint_config {
     static void  write_entry(serializer & s, entry const & e) {
         s << e.m_decl_name << e.m_priority;
     }
+
+    static void  textualize_entry(tlean_exporter & x, entry const & e) {
+        unsigned n_decl_name = x.export_name(e.m_decl_name);
+        x.out() << "#UNIFICATION_HINT"
+                << " " << n_decl_name
+                << " " << e.m_priority
+                << std::endl;
+    }
+
     static entry read_entry(deserializer & d) {
         name decl_name; unsigned prio;
         d >> decl_name >> prio;

--- a/src/library/user_recursors.cpp
+++ b/src/library/user_recursors.cpp
@@ -311,6 +311,8 @@ struct recursor_config {
     static void  write_entry(serializer & s, entry const & e) {
         e.write(s);
     }
+    static void  textualize_entry(tlean_exporter &, entry const &) {}
+
     static entry read_entry(deserializer & d) {
         return recursor_info::read(d);
     }

--- a/src/shell/lean.cpp
+++ b/src/shell/lean.cpp
@@ -40,6 +40,7 @@ Author: Leonardo de Moura
 #include "library/export.h"
 #include "library/message_builder.h"
 #include "library/time_task.h"
+#include "library/library_task_builder.h"
 #include "frontends/lean/parser.h"
 #include "frontends/lean/pp.h"
 #include "frontends/lean/dependencies.h"
@@ -202,6 +203,7 @@ static void display_help(std::ostream & out) {
     std::cout << "  --tstack=num -s    thread stack size in Kb\n";
 #endif
     std::cout << "  --deps             just print dependencies of a Lean input\n";
+    std::cout << "  --old-oleans       reuse existing *.olean files\n";
 #if defined(LEAN_JSON)
     std::cout << "  --path             display the path used for finding Lean libraries and extensions\n";
     std::cout << "  --json             print JSON-formatted structured error messages\n";
@@ -215,6 +217,7 @@ static void display_help(std::ostream & out) {
         )
     std::cout << "  -D name=value      set a configuration option (see set_option command)\n";
     std::cout << "Exporting data:\n";
+    std::cout << "  --tlean            export a textual .tlean file for every .lean file\n";
     std::cout << "  --export=file -E   export final environment as textual low-level file\n";
     std::cout << "  --only-export=decl_name   only export the specified declaration (+ dependencies)\n";
     std::cout << "  --test-suite       capture output and status code from each input file $f in $f.produced and $f.status, respectively\n";
@@ -228,6 +231,7 @@ static struct option g_long_options[] = {
     {"make",         no_argument,       0, 'm'},
     {"old-oleans",   no_argument,       0, 'O'},
     {"recursive",    no_argument,       0, 'R'},
+    {"tlean",        no_argument,       0, 'x'},
     {"export",       required_argument, 0, 'E'},
     {"only-export",  required_argument, 0, 'o'},
     {"memory",       required_argument, 0, 'M'},
@@ -426,6 +430,7 @@ int main(int argc, char ** argv) {
 #endif
     ::initializer init;
     bool make_mode          = false;
+    bool export_tlean       = false;
     bool use_old_oleans     = false;
     bool report_widgets     = true;
     bool recursive          = false;
@@ -475,6 +480,9 @@ int main(int argc, char ** argv) {
         case 'm':
             make_mode = true;
             recursive = true;
+            break;
+        case 'x':
+            export_tlean = true;
             break;
         case 'O':
             use_old_oleans = true;
@@ -744,6 +752,23 @@ int main(int argc, char ** argv) {
         //     // this code is now broken
         //     env = lean::set_native_module_path(env, lean::name(native_output));
         // }
+
+        if (export_tlean) {
+            for (auto & mod : mods) {
+	        add_library_task(task_builder<unit>([mod] {
+                    auto res = get(mod.m_mod_info->m_result);
+		    auto tlean_fn = tlean_of_lean(mod.m_id);
+		    exclusive_file_lock output_lock(tlean_fn);
+		    std::ofstream out(tlean_fn);
+		    write_module_tlean(*res.m_loaded_module, out);
+		    out.close();
+		    if (!out) throw exception("failed to write tlean file");
+                    return unit();
+                }), std::string("saving tlean"));
+            }
+
+            taskq().wait_for_finish(lt.get_root().wait_for_finish());
+        }
 
         if (export_txt && !mods.empty()) {
             buffer<std::shared_ptr<module_info const>> mod_infos;

--- a/src/shell/lean.cpp
+++ b/src/shell/lean.cpp
@@ -754,22 +754,15 @@ int main(int argc, char ** argv) {
         // }
 
         if (export_tlean) {
-            buffer<task<unit>> tasks;
             for (auto & mod : mods) {
-                scope_log_tree scope(logtree().mk_child({}, "saving tlean", {mod.m_id, {{1,0}, {2,0}}}));
-                tasks.push_back(add_library_task(task_builder<unit>([mod] {
-                    auto res = get(mod.m_mod_info->m_result);
-                    auto tlean_fn = tlean_of_lean(mod.m_id);
-                    exclusive_file_lock output_lock(tlean_fn);
-                    std::ofstream out(tlean_fn);
-                    write_module_tlean(*res.m_loaded_module, out);
-                    out.close();
-                    if (!out) throw exception("failed to write tlean file");
-                    return unit();
-                }).wrap(exception_reporter()), "saving tlean"));
-            }
-            for (auto const & task : tasks) {
-                taskq().wait_for_finish(task);
+                auto res = get(mod.m_mod_info->m_result);
+                auto tlean_fn = tlean_of_lean(mod.m_id);
+                std::cerr << "exporting " << tlean_fn << std::endl;
+                exclusive_file_lock output_lock(tlean_fn);
+                std::ofstream out(tlean_fn);
+                write_module_tlean(*res.m_loaded_module, out);
+                out.close();
+                if (!out) throw exception(sstream() << "failed to write tlean file: " << tlean_fn);
             }
         }
 

--- a/src/util/file_lock.cpp
+++ b/src/util/file_lock.cpp
@@ -6,6 +6,7 @@ Author: Leonardo de Moura
 */
 #include <string>
 #include <errno.h>
+#include <string.h>
 #include <fcntl.h>
 #include "util/exception.h"
 #include "util/sstream.h"
@@ -85,12 +86,12 @@ file_lock::file_lock(char const * fname, bool exclusive):
             // fname is probably part of the Lean installation in a system directory.
             // So, we ignore the file_lock in this case.
         } else {
-            throw exception(sstream() << "failed to lock file '" << fname << "'");
+            throw exception(sstream() << "failed to lock file '" << fname << "': " << strerror(errno));
         }
     } else {
         int status = flock(m_fd, exclusive ? LOCK_EX : LOCK_SH);
         if (status == -1)
-            throw exception(sstream() << "failed to lock file '" << fname << "'");
+            throw exception(sstream() << "failed to lock file '" << fname << "': " << strerror(errno));
     }
 #endif
 }

--- a/src/util/lean_path.cpp
+++ b/src/util/lean_path.cpp
@@ -286,6 +286,14 @@ std::string olean_of_lean(std::string const & lean_fn) {
     }
 }
 
+std::string tlean_of_lean(std::string const & lean_fn) {
+    if (lean_fn.size() > 5 && lean_fn.substr(lean_fn.size() - 5) == ".lean") {
+        return lean_fn.substr(0, lean_fn.size() - 5) + ".tlean";
+    } else {
+        throw exception(sstream() << "not a .lean file: " << lean_fn);
+    }
+}
+
 std::string olean_file_to_lean_file(std::string const &olean) {
     lean_assert(is_olean_file(olean));
     std::string lean = olean;

--- a/src/util/lean_path.h
+++ b/src/util/lean_path.h
@@ -60,5 +60,6 @@ bool is_olean_file(std::string const & fname);
 std::string name_to_file(name const & fname);
 
 std::string olean_of_lean(std::string const & lean_fn);
+std::string tlean_of_lean(std::string const & lean_fn);
 std::string olean_file_to_lean_file(std::string const & olean);
 }


### PR DESCRIPTION
This PR adds support for generating textual `.tlean` files in addition to the standard binary `.olean` files. The `.tlean` files can be processed by external tools such as [mathport](https://github.com/dselsam/mathport). The new option `--tlean` instructs lean to produce `.tlean` files as well as `.olean` files.