### PR TITLE
feat(leanpkg): Teach leanpkg to preserve new 'olean_url' field

### DIFF
--- a/leanpkg/leanpkg/toml.lean
+++ b/leanpkg/leanpkg/toml.lean
@@ -153,6 +153,7 @@ Ws *> (value.table <$> many Expression)
    "name = \"sss\"\n" ++
    "version = \"0.1\"\n" ++
    "timeout = 10\n" ++
+   "olean_url = \"https://google.com/\"" ++
    "\n" ++
    "[dependencies]\n" ++
    "library_dev = { git = \"https://github.com/leanprover/library_dev\", rev = \"master\" }"


### PR DESCRIPTION
We want to create an olean cache for LTE. A project needs to be able to record somewhere the location of the olean cache and @PatrickMassot proposes to do this in `leanpkg.toml` - see https://leanprover.zulipchat.com/#narrow/stream/113488-general/topic/CI.20for.20liquid.20tensor.20experiment/near/244008489 . The issue is that `leanpkg` will not preserve this field on e.g. upgrades. This pull request causes `leanpkg` to preserve but otherwise ignore this new field.