### PR TITLE
[Merged by Bors] - feat(library/tactic/apply_tactic): produce a better error for missing typeclasses

### DIFF
--- a/src/library/tactic/apply_tactic.cpp
+++ b/src/library/tactic/apply_tactic.cpp
@@ -67,10 +67,11 @@ static bool try_instance(type_context_old & ctx, expr const & meta, tactic_state
         if (out_error_obj) {
             auto pp_ctx = ::lean::mk_pp_ctx(ctx.env(), s.get_options(), ctx.mctx(), ctx.lctx());
             auto thunk = [=]() {
+                unsigned i = get_pp_indent(s.get_options());
                 format msg("invalid");
                 msg += space() + format(tac_name) + space();
                 msg += format("tactic, failed to synthesize type class instance for");
-                msg += space() + pp_ctx(meta_type);
+                msg += nest(i, line() + pp_ctx(meta_type));
                 return msg;
             };
             *out_error_obj = tactic::mk_exception(thunk, s);

--- a/src/library/tactic/apply_tactic.cpp
+++ b/src/library/tactic/apply_tactic.cpp
@@ -65,13 +65,11 @@ static bool try_instance(type_context_old & ctx, expr const & meta, tactic_state
     optional<expr> inst = ctx.mk_class_instance(meta_type);
     if (!inst) {
         if (out_error_obj) {
-            auto pp_ctx = ::lean::mk_pp_ctx(ctx.env(), s.get_options(), ctx.mctx(), ctx.lctx());
             auto thunk = [=]() {
-                unsigned i = get_pp_indent(s.get_options());
                 format msg("invalid");
                 msg += space() + format(tac_name) + space();
                 msg += format("tactic, failed to synthesize type class instance for");
-                msg += nest(i, line() + pp_ctx(meta_type));
+                msg += pp_indented_expr(s, meta_type);
                 return msg;
             };
             *out_error_obj = tactic::mk_exception(thunk, s);

--- a/src/library/tactic/apply_tactic.cpp
+++ b/src/library/tactic/apply_tactic.cpp
@@ -65,10 +65,12 @@ static bool try_instance(type_context_old & ctx, expr const & meta, tactic_state
     optional<expr> inst = ctx.mk_class_instance(meta_type);
     if (!inst) {
         if (out_error_obj) {
+            auto pp_ctx = ::lean::mk_pp_ctx(ctx.env(), s.get_options(), ctx.mctx(), ctx.lctx());
             auto thunk = [=]() {
                 format msg("invalid");
                 msg += space() + format(tac_name) + space();
-                msg += format("tactic, failed to synthesize type class instance");
+                msg += format("tactic, failed to synthesize type class instance for");
+                msg += space() + pp_ctx(meta_type);
                 return msg;
             };
             *out_error_obj = tactic::mk_exception(thunk, s);

--- a/tests/lean/rewrite.lean
+++ b/tests/lean/rewrite.lean
@@ -4,4 +4,5 @@ class is_one_class (n : ℕ) :=
 lemma one_eq (n : ℕ) [is_one_class n] : 1 = n := is_one_class.one.symm
 
 -- error message should say which typeclass is missing
-example (n : ℕ) : n = 1 := by rw one_eq
+example (n : ℕ) : n = 1 :=
+by rw one_eq

--- a/tests/lean/rewrite.lean
+++ b/tests/lean/rewrite.lean
@@ -1,0 +1,7 @@
+class is_one_class (n : ℕ) :=
+(one : n = 1)
+
+lemma one_eq (n : ℕ) [is_one_class n] : 1 = n := is_one_class.one.symm
+
+-- error message should say which typeclass is missing
+example (n : ℕ) : n = 1 := by rw one_eq

--- a/tests/lean/rewrite.lean.expected.out
+++ b/tests/lean/rewrite.lean.expected.out
@@ -1,1 +1,5 @@
-rewrite.lean:8:4: error: invalid rewrite tactic, failed to synthesize type class instance for is_one_class n
+rewrite.lean:8:3: error: invalid rewrite tactic, failed to synthesize type class instance for
+  is_one_class ?m_1
+state:
+n : ℕ
+⊢ n = 1

--- a/tests/lean/rewrite.lean.expected.out
+++ b/tests/lean/rewrite.lean.expected.out
@@ -1,0 +1,1 @@
+rewrite.lean:8:4: error: invalid rewrite tactic, failed to synthesize type class instance for is_one_class n


### PR DESCRIPTION
When a rewrite fails due to a missing typeclass instance, it previously emitted the message:
```
invalid rewrite tactic, failed to synthesize type class instance
```
With this change, the message now specifies _which_ type class instance could not be synthesized.