### PR TITLE
[Merged by Bors] - backport(type_context.cpp): wf should not compute

### DIFF
--- a/library/init/data/fin/ops.lean
+++ b/library/init/data/fin/ops.lean
@@ -60,7 +60,8 @@ instance : has_mul (fin n)         := ⟨fin.mul⟩
 instance : has_mod (fin n)         := ⟨fin.mod⟩
 instance : has_div (fin n)         := ⟨fin.div⟩
 
-lemma of_nat_zero : @of_nat n 0 = 0 := rfl
+lemma of_nat_zero : @of_nat n 0 = 0 :=
+by { simp only [of_nat], congr, rw mod_def_aux, reflexivity }
 
 lemma add_def (a b : fin n) : (a + b).val = (a.val + b.val) % n :=
 show (fin.add a b).val = (a.val + b.val) % n, from

--- a/src/library/type_context.cpp
+++ b/src/library/type_context.cpp
@@ -707,18 +707,6 @@ optional<expr> type_context_old::reduce_aux_recursor(expr const & e) {
     }
 }
 
-optional<expr> type_context_old::reduce_large_elim_recursor(expr const & e) {
-    expr const & f = get_app_fn(e);
-    if (!is_constant(f))
-        return none_expr();
-    auto & fn = const_name(f);
-    if (fn == get_acc_rec_name()) {
-        transparency_scope scope(*this, transparency_mode::All);
-        return norm_ext(e);
-    }
-    return none_expr();
-}
-
 bool type_context_old::should_unfold_macro(expr const &) {
     /* If m_transparency_mode is set to ALL, then we unfold all
        macros. In this way, we make sure type inference does not fail.
@@ -747,8 +735,6 @@ optional<expr> type_context_old::reduce_recursor(expr const & e) {
     if (auto r = norm_ext(e))
         return r;
     if (auto r = reduce_aux_recursor(e))
-        return r;
-    if (auto r = reduce_large_elim_recursor(e))
         return r;
     return none_expr();
 }
@@ -850,11 +836,6 @@ expr type_context_old::whnf_core(expr const & e0, bool proj_reduce) {
             }
 
             if (auto r = reduce_aux_recursor(e)) {
-                e = *r;
-                continue;
-            }
-
-            if (auto r = reduce_large_elim_recursor(e)) {
                 e = *r;
                 continue;
             }

--- a/src/library/type_context.h
+++ b/src/library/type_context.h
@@ -691,7 +691,6 @@ public:
         This method is useful when we want to normalize the expression until we get a particular symbol as the head symbol. */
     expr whnf_head_pred(expr const & e, std::function<bool(expr const &)> const & pred); // NOLINT
     optional<expr> reduce_aux_recursor(expr const & e);
-    optional<expr> reduce_large_elim_recursor(expr const & e);
     optional<expr> reduce_projection(expr const & e);
     optional<expr> norm_ext(expr const & e) { return env().norm_ext()(e, *this); }
     optional<expr> reduce_recursor(expr const & e);

--- a/tests/lean/run/1782.lean
+++ b/tests/lean/run/1782.lean
@@ -14,9 +14,9 @@ with g : b → nat
 with h : c → nat
 | c.baz := 2
 
-example : f a.foo = 0 := rfl
-example : g b.bar = 1 := rfl
-example : h c.baz = 2 := rfl
+example : f a.foo = 0 := by simp [f]
+example : g b.bar = 1 := by simp [g]
+example : h c.baz = 2 := by simp [h]
 
 
 mutual def f_1, f_2, f_3, f_4
@@ -30,8 +30,8 @@ with f_4 : nat → nat
 | 0     := 3
 | _     := 4
 
-example : f_1 a.foo = 0 := rfl
-example : f_2 b.bar = 1 := rfl
-example : f_3 c.baz = 2 := rfl
-example : f_4 0 = 3 := rfl
-example : f_4 1 = 4 := rfl
+example : f_1 a.foo = 0 := by simp [f_1]
+example : f_2 b.bar = 1 := by simp [f_2]
+example : f_3 c.baz = 2 := by simp [f_3]
+example : f_4 0 = 3 := by simp [f_4]
+example : f_4 1 = 4 := by simp [f_4]

--- a/tests/lean/run/fib_wrec.lean
+++ b/tests/lean/run/fib_wrec.lean
@@ -2,7 +2,7 @@ open nat
 
 definition fib.F (n : nat) : (Π (m : nat), m < n → nat) → nat :=
 nat.cases_on n
-  (λ (f : Π (m : nat), m < 0 → nat), succ 0)
+  (λ (f : Π (m : nat), m < 0 → nat), 0)
   (λ (n₁ : nat), nat.cases_on n₁
     (λ (f : Π (m : nat), m < (succ 0) → nat), succ 0)
     (λ (n₂ : nat) (f : Π (m : nat), m < (succ (succ n₂)) → nat),
@@ -13,7 +13,7 @@ nat.cases_on n
 definition fib (n : nat) :=
 well_founded.fix lt_wf fib.F n
 
-theorem fib.zero_eq : fib 0 = 1 :=
+theorem fib.zero_eq : fib 0 = 0 :=
 well_founded.fix_eq lt_wf fib.F 0
 
 theorem fib.one_eq  : fib 1 = 1 :=
@@ -22,12 +22,8 @@ well_founded.fix_eq lt_wf fib.F 1
 theorem fib.succ_succ_eq (n : nat) : fib (succ (succ n)) = fib (succ n) + fib n :=
 well_founded.fix_eq lt_wf fib.F (succ (succ n))
 
-example : fib 5 = 8 :=
-rfl
-
-example : fib 6 = 13 :=
-rfl
-
+example : fib 5 = 5 := by simp [fib.zero_eq, fib.one_eq, fib.succ_succ_eq]
+example : fib 6 = 8 := by simp [fib.zero_eq, fib.one_eq, fib.succ_succ_eq]
 #print "------------"
-#reduce fib 10
-#eval fib 10
+#reduce fib 11
+#eval fib 11

--- a/tests/lean/run/unfold_lemmas.lean
+++ b/tests/lean/run/unfold_lemmas.lean
@@ -7,4 +7,5 @@ else
     have x % y < y, by { apply mod_lt, cases y, contradiction, apply succ_pos },
     gcd' (x % y) y
 
-@[simp] lemma gcd_zero_right (x : nat) : gcd' 0 x = x := rfl
+@[simp] lemma gcd_zero_right (x : nat) : gcd' 0 x = x :=
+by { rw gcd', simp }


### PR DESCRIPTION
This backport is not necessary for mathport, but it is necessary for (both manually- and automatically-)de-elaborated proofs to re-elaborate in Lean4. 