### PR TITLE
feat(library/init/core): allow lists of proofs

### DIFF
--- a/library/init/core.lean
+++ b/library/init/core.lean
@@ -334,14 +334,14 @@ def decidable_rel {α : Sort u} (r : α → α → Prop) :=
 def decidable_eq (α : Sort u) :=
 decidable_rel (@eq α)
 
-inductive option (α : Type u)
+inductive option (α : Sort u)
 | none : option
 | some (val : α) : option
 
 export option (none some)
 export bool (ff tt)
 
-inductive list (T : Type u)
+inductive list (T : Sort u)
 | nil : list
 | cons (hd : T) (tl : list) : list
 


### PR DESCRIPTION
With upstream changes to mathlib, this would allow `fintype some_prop`, which would in turn allow proofs to be used to index finite things like matrices or summations.