### PR TITLE
[Merged by Bors] - refactor(library/init/data/nat/div): avoid wf recursion

### DIFF
--- a/library/init/data/fin/ops.lean
+++ b/library/init/data/fin/ops.lean
@@ -60,8 +60,7 @@ instance : has_mul (fin n)         := ⟨fin.mul⟩
 instance : has_mod (fin n)         := ⟨fin.mod⟩
 instance : has_div (fin n)         := ⟨fin.div⟩
 
-lemma of_nat_zero : @of_nat n 0 = 0 :=
-by { simp only [of_nat], congr, rw mod_def_aux, reflexivity }
+lemma of_nat_zero : @of_nat n 0 = 0 := rfl
 
 lemma add_def (a b : fin n) : (a + b).val = (a.val + b.val) % n :=
 show (fin.add a b).val = (a.val + b.val) % n, from

--- a/library/init/data/nat/div.lean
+++ b/library/init/data/nat/div.lean
@@ -4,32 +4,27 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Leonardo de Moura
 -/
 prelude
-import init.wf init.data.nat.basic
+import init.data.nat.basic
 namespace nat
 
-private def div_rec_lemma {x y : nat} : 0 < y ∧ y ≤ x → x - y < x :=
-λ h, and.rec (λ ypos ylex, sub_lt (nat.lt_of_lt_of_le ypos ylex) ypos) h
+protected def div_core (y : ℕ) : ℕ → ℕ → ℕ
+| 0 _ := 0
+| (fuel+1) x := if h : 0 < y ∧ y ≤ x then div_core fuel (x - y) + 1 else 0
 
-private def div.F (x : nat) (f : Π x₁, x₁ < x → nat → nat) (y : nat) : nat :=
-if h : 0 < y ∧ y ≤ x then f (x - y) (div_rec_lemma h) y + 1 else zero
-
-protected def div := well_founded.fix lt_wf div.F
+protected def div (x y : ℕ) : ℕ :=
+nat.div_core y x x
 
 instance : has_div nat :=
 ⟨nat.div⟩
 
-lemma div_def_aux (x y : nat) : x / y = if h : 0 < y ∧ y ≤ x then (x - y) / y + 1 else 0 :=
-congr_fun (well_founded.fix_eq lt_wf div.F x) y
+protected def mod_core (y : ℕ) : ℕ → ℕ → ℕ
+| 0 x := x
+| (fuel+1) x := if h : 0 < y ∧ y ≤ x then mod_core fuel (x - y) else x
 
-private def mod.F (x : nat) (f : Π x₁, x₁ < x → nat → nat) (y : nat) : nat :=
-if h : 0 < y ∧ y ≤ x then f (x - y) (div_rec_lemma h) y else x
-
-protected def mod := well_founded.fix lt_wf mod.F
+protected def mod (x y : ℕ) : ℕ :=
+nat.mod_core y x x
 
 instance : has_mod nat :=
 ⟨nat.mod⟩
-
-lemma mod_def_aux (x y : nat) : x % y = if h : 0 < y ∧ y ≤ x then (x - y) % y else x :=
-congr_fun (well_founded.fix_eq lt_wf mod.F x) y
 
 end nat

--- a/library/init/data/nat/lemmas.lean
+++ b/library/init/data/nat/lemmas.lean
@@ -614,8 +614,27 @@ nat.strong_induction_on a $ λ n,
   end
 
 /- mod -/
+
+private lemma mod_core_congr {x y f1 f2} (h1 : x ≤ f1) (h2 : x ≤ f2) :
+  nat.mod_core y f1 x = nat.mod_core y f2 x :=
+begin
+  cases y, { cases f1; cases f2; refl },
+  induction f1 with f1 ih generalizing x f2, { cases h1, cases f2; refl },
+  cases x, { cases f1; cases f2; refl },
+  cases f2, { cases h2 },
+  refine if_congr iff.rfl _ rfl,
+  simp only [succ_sub_succ],
+  exact ih
+    (le_trans (sub_le _ _) (le_of_succ_le_succ h1))
+    (le_trans (sub_le _ _) (le_of_succ_le_succ h2))
+end
+
 lemma mod_def (x y : nat) : x % y = if 0 < y ∧ y ≤ x then (x - y) % y else x :=
-by have h := mod_def_aux x y; rwa [dif_eq_if] at h
+begin
+  cases x, { cases y; refl },
+  cases y, { refl },
+  refine if_congr iff.rfl (mod_core_congr _ _) rfl; simp [sub_le]
+end
 
 @[simp] lemma mod_zero (a : nat) : a % 0 = a :=
 begin
@@ -673,8 +692,29 @@ match n % 2, @nat.mod_lt n 2 dec_trivial with
 end
 
 /- div & mod -/
+
+private lemma div_core_congr {x y f1 f2} (h1 : x ≤ f1) (h2 : x ≤ f2) :
+  nat.div_core y f1 x = nat.div_core y f2 x :=
+begin
+  cases y, { cases f1; cases f2; refl },
+  induction f1 with f1 ih generalizing x f2, { cases h1, cases f2; refl },
+  cases x, { cases f1; cases f2; refl },
+  cases f2, { cases h2 },
+  refine if_congr iff.rfl _ rfl,
+  simp only [succ_sub_succ],
+  refine congr_arg (+1) _,
+  exact ih
+    (le_trans (sub_le _ _) (le_of_succ_le_succ h1))
+    (le_trans (sub_le _ _) (le_of_succ_le_succ h2))
+end
+
 lemma div_def (x y : nat) : x / y = if 0 < y ∧ y ≤ x then (x - y) / y + 1 else 0 :=
-by have h := div_def_aux x y; rwa dif_eq_if at h
+begin
+  cases x, { cases y; refl },
+  cases y, { refl },
+  refine if_congr iff.rfl (congr_arg (+1) _) rfl,
+  refine div_core_congr _ _; simp [sub_le]
+end
 
 lemma mod_add_div (m k : ℕ)
 : m % k + k * (m / k) = m :=

--- a/tests/lean/run/kernel_fin_rfl.lean
+++ b/tests/lean/run/kernel_fin_rfl.lean
@@ -1,0 +1,4 @@
+example : (1 : fin 2) = (3 : fin 2) := rfl
+example : (3/2 : fin 2) = (0 : fin 2) := rfl
+example : (1 + 1 + 1 * 1 : fin 2) = (1 : fin 2) := rfl
+example : fin.succ 0 = (1 : fin 2) := rfl


### PR DESCRIPTION
Define `nat.mod` and `nat.div` without well-founded recursion.  Otherwise they don't compute in the kernel.  This is bad because then expressions such as `(1 : fin 2)` and `fin.succ (0 : fin 1)` are no longer definitionally equal.