### PR TITLE
[Merged by Bors] - refactor(init/algebra/order): clean up choice use

### DIFF
--- a/library/init/algebra/order.lean
+++ b/library/init/algebra/order.lean
@@ -221,25 +221,26 @@ or.elim (le_total a b)
     (λ h : b < a, or.inr (or.inr h))
     (λ h : b = a, or.inr (or.inl h.symm)))
 
-lemma le_of_not_gt {a b : α} (h : ¬ a > b) : a ≤ b :=
+lemma le_of_not_lt {a b : α} (h : ¬ b < a) : a ≤ b :=
 match lt_trichotomy a b with
 | or.inl hlt          := le_of_lt hlt
 | or.inr (or.inl heq) := heq ▸ le_refl a
 | or.inr (or.inr hgt) := absurd hgt h
 end
 
+lemma le_of_not_gt {a b : α} : ¬ a > b → a ≤ b := le_of_not_lt
+
 lemma lt_of_not_ge {a b : α} (h : ¬ a ≥ b) : a < b :=
 lt_of_le_not_le ((le_total _ _).resolve_right h) h
 
-lemma lt_or_ge (a b : α) : a < b ∨ a ≥ b :=
-match lt_trichotomy a b with
-| or.inl hlt          := or.inl hlt
-| or.inr (or.inl heq) := or.inr (heq ▸ le_refl a)
-| or.inr (or.inr hgt) := or.inr (le_of_lt hgt)
-end
+lemma lt_or_le (a b : α) : a < b ∨ b ≤ a :=
+if hba : b ≤ a then or.inr hba else or.inl $ lt_of_not_ge hba
 
-lemma le_or_gt (a b : α) : a ≤ b ∨ a > b :=
-or.swap (lt_or_ge b a)
+lemma le_or_lt (a b : α) : a ≤ b ∨ b < a :=
+(lt_or_le b a).swap
+
+lemma lt_or_ge : ∀ (a b : α), a < b ∨ a ≥ b := lt_or_le
+lemma le_or_gt : ∀ (a b : α), a ≤ b ∨ a > b := le_or_lt
 
 lemma lt_or_gt_of_ne {a b : α} (h : a ≠ b) : a < b ∨ a > b :=
 match lt_trichotomy a b with
@@ -281,15 +282,6 @@ is_strict_weak_order_of_is_total_preorder lt_iff_not_ge
 /- TODO(Leo): decide whether we should keep this instance or not -/
 instance is_strict_total_order_of_linear_order : is_strict_total_order α (<) :=
 { trichotomous := lt_trichotomy }
-
-lemma le_of_not_lt {a b : α} (h : ¬ b < a) : a ≤ b :=
-decidable.by_contradiction $ λ h', h $ lt_of_le_not_le ((le_total _ _).resolve_right h') h'
-
-lemma lt_or_le (a b : α) : a < b ∨ b ≤ a :=
-if hba : b ≤ a then or.inr hba else or.inl $ lt_of_not_ge hba
-
-lemma le_or_lt (a b : α) : a ≤ b ∨ b < a :=
-(lt_or_le b a).swap
 
 /-- Perform a case-split on the ordering of `x` and `y` in a decidable linear order. -/
 def lt_by_cases (x y : α) {P : Sort*}

--- a/library/init/data/int/basic.lean
+++ b/library/init/data/int/basic.lean
@@ -345,7 +345,7 @@ calc
 
 lemma sub_nat_nat_add (m n k : ℕ) : sub_nat_nat (m + n) k = of_nat m + sub_nat_nat n k :=
 begin
-  have h := decidable.le_or_lt k n,
+  have h := le_or_lt k n,
   cases h with h' h',
   { rw [sub_nat_nat_of_le h'],
     have h₂ : k ≤ m + n, exact (le_trans h' (le_add_left _ _)),
@@ -359,7 +359,7 @@ end
 lemma sub_nat_nat_add_neg_succ_of_nat (m n k : ℕ) :
     sub_nat_nat m n + -[1+ k] = sub_nat_nat m (n + succ k) :=
 begin
-  have h := decidable.le_or_lt n m,
+  have h := le_or_lt n m,
   cases h with h' h',
   { rw [sub_nat_nat_of_le h'], simp, rw [sub_nat_nat_sub h', nat.add_comm] },
   have h₂ : m < n + succ k, exact nat.lt_of_lt_of_le h' (le_add_right _ _),

--- a/library/init/data/int/order.lean
+++ b/library/init/data/int/order.lean
@@ -943,9 +943,9 @@ theorem sign_eq_zero_iff_zero (a : ℤ) : sign a = 0 ↔ a = 0 :=
 
 protected lemma eq_zero_or_eq_zero_of_mul_eq_zero
         {a b : ℤ} (h : a * b = 0) : a = 0 ∨ b = 0 :=
-match decidable.lt_trichotomy 0 a with
+match lt_trichotomy 0 a with
 | or.inl hlt₁          :=
-  match decidable.lt_trichotomy 0 b with
+  match lt_trichotomy 0 b with
   | or.inl hlt₂          :=
     have 0 < a * b, from int.mul_pos hlt₁ hlt₂,
     begin rw h at this, exact absurd this (lt_irrefl _) end
@@ -956,7 +956,7 @@ match decidable.lt_trichotomy 0 a with
   end
 | or.inr (or.inl heq₁) := or.inl heq₁.symm
 | or.inr (or.inr hgt₁) :=
-  match decidable.lt_trichotomy 0 b with
+  match lt_trichotomy 0 b with
   | or.inl hlt₂          :=
     have 0 > a * b, from int.mul_neg_of_neg_of_pos hgt₁ hlt₂,
     begin rw h at this, exact absurd this (lt_irrefl _)  end

--- a/library/init/data/nat/lemmas.lean
+++ b/library/init/data/nat/lemmas.lean
@@ -292,7 +292,7 @@ protected lemma mul_lt_mul_of_pos_right {n m k : ℕ} (h : n < m) (hk : 0 < k) :
 nat.mul_comm k m ▸ nat.mul_comm k n ▸ nat.mul_lt_mul_of_pos_left h hk
 
 protected lemma le_of_mul_le_mul_left {a b c : ℕ} (h : c * a ≤ c * b) (hc : 0 < c) : a ≤ b :=
-decidable.not_lt.1
+not_lt.1
   (assume h1 : b < a,
    have h2 : c * b < c * a, from nat.mul_lt_mul_of_pos_left h1 hc,
    not_le_of_gt h2 h)
@@ -652,7 +652,7 @@ begin
   { rw zero_mod, assumption },
   { by_cases h₁ : succ x < y,
     { rwa [mod_eq_of_lt h₁] },
-    { have h₁ : succ x % y = (succ x - y) % y := mod_eq_sub_mod (decidable.not_lt.1 h₁),
+    { have h₁ : succ x % y = (succ x - y) % y := mod_eq_sub_mod (not_lt.1 h₁),
       have : succ x - y ≤ x := le_of_lt_succ (sub_lt (succ_pos x) h),
       have h₂ : (succ x - y) % y < y := ih _ this,
       rwa [← h₁] at h₂ } }
@@ -752,7 +752,7 @@ begin
   apply nat.strong_induction_on y _,
   clear y,
   intros y IH x,
-  cases decidable.lt_or_le y k with h h,
+  cases lt_or_le y k with h h,
   -- base case: y < k
   { rw [div_eq_of_lt h],
     cases x with x,
@@ -962,14 +962,14 @@ protected theorem find_spec : p nat.find := nat.find_x.2.left
 protected theorem find_min : ∀ {m : ℕ}, m < nat.find → ¬p m := nat.find_x.2.right
 
 protected theorem find_min' {m : ℕ} (h : p m) : nat.find ≤ m :=
-decidable.le_of_not_lt (λ l, find_min l h)
+le_of_not_lt (λ l, find_min l h)
 
 end find
 
 /- mod -/
 
 theorem mod_le (x y : ℕ) : x % y ≤ x :=
-or.elim (decidable.lt_or_le x y)
+or.elim (lt_or_le x y)
   (λxlty, by rw mod_eq_of_lt xlty; refl)
   (λylex, or.elim (eq_zero_or_pos y)
     (λy0, by rw [y0, mod_zero]; refl)
@@ -1001,7 +1001,7 @@ else if z0 : z = 0 then
 else x.strong_induction_on $ λn IH,
   have y0 : y > 0, from nat.pos_of_ne_zero y0,
   have z0 : z > 0, from nat.pos_of_ne_zero z0,
-  or.elim (decidable.le_or_lt y n)
+  or.elim (le_or_lt y n)
     (λyn, by rw [
         mod_eq_sub_mod yn,
         mod_eq_sub_mod (mul_le_mul_left z yn),


### PR DESCRIPTION
The `decidable` namespace previously contained theorems about partial and
linear orders for theorems that were not true without AC. With the
change to make `linear_order` mean `decidable_linear_order`, most of
these lemmas are now superfluous and can live in the root namespace,
because the lemmas themselves don't use AC anymore.

With this, every single lemma and definition in core is now AC-minimal:
only theorems that obviously require AC or LEM use AC. (Fun fact:
`#print axioms tactic.by_cases` lists AC, because apparently constants
inside quotations are not excluded in the implementation of
`#print axioms`.)