### PR TITLE
[Merged by Bors] - doc(library/init/data/nat/lemmas.lean): add docstring for nat.find

### DIFF
--- a/library/init/data/nat/lemmas.lean
+++ b/library/init/data/nat/lemmas.lean
@@ -956,7 +956,10 @@ protected def find_x : {n // p n ∧ ∀m < n, ¬p m} :=
 0 (λn h, absurd h (nat.not_lt_zero _))
 
 /--
-If `p` is a (decidable) predicate and `hp : ∃ (n : ℕ), p n` is a proof that there exists some natural number satisfying `p`, then `nat.find hp` is the smallest natural number satisfying `p`. Note that `nat.find` is protected, meaning that you can't just write `find`, even if the `nat` namespace is open.
+If `p` is a (decidable) predicate and `hp : ∃ (n : ℕ), p n` is a proof that
+there exists some natural number satisfying `p`, then `nat.find hp` is the
+smallest natural number satisfying `p`. Note that `nat.find` is protected,
+meaning that you can't just write `find`, even if the `nat` namespace is open.
 
 The API for `nat.find` is: 
 

--- a/library/init/data/nat/lemmas.lean
+++ b/library/init/data/nat/lemmas.lean
@@ -955,6 +955,15 @@ protected def find_x : {n // p n ∧ ∀m < n, ¬p m} :=
     IH _ ⟨rfl, this⟩ (λn h, this n $ nat.le_of_succ_le_succ h))
 0 (λn h, absurd h (nat.not_lt_zero _))
 
+/--
+If `p` is a (decidable) predicate and `hp : ∃ (n : ℕ), p n` is a proof that there exists some natural number satisfying `p`, then `nat.find hp` is the smallest natural number satisfying `p`. Note that `nat.find` is protected, meaning that you can't just write `find`, even if the `nat` namespace is open.
+
+The API for `nat.find` is: 
+
+* `nat.find_spec` is the proof that `nat.find hp` satisfies `p`.
+* `nat.find_min` is the proof that if `m < nat.find hp` then `m` does not satisfy `p`.
+* `nat.find_min'` is the proof that if `m` does satisfy `p` then nat.find hp ≤ m`.
+-/
 protected def find : ℕ := nat.find_x.1
 
 protected theorem find_spec : p nat.find := nat.find_x.2.left

--- a/library/init/data/nat/lemmas.lean
+++ b/library/init/data/nat/lemmas.lean
@@ -956,7 +956,7 @@ protected def find_x : {n // p n ∧ ∀m < n, ¬p m} :=
 0 (λn h, absurd h (nat.not_lt_zero _))
 
 /--
-If `p` is a (decidable) predicate and `hp : ∃ (n : ℕ), p n` is a proof that
+If `p` is a (decidable) predicate on `ℕ` and `hp : ∃ (n : ℕ), p n` is a proof that
 there exists some natural number satisfying `p`, then `nat.find hp` is the
 smallest natural number satisfying `p`. Note that `nat.find` is protected,
 meaning that you can't just write `find`, even if the `nat` namespace is open.

--- a/library/init/data/nat/lemmas.lean
+++ b/library/init/data/nat/lemmas.lean
@@ -965,7 +965,7 @@ The API for `nat.find` is:
 
 * `nat.find_spec` is the proof that `nat.find hp` satisfies `p`.
 * `nat.find_min` is the proof that if `m < nat.find hp` then `m` does not satisfy `p`.
-* `nat.find_min'` is the proof that if `m` does satisfy `p` then nat.find hp ≤ m`.
+* `nat.find_min'` is the proof that if `m` does satisfy `p` then `nat.find hp ≤ m`.
 -/
 protected def find : ℕ := nat.find_x.1
 


### PR DESCRIPTION
Users do tend to need this core Lean command occasionally, so I thought it was worth adding a docstring so once they've found it they can see how it works.