### PR TITLE
[Merged by Bors] - fix(library/tactic/smt/congruence_closure): partly disable broken support for symmetric relations

### DIFF
--- a/src/library/tactic/smt/congruence_closure.cpp
+++ b/src/library/tactic/smt/congruence_closure.cpp
@@ -565,7 +565,9 @@ void congruence_closure::add_symm_congruence_table(expr const & e) {
                 // NOTE(gabriel): support for symmetric relations is pretty much broken,
                 // since it ignores all arguments except the last two ones.
                 // e.g. this would claim that `modeq n a b` and `modeq m a b` are equivalent.
-                // push_eq(e, p.first, *g_congr_mark);
+                // Whitelist some relations to contain breakage:
+                if (*rel == get_eq_name() || get_app_num_args(e) == 2)
+                    push_eq(e, p.first, *g_congr_mark);
                 check_eq_true(e);
                 return;
             }

--- a/src/library/tactic/smt/congruence_closure.cpp
+++ b/src/library/tactic/smt/congruence_closure.cpp
@@ -562,7 +562,10 @@ void congruence_closure::add_symm_congruence_table(expr const & e) {
                 new_entry.m_cg_root = p.first;
                 m_state.m_entries.insert(e, new_entry);
                 /* 2. Put new equivalence in the TODO queue */
-                push_eq(e, p.first, *g_congr_mark);
+                // NOTE(gabriel): support for symmetric relations is pretty much broken,
+                // since it ignores all arguments except the last two ones.
+                // e.g. this would claim that `modeq n a b` and `modeq m a b` are equivalent.
+                // push_eq(e, p.first, *g_congr_mark);
                 check_eq_true(e);
                 return;
             }

--- a/tests/lean/run/575c.lean
+++ b/tests/lean/run/575c.lean
@@ -1,0 +1,10 @@
+def modeq (n a b : ℕ) := a % n = b % n
+
+notation a ` ≡ `:50 b ` [MOD `:50 n `]`:0 := modeq n a b
+
+@[symm] protected theorem modeq.symm {a b n} :
+  a ≡ b [MOD n] → b ≡ a [MOD n] :=
+eq.symm
+
+example (a b m n : ℕ) (h : a ≡ b [MOD m * n]) : a ≡ b [MOD m] :=
+by cc

--- a/tests/lean/run/575c.lean
+++ b/tests/lean/run/575c.lean
@@ -7,4 +7,7 @@ notation a ` ≡ `:50 b ` [MOD `:50 n `]`:0 := modeq n a b
 eq.symm
 
 example (a b m n : ℕ) (h : a ≡ b [MOD m * n]) : a ≡ b [MOD m] :=
-by cc
+begin
+  success_if_fail { cc },
+  sorry
+end

--- a/tests/lean/run/smt_tests3.lean
+++ b/tests/lean/run/smt_tests3.lean
@@ -11,12 +11,13 @@ begin
   apply nat.succ_ne_zero
 end
 
-lemma ex2  (a : nat) : f a ≠ 0 :=
-begin [smt]
-  induction a,
-  { intros, ematch_using [f] },
-  { iterate { ematch_using [f, nat.add_one, nat.succ_ne_zero] }}
-end
+-- TODO(gabriel): broken due to 575c
+-- lemma ex2  (a : nat) : f a ≠ 0 :=
+-- begin [smt]
+--   induction a,
+--   { intros, ematch_using [f] },
+--   { iterate { ematch_using [f, nat.add_one, nat.succ_ne_zero] }}
+-- end
 
 lemma ex3 (a : nat) : f (a+1) = f a + 1 :=
 begin [smt]

--- a/tests/lean/run/smt_tests3.lean
+++ b/tests/lean/run/smt_tests3.lean
@@ -11,13 +11,12 @@ begin
   apply nat.succ_ne_zero
 end
 
--- TODO(gabriel): broken due to 575c
--- lemma ex2  (a : nat) : f a ≠ 0 :=
--- begin [smt]
---   induction a,
---   { intros, ematch_using [f] },
---   { iterate { ematch_using [f, nat.add_one, nat.succ_ne_zero] }}
--- end
+lemma ex2  (a : nat) : f a ≠ 0 :=
+begin [smt]
+  induction a,
+  { intros, ematch_using [f] },
+  { iterate { ematch_using [f, nat.add_one, nat.succ_ne_zero] }}
+end
 
 lemma ex3 (a : nat) : f (a+1) = f a + 1 :=
 begin [smt]


### PR DESCRIPTION
Fixes #575