### PR TITLE
[Merged by Bors] - fix(mt_task_queue): Allow running rdep

### DIFF
--- a/src/library/mt_task_queue.cpp
+++ b/src/library/mt_task_queue.cpp
@@ -167,7 +167,7 @@ void mt_task_queue::handle_finished(gtask const & t) {
                 // TODO(gabriel): removed failed tasks from reverse dependency lists?
                 m_waiting.erase(rdep);
                 break;
-            case task_state::Success:
+            case task_state::Running: case task_state::Success:
                 // this can happen if a task occurs in more than one reverse dependency list,
                 // or gets submitted more than once
                 break;


### PR DESCRIPTION
Removes an Unreachable code reached assertion when a reverse dependency is removed in handle_finished. Encountered this issue when trying to build parser snapshots for mathlib on 80 cores

cc @gebner 