### PR TITLE
[Merged by Bors] - feat(data/nat): protect more lemmas

### DIFF
--- a/library/data/rbtree/basic.lean
+++ b/library/data/rbtree/basic.lean
@@ -222,7 +222,7 @@ le_trans (depth_max' h) (upper_le _ _)
 lemma balanced {c n} {t : rbnode α} (h : is_red_black t c n) : 2 * depth min t + 1 ≥ depth max t :=
 begin
  have : 2 * depth min t + 1 ≥ 2 * n + 1,
- { apply succ_le_succ, apply mul_le_mul_left, apply depth_min h},
+ { apply succ_le_succ, apply nat.mul_le_mul_left, apply depth_min h},
  apply le_trans, apply depth_max h, apply this
 end
 

--- a/library/init/data/fin/basic.lean
+++ b/library/init/data/fin/basic.lean
@@ -31,7 +31,7 @@ instance decidable_le {n} (a b : fin n) : decidable (a ≤ b) :=
 nat.decidable_le _ _
 
 def {u} elim0 {α : fin 0 → Sort u} : Π (x : fin 0), α x
-| ⟨_, h⟩ := absurd h (not_lt_zero _)
+| ⟨n, h⟩ := absurd h n.not_lt_zero
 
 variable {n : nat}
 

--- a/library/init/data/int/basic.lean
+++ b/library/init/data/int/basic.lean
@@ -214,7 +214,7 @@ sub_nat_nat_elim m n (λm n i, sub_nat_nat (m + k) (n + k) = i)
     begin rw [this], exact sub_nat_nat_add_right end)
 
 lemma sub_nat_nat_of_le {m n : ℕ} (h : n ≤ m) : sub_nat_nat m n = of_nat (m - n) :=
-sub_nat_nat_of_sub_eq_zero (sub_eq_zero_of_le h)
+sub_nat_nat_of_sub_eq_zero (nat.sub_eq_zero_of_le h)
 
 lemma sub_nat_nat_of_lt {m n : ℕ} (h : m < n) : sub_nat_nat m n = -[1+ pred (n - m)] :=
 have n - m = succ (pred (n - m)), from eq.symm (succ_pred_eq_of_pos (nat.sub_pos_of_lt h)),
@@ -233,7 +233,7 @@ lemma eq_zero_of_nat_abs_eq_zero : Π {a : ℤ}, nat_abs a = 0 → a = 0
 | -[1+ m']   H := absurd H (succ_ne_zero _)
 
 lemma nat_abs_pos_of_ne_zero {a : ℤ} (h : a ≠ 0) : 0 < nat_abs a :=
-(eq_zero_or_pos _).resolve_left $ mt eq_zero_of_nat_abs_eq_zero h
+(nat.eq_zero_or_pos _).resolve_left $ mt eq_zero_of_nat_abs_eq_zero h
 
 lemma nat_abs_zero : nat_abs (0 : int) = (0 : nat) := rfl
 
@@ -348,7 +348,7 @@ begin
   have h := le_or_lt k n,
   cases h with h' h',
   { rw [sub_nat_nat_of_le h'],
-    have h₂ : k ≤ m + n, exact (le_trans h' (le_add_left _ _)),
+    have h₂ : k ≤ m + n, exact (le_trans h' (nat.le_add_left _ _)),
     rw [sub_nat_nat_of_le h₂], simp,
     rw nat.add_sub_assoc h' },
   rw [sub_nat_nat_of_lt h'], simp, rw [succ_pred_eq_of_pos (nat.sub_pos_of_lt h')],
@@ -362,7 +362,7 @@ begin
   have h := le_or_lt n m,
   cases h with h' h',
   { rw [sub_nat_nat_of_le h'], simp, rw [sub_nat_nat_sub h', nat.add_comm] },
-  have h₂ : m < n + succ k, exact nat.lt_of_lt_of_le h' (le_add_right _ _),
+  have h₂ : m < n + succ k, exact nat.lt_of_lt_of_le h' (nat.le_add_right _ _),
   have h₃ : m ≤ n + k, exact le_of_succ_le_succ h₂,
   rw [sub_nat_nat_of_lt h', sub_nat_nat_of_lt h₂], simp [nat.add_comm],
   rw [← add_succ, succ_pred_eq_of_pos (nat.sub_pos_of_lt h'), add_succ, succ_sub h₃, pred_succ],
@@ -464,7 +464,7 @@ lemma of_nat_mul_sub_nat_nat (m n k : ℕ) :
   of_nat m * sub_nat_nat n k = sub_nat_nat (m * n) (m * k) :=
 begin
   have h₀ : m > 0 ∨ 0 = m,
-    exact decidable.lt_or_eq_of_le (zero_le _),
+    exact decidable.lt_or_eq_of_le m.zero_le,
   cases h₀ with h₀ h₀,
   { have h := nat.lt_or_ge n k,
     cases h with h h,
@@ -475,7 +475,7 @@ begin
       rw [← neg_of_nat_of_succ, nat.mul_sub_left_distrib],
       rw [← succ_pred_eq_of_pos (nat.sub_pos_of_lt h')], reflexivity },
     have h' : m * k ≤ m * n,
-      exact mul_le_mul_left _ h,
+      exact nat.mul_le_mul_left _ h,
     rw [sub_nat_nat_of_le h, sub_nat_nat_of_le h'], simp,
     rw [nat.mul_sub_left_distrib]
   },
@@ -542,7 +542,7 @@ lemma of_nat_sub {n m : ℕ} (h : m ≤ n) : of_nat (n - m) = of_nat n - of_nat 
 show of_nat (n - m) = of_nat n + neg_of_nat m, from match m, h with
 | 0, h := rfl
 | succ m, h := show of_nat (n - succ m) = sub_nat_nat n (succ m),
-  by delta sub_nat_nat; rw sub_eq_zero_of_le h; refl
+  by delta sub_nat_nat; rw nat.sub_eq_zero_of_le h; refl
 end
 
 protected lemma add_left_comm (a b c : ℤ) : a + (b + c) = b + (a + c) :=

--- a/library/init/data/list/basic.lean
+++ b/library/init/data/list/basic.lean
@@ -88,7 +88,7 @@ open option nat
 | (a :: l) (n+1) := nth l n
 
 @[simp] def nth_le : Π (l : list α) (n), n < l.length → α
-| []       n     h := absurd h (not_lt_zero n)
+| []       n     h := absurd h n.not_lt_zero
 | (a :: l) 0     h := a
 | (a :: l) (n+1) h := nth_le l n (le_of_succ_le_succ h)
 

--- a/library/init/data/nat/basic.lean
+++ b/library/init/data/nat/basic.lean
@@ -76,19 +76,19 @@ less_than_or_equal.step (nat.le_refl n)
 lemma succ_le_succ {n m : ℕ} : n ≤ m → succ n ≤ succ m :=
 λ h, less_than_or_equal.rec (nat.le_refl (succ n)) (λ a b, less_than_or_equal.step) h
 
-lemma zero_le : ∀ (n : ℕ), 0 ≤ n
+protected lemma zero_le : ∀ (n : ℕ), 0 ≤ n
 | 0     := nat.le_refl 0
 | (n+1) := less_than_or_equal.step (zero_le n)
 
 lemma zero_lt_succ (n : ℕ) : 0 < succ n :=
-succ_le_succ (zero_le n)
+succ_le_succ n.zero_le
 
 lemma succ_pos (n : ℕ) : 0 < succ n := zero_lt_succ n
 
 lemma not_succ_le_zero : ∀ (n : ℕ), succ n ≤ 0 → false
 .
 
-lemma not_lt_zero (a : ℕ) : ¬ a < 0 := not_succ_le_zero a
+protected lemma not_lt_zero (a : ℕ) : ¬ a < 0 := not_succ_le_zero a
 
 lemma pred_le_pred {n m : ℕ} : n ≤ m → pred n ≤ pred m :=
 λ h, less_than_or_equal.rec_on h
@@ -99,7 +99,7 @@ lemma le_of_succ_le_succ {n m : ℕ} : succ n ≤ succ m → n ≤ m :=
 pred_le_pred
 
 instance decidable_le : ∀ a b : ℕ, decidable (a ≤ b)
-| 0     b     := is_true (zero_le b)
+| 0     b     := is_true b.zero_le
 | (a+1) 0     := is_false (not_succ_le_zero a)
 | (a+1) (b+1) :=
   match decidable_le a b with
@@ -138,16 +138,16 @@ lemma pred_lt : ∀ {n : ℕ}, n ≠ 0 → pred n < n
 | 0        h := absurd rfl h
 | (succ a) h := lt_succ_of_le less_than_or_equal.refl
 
-lemma sub_le (a b : ℕ) : a - b ≤ a :=
+protected lemma sub_le (a b : ℕ) : a - b ≤ a :=
 nat.rec_on b (nat.le_refl (a - 0)) (λ b₁, nat.le_trans (pred_le (a - b₁)))
 
-lemma sub_lt : ∀ {a b : ℕ}, 0 < a → 0 < b → a - b < a
+protected lemma sub_lt : ∀ {a b : ℕ}, 0 < a → 0 < b → a - b < a
 | 0     b     h1 h2 := absurd h1 (nat.lt_irrefl 0)
 | (a+1) 0     h1 h2 := absurd h2 (nat.lt_irrefl 0)
 | (a+1) (b+1) h1 h2 :=
   eq.symm (succ_sub_succ_eq_sub a b) ▸
     show a - b < succ a, from
-    lt_succ_of_le (sub_le a b)
+    lt_succ_of_le (a.sub_le b)
 
 protected lemma lt_of_lt_of_le {n m k : ℕ} : n < m → m ≤ k → n < k :=
 nat.le_trans

--- a/library/init/data/nat/bitwise.lean
+++ b/library/init/data/nat/bitwise.lean
@@ -75,7 +75,7 @@ end
 
 theorem div2_val (n) : div2 n = n / 2 :=
 begin
-  refine eq_of_mul_eq_mul_left dec_trivial
+  refine nat.eq_of_mul_eq_mul_left dec_trivial
       (nat.add_left_cancel (eq.trans _ (nat.mod_add_div n 2).symm)),
   rw [mod_two_of_bodd, bodd_add_div2]
 end
@@ -121,7 +121,7 @@ def binary_rec {C : nat → Sort u} (z : C 0) (f : ∀ b n, C n → C (bit b n))
       change div2 n < n, rw div2_val,
       apply (div_lt_iff_lt_mul _ _ (succ_pos 1)).2,
       have := nat.mul_lt_mul_of_pos_left (lt_succ_self 1)
-        (lt_of_le_of_ne (zero_le _) (ne.symm n0)),
+        (lt_of_le_of_ne n.zero_le (ne.symm n0)),
       rwa nat.mul_one at this
     end,
     by rw [← show bit (bodd n) n' = n, from bit_decomp n]; exact

--- a/library/init/data/nat/lemmas.lean
+++ b/library/init/data/nat/lemmas.lean
@@ -47,7 +47,7 @@ assume h, nat.no_confusion h
 protected lemma zero_ne_one : 0 ≠ (1 : ℕ) :=
 assume h, nat.no_confusion h
 
-lemma eq_zero_of_add_eq_zero_right : ∀ {n m : ℕ}, n + m = 0 → n = 0
+protected lemma eq_zero_of_add_eq_zero_right : ∀ {n m : ℕ}, n + m = 0 → n = 0
 | 0     m := by simp [nat.zero_add]
 | (n+1) m := λ h,
   begin
@@ -56,8 +56,8 @@ lemma eq_zero_of_add_eq_zero_right : ∀ {n m : ℕ}, n + m = 0 → n = 0
     apply succ_ne_zero _ h
   end
 
-lemma eq_zero_of_add_eq_zero_left {n m : ℕ} (h : n + m = 0) : m = 0 :=
-@eq_zero_of_add_eq_zero_right m n (nat.add_comm n m ▸ h)
+protected lemma eq_zero_of_add_eq_zero_left {n m : ℕ} (h : n + m = 0) : m = 0 :=
+@nat.eq_zero_of_add_eq_zero_right m n (nat.add_comm n m ▸ h)
 
 @[simp]
 lemma pred_zero : pred 0 = 0 :=
@@ -127,11 +127,11 @@ le_of_succ_le h
 
 lemma lt.step {n m : ℕ} : n < m → n < succ m := less_than_or_equal.step
 
-lemma eq_zero_or_pos (n : ℕ) : n = 0 ∨ 0 < n :=
+protected lemma eq_zero_or_pos (n : ℕ) : n = 0 ∨ 0 < n :=
 by {cases n, exact or.inl rfl, exact or.inr (succ_pos _)}
 
 protected lemma pos_of_ne_zero {n : nat} : n ≠ 0 → 0 < n :=
-or.resolve_left (eq_zero_or_pos n)
+or.resolve_left n.eq_zero_or_pos
 
 protected lemma lt_trans {n m k : ℕ} (h₁ : n < m) : m < k → n < k :=
 nat.le_trans (less_than_or_equal.step h₁)
@@ -180,7 +180,7 @@ instance : linear_order ℕ :=
   decidable_le               := nat.decidable_le,
   decidable_eq               := nat.decidable_eq }
 
-lemma eq_zero_of_le_zero {n : nat} (h : n ≤ 0) : n = 0 :=
+protected lemma eq_zero_of_le_zero {n : nat} (h : n ≤ 0) : n = 0 :=
 le_antisymm h (zero_le _)
 
 lemma succ_lt_succ {a b : ℕ} : a < b → succ a < succ b :=
@@ -201,12 +201,12 @@ lemma lt_of_succ_le {a b : ℕ} (h : succ a ≤ b) : a < b := h
 
 lemma succ_le_of_lt {a b : ℕ} (h : a < b) : succ a ≤ b := h
 
-lemma le_add_right : ∀ (n k : ℕ), n ≤ n + k
+protected lemma le_add_right : ∀ (n k : ℕ), n ≤ n + k
 | n 0     := nat.le_refl n
 | n (k+1) := le_succ_of_le (le_add_right n k)
 
-lemma le_add_left (n m : ℕ): n ≤ m + n :=
-nat.add_comm n m ▸ le_add_right n m
+protected lemma le_add_left (n m : ℕ): n ≤ m + n :=
+nat.add_comm n m ▸ n.le_add_right m
 
 lemma le.dest : ∀ {n m : ℕ}, n ≤ m → ∃ k, n + k = m
 | n _ less_than_or_equal.refl := ⟨0, rfl⟩
@@ -215,8 +215,8 @@ lemma le.dest : ∀ {n m : ℕ}, n ≤ m → ∃ k, n + k = m
   | ⟨w, hw⟩ := ⟨succ w, hw ▸ add_succ n w⟩
   end
 
-lemma le.intro {n m k : ℕ} (h : n + k = m) : n ≤ m :=
-h ▸ le_add_right n k
+protected lemma le.intro {n m k : ℕ} (h : n + k = m) : n ≤ m :=
+h ▸ n.le_add_right k
 
 protected lemma add_le_add_left {n m : ℕ} (h : n ≤ m) (k : ℕ) : k + n ≤ k + m :=
 match le.dest h with
@@ -275,18 +275,19 @@ le_trans (nat.add_le_add_right h₁ c) (nat.add_le_add_left h₂ b)
 protected lemma zero_lt_one : 0 < (1:nat) :=
 zero_lt_succ 0
 
-lemma mul_le_mul_left {n m : ℕ} (k : ℕ) (h : n ≤ m) : k * n ≤ k * m :=
+protected lemma mul_le_mul_left {n m : ℕ} (k : ℕ) (h : n ≤ m) : k * n ≤ k * m :=
 match le.dest h with
 | ⟨l, hl⟩ :=
   have k * n + k * l = k * m, by rw [← nat.left_distrib, hl],
   le.intro this
 end
 
-lemma mul_le_mul_right {n m : ℕ} (k : ℕ) (h : n ≤ m) : n * k ≤ m * k :=
-nat.mul_comm k m ▸ nat.mul_comm k n ▸ mul_le_mul_left k h
+protected lemma mul_le_mul_right {n m : ℕ} (k : ℕ) (h : n ≤ m) : n * k ≤ m * k :=
+nat.mul_comm k m ▸ nat.mul_comm k n ▸ k.mul_le_mul_left h
 
 protected lemma mul_lt_mul_of_pos_left {n m k : ℕ} (h : n < m) (hk : 0 < k) : k * n < k * m :=
-nat.lt_of_lt_of_le (nat.lt_add_of_pos_right hk) (mul_succ k n ▸ nat.mul_le_mul_left k (succ_le_of_lt h))
+nat.lt_of_lt_of_le (nat.lt_add_of_pos_right hk)
+  (mul_succ k n ▸ nat.mul_le_mul_left k (succ_le_of_lt h))
 
 protected lemma mul_lt_mul_of_pos_right {n m k : ℕ} (h : n < m) (hk : 0 < k) : n * k < m * k :=
 nat.mul_comm k m ▸ nat.mul_comm k n ▸ nat.mul_lt_mul_of_pos_left h hk
@@ -300,7 +301,7 @@ not_lt.1
 lemma le_of_lt_succ {m n : nat} : m < succ n → m ≤ n :=
 le_of_succ_le_succ
 
-theorem eq_of_mul_eq_mul_left {m k n : ℕ} (Hn : 0 < n) (H : n * m = n * k) : m = k :=
+protected theorem eq_of_mul_eq_mul_left {m k n : ℕ} (Hn : 0 < n) (H : n * m = n * k) : m = k :=
 le_antisymm (nat.le_of_mul_le_mul_left (le_of_eq H) Hn)
             (nat.le_of_mul_le_mul_left (le_of_eq H.symm) Hn)
 
@@ -480,7 +481,7 @@ protected theorem sub_sub : ∀ (n m k : ℕ), n - m - k = n - (m + k)
 | n m 0        := by rw [nat.add_zero, nat.sub_zero]
 | n m (succ k) := by rw [add_succ, nat.sub_succ, nat.sub_succ, sub_sub n m k]
 
-theorem le_of_le_of_sub_le_sub_right {n m k : ℕ}
+protected theorem le_of_le_of_sub_le_sub_right {n m k : ℕ}
   (h₀ : k ≤ m)
   (h₁ : n - k ≤ m - k)
 : n ≤ m :=
@@ -501,25 +502,25 @@ end
 protected theorem sub_le_sub_right_iff (n m k : ℕ)
   (h : k ≤ m)
 : n - k ≤ m - k ↔ n ≤ m :=
-⟨ le_of_le_of_sub_le_sub_right h , assume h, nat.sub_le_sub_right h k ⟩
+⟨ nat.le_of_le_of_sub_le_sub_right h , assume h, nat.sub_le_sub_right h k ⟩
 
-theorem sub_self_add (n m : ℕ) : n - (n + m) = 0 :=
+protected theorem sub_self_add (n m : ℕ) : n - (n + m) = 0 :=
 show (n + 0) - (n + m) = 0, from
 by rw [nat.add_sub_add_left, nat.zero_sub]
 
-theorem add_le_to_le_sub (x : ℕ) {y k : ℕ}
+protected theorem add_le_to_le_sub (x : ℕ) {y k : ℕ}
   (h : k ≤ y)
 : x + k ≤ y ↔ x ≤ y - k :=
 by rw [← nat.add_sub_cancel x k, nat.sub_le_sub_right_iff _ _ _ h, nat.add_sub_cancel]
 
-lemma sub_lt_of_pos_le (a b : ℕ) (h₀ : 0 < a) (h₁ : a ≤ b)
+protected lemma sub_lt_of_pos_le (a b : ℕ) (h₀ : 0 < a) (h₁ : a ≤ b)
 : b - a < b :=
 begin
   apply sub_lt _ h₀,
   apply lt_of_lt_of_le h₀ h₁
 end
 
-theorem sub_one (n : ℕ) : n - 1 = pred n :=
+protected theorem sub_one (n : ℕ) : n - 1 = pred n :=
 rfl
 
 theorem succ_sub_one (n : ℕ) : succ n - 1 = n :=
@@ -529,9 +530,9 @@ theorem succ_pred_eq_of_pos : ∀ {n : ℕ}, 0 < n → succ (pred n) = n
 | 0 h        := absurd h (lt_irrefl 0)
 | (succ k) h := rfl
 
-theorem sub_eq_zero_of_le {n m : ℕ} (h : n ≤ m) : n - m = 0 :=
+protected theorem sub_eq_zero_of_le {n m : ℕ} (h : n ≤ m) : n - m = 0 :=
 exists.elim (nat.le.dest h)
-  (assume k, assume hk : n + k = m, by rw [← hk, sub_self_add])
+  (assume k, assume hk : n + k = m, by rw [← hk, nat.sub_self_add])
 
 protected theorem le_of_sub_eq_zero : ∀{n m : ℕ}, n - m = 0 → n ≤ m
 | n 0 H := begin rw [nat.sub_zero] at H, simp [H] end
@@ -542,13 +543,13 @@ protected theorem le_of_sub_eq_zero : ∀{n m : ℕ}, n - m = 0 → n ≤ m
 protected theorem sub_eq_zero_iff_le {n m : ℕ} : n - m = 0 ↔ n ≤ m :=
 ⟨nat.le_of_sub_eq_zero, nat.sub_eq_zero_of_le⟩
 
-theorem add_sub_of_le {n m : ℕ} (h : n ≤ m) : n + (m - n) = m :=
+protected theorem add_sub_of_le {n m : ℕ} (h : n ≤ m) : n + (m - n) = m :=
 exists.elim (nat.le.dest h)
   (assume k, assume hk : n + k = m,
     by rw [← hk, nat.add_sub_cancel_left])
 
 protected theorem sub_add_cancel {n m : ℕ} (h : m ≤ n) : n - m + m = n :=
-by rw [nat.add_comm, add_sub_of_le h]
+by rw [nat.add_comm, nat.add_sub_of_le h]
 
 protected theorem add_sub_assoc {m k : ℕ} (h : k ≤ m) (n : ℕ) : n + m - k = n + (m - k) :=
 exists.elim (nat.le.dest h)
@@ -563,10 +564,10 @@ protected lemma lt_of_sub_eq_succ {m n l : ℕ} (H : m - n = nat.succ l) : n < m
 not_le.1
   (assume (H' : n ≥ m), begin simp [nat.sub_eq_zero_of_le H'] at H, contradiction end)
 
-lemma zero_min (a : ℕ) : min 0 a = 0 :=
+protected lemma zero_min (a : ℕ) : min 0 a = 0 :=
 min_eq_left (zero_le a)
 
-lemma min_zero (a : ℕ) : min a 0 = 0 :=
+protected lemma min_zero (a : ℕ) : min a 0 = 0 :=
 min_eq_right (zero_le a)
 
 -- Distribute succ over min
@@ -583,9 +584,9 @@ decidable.by_cases f g
 
 theorem sub_eq_sub_min (n m : ℕ) : n - m = n - min n m :=
 if h : n ≥ m then by rewrite [min_eq_right h]
-else by rewrite [sub_eq_zero_of_le (le_of_not_ge h), min_eq_left (le_of_not_ge h), nat.sub_self]
+else by rewrite [nat.sub_eq_zero_of_le (le_of_not_ge h), min_eq_left (le_of_not_ge h), nat.sub_self]
 
-@[simp] theorem sub_add_min_cancel (n m : ℕ) : n - m + min n m = n :=
+@[simp] protected theorem sub_add_min_cancel (n m : ℕ) : n - m + min n m = n :=
 by rw [sub_eq_sub_min, nat.sub_add_cancel (min_le_left n m)]
 
 /- TODO(Leo): sub + inequalities -/
@@ -661,7 +662,7 @@ begin
 end
 
 lemma mod_eq_sub_mod {a b : nat} (h : b ≤ a) : a % b = (a - b) % b :=
-or.elim (eq_zero_or_pos b)
+or.elim b.eq_zero_or_pos
   (λb0, by rw [b0, nat.sub_zero])
   (λh₂, by rw [mod_def, if_pos (and.intro h₂ h)])
 
@@ -682,7 +683,7 @@ by rw [mod_eq_sub_mod (le_refl _), nat.sub_self, zero_mod]
 
 @[simp] lemma mod_one (n : ℕ) : n % 1 = 0 :=
 have n % 1 < 1, from (mod_lt n) (succ_pos 0),
-eq_zero_of_le_zero (le_of_lt_succ this)
+nat.eq_zero_of_le_zero (le_of_lt_succ this)
 
 lemma mod_two_eq_zero_or_one (n : ℕ) : n % 2 = 0 ∨ n % 2 = 1 :=
 match n % 2, @nat.mod_lt n 2 dec_trivial with
@@ -751,7 +752,7 @@ protected lemma div_le_of_le_mul {m n : ℕ} : ∀ {k}, m ≤ k * n → m / k �
 | (succ k) h :=
   suffices succ k * (m / succ k) ≤ succ k * n, from nat.le_of_mul_le_mul_left this (zero_lt_succ _),
   calc
-    succ k * (m / succ k) ≤ m % succ k + succ k * (m / succ k) : le_add_left _ _
+    succ k * (m / succ k) ≤ m % succ k + succ k * (m / succ k) : nat.le_add_left _ _
                       ... = m                                  : by rw mod_add_div
                       ... ≤ succ k * n                         : h
 
@@ -760,7 +761,7 @@ protected lemma div_le_self : ∀ (m n : ℕ), m / n ≤ m
 | m (succ n) :=
   have m ≤ succ n * m, from calc
     m  = 1 * m      : by rw nat.one_mul
-   ... ≤ succ n * m : mul_le_mul_right _ (succ_le_succ (zero_le _)),
+   ... ≤ succ n * m : m.mul_le_mul_right (succ_le_succ (zero_le _)),
   nat.div_le_of_le_mul this
 
 lemma div_eq_sub_div {a b : nat} (h₁ : 0 < b) (h₂ : b ≤ a) : a / b = (a - b) / b + 1 :=
@@ -799,18 +800,18 @@ begin
     { simp [nat.zero_mul, zero_le] },
     { simp [succ_mul, not_succ_le_zero, nat.add_comm],
       apply lt_of_lt_of_le h,
-      apply le_add_right } },
+      apply nat.le_add_right } },
   -- step: k ≤ y
   { rw [div_eq_sub_div Hk h],
     cases x with x,
     { simp [nat.zero_mul, zero_le] },
     { have Hlt : y - k < y,
-      { apply sub_lt_of_pos_le ; assumption },
+      { apply nat.sub_lt_of_pos_le ; assumption },
       rw [ ← add_one
          , nat.add_le_add_iff_le_right
          , IH (y - k) Hlt x
          , add_one
-         , succ_mul, add_le_to_le_sub _ h ]
+         , succ_mul, nat.add_le_to_le_sub _ h ]
      } }
 end
 
@@ -872,7 +873,7 @@ theorem eq_zero_of_mul_eq_zero : ∀ {n m : ℕ}, n * m = 0 → n = 0 ∨ m = 0
 | (succ n) m :=
   begin
     rw succ_mul, intro h,
-    exact or.inr (eq_zero_of_add_eq_zero_left h)
+    exact or.inr (nat.eq_zero_of_add_eq_zero_left h)
   end
 
 /- properties of inequality -/
@@ -952,7 +953,7 @@ have 0 + m < n - m + m, begin rw [nat.zero_add, nat.sub_add_cancel (le_of_lt h)]
 nat.lt_of_add_lt_add_right this
 
 protected theorem sub_sub_self {n m : ℕ} (h : m ≤ n) : n - (n - m) = m :=
-(nat.sub_eq_iff_eq_add (nat.sub_le _ _)).2 (eq.symm (add_sub_of_le h))
+(nat.sub_eq_iff_eq_add (nat.sub_le _ _)).2 (nat.add_sub_of_le h).symm
 
 protected theorem sub_add_comm {n m k : ℕ} (h : k ≤ n) : n + m - k = n - k + m :=
 (nat.sub_eq_iff_eq_add (nat.le_trans h (nat.le_add_right _ _))).2
@@ -1001,7 +1002,7 @@ there exists some natural number satisfying `p`, then `nat.find hp` is the
 smallest natural number satisfying `p`. Note that `nat.find` is protected,
 meaning that you can't just write `find`, even if the `nat` namespace is open.
 
-The API for `nat.find` is: 
+The API for `nat.find` is:
 
 * `nat.find_spec` is the proof that `nat.find hp` satisfies `p`.
 * `nat.find_min` is the proof that if `m < nat.find hp` then `m` does not satisfy `p`.
@@ -1023,7 +1024,7 @@ end find
 theorem mod_le (x y : ℕ) : x % y ≤ x :=
 or.elim (lt_or_le x y)
   (λxlty, by rw mod_eq_of_lt xlty; refl)
-  (λylex, or.elim (eq_zero_or_pos y)
+  (λylex, or.elim y.eq_zero_or_pos
     (λy0, by rw [y0, mod_zero]; refl)
     (λypos, le_trans (le_of_lt (mod_lt _ ypos)) ylex))
 
@@ -1056,7 +1057,7 @@ else x.strong_induction_on $ λn IH,
   or.elim (le_or_lt y n)
     (λyn, by rw [
         mod_eq_sub_mod yn,
-        mod_eq_sub_mod (mul_le_mul_left z yn),
+        mod_eq_sub_mod (nat.mul_le_mul_left z yn),
         ← nat.mul_sub_left_distrib];
       exact IH _ (sub_lt (lt_of_lt_of_le y0 yn) y0))
     (λyn, by rw [mod_eq_of_lt yn, mod_eq_of_lt (nat.mul_lt_mul_of_pos_left yn z0)])
@@ -1079,7 +1080,7 @@ begin
   { have h₂ : n * k ≤ x,
     { rw [mul_succ] at h₁,
       apply nat.le_trans _ h₁,
-      apply le_add_right _ n },
+      apply nat.le_add_right _ n },
     have h₄ : x - n * k ≥ n,
     { apply @nat.le_of_add_le_add_right (n*k),
       rw [nat.sub_add_cancel h₂],
@@ -1091,7 +1092,7 @@ end
 
 theorem sub_mul_div (x n p : ℕ) (h₁ : n*p ≤ x) : (x - n*p) / n = x / n - p :=
 begin
-  cases eq_zero_or_pos n with h₀ h₀,
+  cases nat.eq_zero_or_pos n with h₀ h₀,
   { rw [h₀, nat.div_zero, nat.div_zero, nat.zero_sub] },
   { induction p with p,
     { rw [nat.mul_zero, nat.sub_zero, nat.sub_zero] },
@@ -1155,7 +1156,7 @@ by rw [H2, nat.mul_div_cancel_left _ H1]
 protected theorem div_eq_of_lt_le {m n k : ℕ}
   (lo : k * n ≤ m) (hi : m < succ k * n) :
   m / n = k :=
-have npos : 0 < n, from (eq_zero_or_pos _).resolve_left $ λ hn,
+have npos : 0 < n, from n.eq_zero_or_pos.resolve_left $ λ hn,
   by rw [hn, nat.mul_zero] at hi lo; exact absurd lo (not_le_of_gt hi),
 le_antisymm
   (le_of_lt_succ ((nat.div_lt_iff_lt_mul _ _ npos).2 hi))
@@ -1163,7 +1164,7 @@ le_antisymm
 
 theorem mul_sub_div (x n p : ℕ) (h₁ : x < n*p) : (n * p - succ x) / n = p - succ (x / n) :=
 begin
-  have npos : 0 < n := (eq_zero_or_pos _).resolve_left (λ n0,
+  have npos : 0 < n := n.eq_zero_or_pos.resolve_left (λ n0,
     by rw [n0, nat.zero_mul] at h₁; exact not_lt_zero _ h₁),
   apply nat.div_eq_of_lt_le,
   { rw [nat.mul_sub_right_distrib, nat.mul_comm],
@@ -1183,8 +1184,8 @@ by rwa nat.zero_mul at h
 
 protected theorem div_div_eq_div_mul (m n k : ℕ) : m / n / k = m / (n * k) :=
 begin
-  cases eq_zero_or_pos k with k0 kpos, {rw [k0, nat.mul_zero, nat.div_zero, nat.div_zero]},
-  cases eq_zero_or_pos n with n0 npos, {rw [n0, nat.zero_mul, nat.div_zero, nat.zero_div]},
+  cases k.eq_zero_or_pos with k0 kpos, {rw [k0, nat.mul_zero, nat.div_zero, nat.div_zero]},
+  cases n.eq_zero_or_pos with n0 npos, {rw [n0, nat.zero_mul, nat.div_zero, nat.zero_div]},
   apply le_antisymm,
   { apply (le_div_iff_mul_le _ _ (nat.mul_pos npos kpos)).2,
     rw [nat.mul_comm n k, ← nat.mul_assoc],
@@ -1237,7 +1238,7 @@ theorem le_of_dvd {m n : ℕ} (h : 0 < n) : m ∣ n → m ≤ n :=
 λ⟨k, e⟩, by {
   revert h, rw e, refine k.cases_on _ _,
   exact λhn, absurd hn (lt_irrefl _),
-  exact λk _, let t := mul_le_mul_left m (succ_pos k) in by rwa nat.mul_one at t }
+  exact λk _, let t := m.mul_le_mul_left (succ_pos k) in by rwa nat.mul_one at t }
 
 theorem dvd_antisymm : Π {m n : ℕ}, m ∣ n → n ∣ m → m = n
 | m        0        h₁ h₂ := nat.eq_zero_of_zero_dvd h₂
@@ -1269,13 +1270,13 @@ protected theorem div_mul_cancel {m n : ℕ} (H : n ∣ m) : m / n * n = m :=
 by rw [nat.mul_comm, nat.mul_div_cancel' H]
 
 protected theorem mul_div_assoc (m : ℕ) {n k : ℕ} (H : k ∣ n) : m * n / k = m * (n / k) :=
-or.elim (eq_zero_or_pos k)
+or.elim k.eq_zero_or_pos
   (λh, by rw [h, nat.div_zero, nat.div_zero, nat.mul_zero])
   (λh, have m * n / k = m * (n / k * k) / k, by rw nat.div_mul_cancel H,
        by rw[this, ← nat.mul_assoc, nat.mul_div_cancel _ h])
 
 theorem dvd_of_mul_dvd_mul_left {m n k : ℕ} (kpos : 0 < k) (H : k * m ∣ k * n) : m ∣ n :=
-exists.elim H (λl H1, by rw nat.mul_assoc at H1; exact ⟨_, eq_of_mul_eq_mul_left kpos H1⟩)
+exists.elim H (λl H1, by rw nat.mul_assoc at H1; exact ⟨_, nat.eq_of_mul_eq_mul_left kpos H1⟩)
 
 theorem dvd_of_mul_dvd_mul_right {m n k : ℕ} (kpos : 0 < k) (H : m * k ∣ n * k) : m ∣ n :=
 by rw [nat.mul_comm m k, nat.mul_comm n k] at H; exact dvd_of_mul_dvd_mul_left kpos H
@@ -1286,17 +1287,20 @@ protected lemma mul_le_mul_of_nonneg_left {a b c : ℕ} (h₁ : a ≤ b) : c * a
 begin
   by_cases hba : b ≤ a, { simp [le_antisymm hba h₁] },
   by_cases hc0 : c ≤ 0, { simp [le_antisymm hc0 (zero_le c), nat.zero_mul] },
-  exact (le_not_le_of_lt (nat.mul_lt_mul_of_pos_left (lt_of_le_not_le h₁ hba) (lt_of_le_not_le (zero_le c) hc0))).left,
+  exact (le_not_le_of_lt
+    (nat.mul_lt_mul_of_pos_left (lt_of_le_not_le h₁ hba) (lt_of_le_not_le (zero_le c) hc0))).left,
 end
 
 protected lemma mul_le_mul_of_nonneg_right {a b c : ℕ} (h₁ : a ≤ b) : a * c ≤ b * c :=
 begin
   by_cases hba : b ≤ a, { simp [le_antisymm hba h₁] },
   by_cases hc0 : c ≤ 0, { simp [le_antisymm hc0 (zero_le c), nat.mul_zero] },
-  exact (le_not_le_of_lt (nat.mul_lt_mul_of_pos_right (lt_of_le_not_le h₁ hba) (lt_of_le_not_le (zero_le c) hc0))).left,
+  exact (le_not_le_of_lt
+    (nat.mul_lt_mul_of_pos_right (lt_of_le_not_le h₁ hba) (lt_of_le_not_le (zero_le c) hc0))).left,
 end
 
-protected lemma mul_lt_mul {a b c d : ℕ} (hac : a < c) (hbd : b ≤ d) (pos_b : 0 < b) :  a * b < c * d :=
+protected lemma mul_lt_mul {a b c d : ℕ} (hac : a < c) (hbd : b ≤ d) (pos_b : 0 < b) :
+  a * b < c * d :=
 calc
   a * b < c * b : nat.mul_lt_mul_of_pos_right hac pos_b
     ... ≤ c * d : nat.mul_le_mul_of_nonneg_left hbd

--- a/library/init/data/nat/lemmas.lean
+++ b/library/init/data/nat/lemmas.lean
@@ -147,7 +147,7 @@ protected lemma le_antisymm {n m : ℕ} (h₁ : n ≤ m) : m ≤ n → n = m :=
 less_than_or_equal.cases_on h₁ (λ a, rfl) (λ a b c, absurd (nat.lt_of_le_of_lt b c) (nat.lt_irrefl n))
 
 protected lemma lt_or_ge : ∀ (a b : ℕ), a < b ∨ b ≤ a
-| a 0     := or.inr (zero_le a)
+| a 0     := or.inr a.zero_le
 | a (b+1) :=
   match lt_or_ge a b with
   | or.inl h := or.inl (le_succ_of_le h)
@@ -181,7 +181,7 @@ instance : linear_order ℕ :=
   decidable_eq               := nat.decidable_eq }
 
 protected lemma eq_zero_of_le_zero {n : nat} (h : n ≤ 0) : n = 0 :=
-le_antisymm h (zero_le _)
+le_antisymm h n.zero_le
 
 lemma succ_lt_succ {a b : ℕ} : a < b → succ a < succ b :=
 succ_le_succ
@@ -194,7 +194,7 @@ le_of_succ_le_succ
 
 lemma pred_lt_pred : ∀ {n m : ℕ}, n ≠ 0 → n < m → pred n < pred m
 | 0         _       h₁ h := absurd rfl h₁
-| _         0       h₁ h := absurd h (not_lt_zero _)
+| n         0       h₁ h := absurd h n.not_lt_zero
 | (succ n) (succ m) _  h := lt_of_succ_lt_succ h
 
 lemma lt_of_succ_le {a b : ℕ} (h : succ a ≤ b) : a < b := h
@@ -312,7 +312,7 @@ le_antisymm (nat.le_of_mul_le_mul_left (le_of_eq H) Hn)
 | (a+1) := congr_arg pred (zero_sub a)
 
 lemma sub_lt_succ (a b : ℕ) : a - b < succ a :=
-lt_succ_of_le (sub_le a b)
+lt_succ_of_le (a.sub_le b)
 
 protected theorem sub_le_sub_right {n m : ℕ} (h : n ≤ m) : ∀ k, n - k ≤ m - k
 | 0        := h
@@ -422,7 +422,7 @@ protected lemma bit0_lt_bit1 {n m : nat} (h : n ≤ m) : bit0 n < bit1 m :=
 lt_succ_of_le (nat.add_le_add h h)
 
 protected lemma bit1_lt_bit0 : ∀ {n m : nat}, n < m → bit1 n < bit0 m
-| n 0        h := absurd h (not_lt_zero _)
+| n 0        h := absurd h n.not_lt_zero
 | n (succ m) h :=
   have n ≤ m, from le_of_lt_succ h,
   have succ (n + n) ≤ succ (m + m), from succ_le_succ (nat.add_le_add this this),
@@ -431,14 +431,14 @@ protected lemma bit1_lt_bit0 : ∀ {n m : nat}, n < m → bit1 n < bit0 m
 
 protected lemma one_le_bit1 (n : ℕ) : 1 ≤ bit1 n :=
 show 1 ≤ succ (bit0 n), from
-succ_le_succ (zero_le (bit0 n))
+succ_le_succ (bit0 n).zero_le
 
 protected lemma one_le_bit0 : ∀ (n : ℕ), n ≠ 0 → 1 ≤ bit0 n
 | 0     h := absurd rfl h
 | (n+1) h :=
   suffices 1 ≤ succ (succ (bit0 n)), from
     eq.symm (nat.bit0_succ_eq n) ▸ this,
-  succ_le_succ (zero_le (succ (bit0 n)))
+  succ_le_succ (bit0 n).succ.zero_le
 
 /- subtraction -/
 @[simp]
@@ -488,7 +488,7 @@ protected theorem le_of_le_of_sub_le_sub_right {n m k : ℕ}
 begin
   revert k m,
   induction n with n ; intros k m h₀ h₁,
-  { apply zero_le },
+  { exact m.zero_le },
   { cases k with k,
     { apply h₁ },
     cases m with m,
@@ -516,7 +516,7 @@ by rw [← nat.add_sub_cancel x k, nat.sub_le_sub_right_iff _ _ _ h, nat.add_sub
 protected lemma sub_lt_of_pos_le (a b : ℕ) (h₀ : 0 < a) (h₁ : a ≤ b)
 : b - a < b :=
 begin
-  apply sub_lt _ h₀,
+  apply nat.sub_lt _ h₀,
   apply lt_of_lt_of_le h₀ h₁
 end
 
@@ -536,7 +536,7 @@ exists.elim (nat.le.dest h)
 
 protected theorem le_of_sub_eq_zero : ∀{n m : ℕ}, n - m = 0 → n ≤ m
 | n 0 H := begin rw [nat.sub_zero] at H, simp [H] end
-| 0 (m+1) H := zero_le _
+| 0 (m+1) H := (m + 1).zero_le
 | (n+1) (m+1) H := nat.add_le_add_right
   (le_of_sub_eq_zero begin simp [nat.add_sub_add_right] at H, exact H end) _
 
@@ -565,10 +565,10 @@ not_le.1
   (assume (H' : n ≥ m), begin simp [nat.sub_eq_zero_of_le H'] at H, contradiction end)
 
 protected lemma zero_min (a : ℕ) : min 0 a = 0 :=
-min_eq_left (zero_le a)
+min_eq_left a.zero_le
 
 protected lemma min_zero (a : ℕ) : min a 0 = 0 :=
-min_eq_right (zero_le a)
+min_eq_right a.zero_le
 
 -- Distribute succ over min
 theorem min_succ_succ (x y : ℕ) : min (succ x) (succ y) = succ (min x y) :=
@@ -595,7 +595,7 @@ protected def strong_rec_on {p : nat → Sort u} (n : nat) (h : ∀ n, (∀ m, m
 suffices ∀ n m, m < n → p m, from this (succ n) n (lt_succ_self _),
 begin
   intros n, induction n with n ih,
-    {intros m h₁, exact absurd h₁ (not_lt_zero _)},
+    {intros m h₁, exact absurd h₁ m.not_lt_zero},
     {intros m h₁,
       apply or.by_cases (decidable.lt_or_eq_of_le (le_of_lt_succ h₁)),
         {intros, apply ih, assumption},
@@ -626,15 +626,15 @@ begin
   refine if_congr iff.rfl _ rfl,
   simp only [succ_sub_succ],
   exact ih
-    (le_trans (sub_le _ _) (le_of_succ_le_succ h1))
-    (le_trans (sub_le _ _) (le_of_succ_le_succ h2))
+    (le_trans (nat.sub_le _ _) (le_of_succ_le_succ h1))
+    (le_trans (nat.sub_le _ _) (le_of_succ_le_succ h2))
 end
 
 lemma mod_def (x y : nat) : x % y = if 0 < y ∧ y ≤ x then (x - y) % y else x :=
 begin
   cases x, { cases y; refl },
   cases y, { refl },
-  refine if_congr iff.rfl (mod_core_congr _ _) rfl; simp [sub_le]
+  refine if_congr iff.rfl (mod_core_congr _ _) rfl; simp [nat.sub_le]
 end
 
 @[simp] lemma mod_zero (a : nat) : a % 0 = a :=
@@ -673,7 +673,7 @@ begin
   { by_cases h₁ : succ x < y,
     { rwa [mod_eq_of_lt h₁] },
     { have h₁ : succ x % y = (succ x - y) % y := mod_eq_sub_mod (not_lt.1 h₁),
-      have : succ x - y ≤ x := le_of_lt_succ (sub_lt (succ_pos x) h),
+      have : succ x - y ≤ x := le_of_lt_succ (nat.sub_lt (succ_pos x) h),
       have h₂ : (succ x - y) % y < y := ih _ this,
       rwa [← h₁] at h₂ } }
 end
@@ -705,8 +705,8 @@ begin
   simp only [succ_sub_succ],
   refine congr_arg (+1) _,
   exact ih
-    (le_trans (sub_le _ _) (le_of_succ_le_succ h1))
-    (le_trans (sub_le _ _) (le_of_succ_le_succ h2))
+    (le_trans (nat.sub_le _ _) (le_of_succ_le_succ h1))
+    (le_trans (nat.sub_le _ _) (le_of_succ_le_succ h2))
 end
 
 lemma div_def (x y : nat) : x / y = if 0 < y ∧ y ≤ x then (x - y) / y + 1 else 0 :=
@@ -714,7 +714,7 @@ begin
   cases x, { cases y; refl },
   cases y, { refl },
   refine if_congr iff.rfl (congr_arg (+1) _) rfl,
-  refine div_core_congr _ _; simp [sub_le]
+  refine div_core_congr _ _; simp [nat.sub_le]
 end
 
 lemma mod_add_div (m k : ℕ)
@@ -748,7 +748,7 @@ begin rw [div_def], simp [lt_irrefl] end
 eq.trans (div_def 0 b) $ if_neg (and.rec not_le_of_gt)
 
 protected lemma div_le_of_le_mul {m n : ℕ} : ∀ {k}, m ≤ k * n → m / k ≤ n
-| 0        h := by simp [nat.div_zero]; apply zero_le
+| 0        h := by simp [nat.div_zero, n.zero_le]
 | (succ k) h :=
   suffices succ k * (m / succ k) ≤ succ k * n, from nat.le_of_mul_le_mul_left this (zero_lt_succ _),
   calc
@@ -757,11 +757,11 @@ protected lemma div_le_of_le_mul {m n : ℕ} : ∀ {k}, m ≤ k * n → m / k �
                       ... ≤ succ k * n                         : h
 
 protected lemma div_le_self : ∀ (m n : ℕ), m / n ≤ m
-| m 0        := by simp [nat.div_zero]; apply zero_le
+| m 0        := by simp [nat.div_zero, m.zero_le]
 | m (succ n) :=
   have m ≤ succ n * m, from calc
     m  = 1 * m      : by rw nat.one_mul
-   ... ≤ succ n * m : m.mul_le_mul_right (succ_le_succ (zero_le _)),
+   ... ≤ succ n * m : m.mul_le_mul_right (succ_le_succ n.zero_le),
   nat.div_le_of_le_mul this
 
 lemma div_eq_sub_div {a b : nat} (h₁ : 0 < b) (h₂ : b ≤ a) : a / b = (a - b) / b + 1 :=
@@ -797,14 +797,14 @@ begin
   -- base case: y < k
   { rw [div_eq_of_lt h],
     cases x with x,
-    { simp [nat.zero_mul, zero_le] },
+    { simp [nat.zero_mul, y.zero_le] },
     { simp [succ_mul, not_succ_le_zero, nat.add_comm],
       apply lt_of_lt_of_le h,
       apply nat.le_add_right } },
   -- step: k ≤ y
   { rw [div_eq_sub_div Hk h],
     cases x with x,
-    { simp [nat.zero_mul, zero_le] },
+    { simp [nat.zero_mul, nat.zero_le] },
     { have Hlt : y - k < y,
       { apply nat.sub_lt_of_pos_le ; assumption },
       rw [ ← add_one
@@ -1059,7 +1059,7 @@ else x.strong_induction_on $ λn IH,
         mod_eq_sub_mod yn,
         mod_eq_sub_mod (nat.mul_le_mul_left z yn),
         ← nat.mul_sub_left_distrib];
-      exact IH _ (sub_lt (lt_of_lt_of_le y0 yn) y0))
+      exact IH _ (nat.sub_lt (lt_of_lt_of_le y0 yn) y0))
     (λyn, by rw [mod_eq_of_lt yn, mod_eq_of_lt (nat.mul_lt_mul_of_pos_left yn z0)])
 
 theorem mul_mod_mul_right (z x y : ℕ) : (x * z) % (y * z) = (x % y) * z :=
@@ -1111,7 +1111,7 @@ begin
 end
 
 theorem div_mul_le_self : ∀ (m n : ℕ), m / n * n ≤ m
-| m 0        := by simp; apply zero_le
+| m 0        := by simp [m.zero_le, nat.zero_mul]
 | m (succ n) := (le_div_iff_mul_le _ _ (nat.succ_pos _)).1 (le_refl _)
 
 @[simp] theorem add_div_right (x : ℕ) {z : ℕ} (H : 0 < z) : (x + z) / z = succ (x / z) :=
@@ -1165,7 +1165,7 @@ le_antisymm
 theorem mul_sub_div (x n p : ℕ) (h₁ : x < n*p) : (n * p - succ x) / n = p - succ (x / n) :=
 begin
   have npos : 0 < n := n.eq_zero_or_pos.resolve_left (λ n0,
-    by rw [n0, nat.zero_mul] at h₁; exact not_lt_zero _ h₁),
+    by rw [n0, nat.zero_mul] at h₁; exact nat.not_lt_zero _ h₁),
   apply nat.div_eq_of_lt_le,
   { rw [nat.mul_sub_right_distrib, nat.mul_comm],
     apply nat.sub_le_sub_left,
@@ -1286,17 +1286,17 @@ by rw [nat.mul_comm m k, nat.mul_comm n k] at H; exact dvd_of_mul_dvd_mul_left k
 protected lemma mul_le_mul_of_nonneg_left {a b c : ℕ} (h₁ : a ≤ b) : c * a ≤ c * b :=
 begin
   by_cases hba : b ≤ a, { simp [le_antisymm hba h₁] },
-  by_cases hc0 : c ≤ 0, { simp [le_antisymm hc0 (zero_le c), nat.zero_mul] },
+  by_cases hc0 : c ≤ 0, { simp [le_antisymm hc0 c.zero_le, nat.zero_mul] },
   exact (le_not_le_of_lt
-    (nat.mul_lt_mul_of_pos_left (lt_of_le_not_le h₁ hba) (lt_of_le_not_le (zero_le c) hc0))).left,
+    (nat.mul_lt_mul_of_pos_left (lt_of_le_not_le h₁ hba) (lt_of_le_not_le c.zero_le hc0))).left,
 end
 
 protected lemma mul_le_mul_of_nonneg_right {a b c : ℕ} (h₁ : a ≤ b) : a * c ≤ b * c :=
 begin
   by_cases hba : b ≤ a, { simp [le_antisymm hba h₁] },
-  by_cases hc0 : c ≤ 0, { simp [le_antisymm hc0 (zero_le c), nat.mul_zero] },
+  by_cases hc0 : c ≤ 0, { simp [le_antisymm hc0 c.zero_le, nat.mul_zero] },
   exact (le_not_le_of_lt
-    (nat.mul_lt_mul_of_pos_right (lt_of_le_not_le h₁ hba) (lt_of_le_not_le (zero_le c) hc0))).left,
+    (nat.mul_lt_mul_of_pos_right (lt_of_le_not_le h₁ hba) (lt_of_le_not_le c.zero_le hc0))).left,
 end
 
 protected lemma mul_lt_mul {a b c d : ℕ} (hac : a < c) (hbd : b ≤ d) (pos_b : 0 < b) :

--- a/tests/lean/run/div_wf.lean
+++ b/tests/lean/run/div_wf.lean
@@ -5,7 +5,7 @@ set_option pp.all true
 -- Auxiliary lemma used to justify recursive call
 private definition lt_aux {x y : nat} (H : 0 < y ∧ y ≤ x) : x - y < x :=
 and.rec_on H (λ ypos ylex,
-  sub_lt (nat.lt_of_lt_of_le ypos ylex) ypos)
+  nat.sub_lt (nat.lt_of_lt_of_le ypos ylex) ypos)
 
 definition wdiv.F (x : nat) (f : Π x₁, x₁ < x → nat → nat) (y : nat) : nat :=
 if H : 0 < y ∧ y ≤ x then f (x - y) (lt_aux H) y + 1 else 0

--- a/tests/lean/run/gcd.lean
+++ b/tests/lean/run/gcd.lean
@@ -10,11 +10,11 @@ infixl `≺`:50 := pair_nat.lt
 
 -- Lemma for justifying recursive call
 private lemma lt₁ (x₁ y₁ : nat) : (x₁ - y₁, succ y₁) ≺ (succ x₁, succ y₁) :=
-lex.left _ _ (lt_succ_of_le (sub_le x₁ y₁))
+lex.left _ _ (lt_succ_of_le (x₁.sub_le y₁))
 
 -- Lemma for justifying recursive call
 private lemma lt₂ (x₁ y₁ : nat) : (succ x₁, y₁ - x₁) ≺ (succ x₁, succ y₁) :=
-lex.right _ (lt_succ_of_le (sub_le y₁ x₁))
+lex.right _ (lt_succ_of_le (y₁.sub_le x₁))
 
 definition gcd.F (p₁ : nat × nat) : (Π p₂ : nat × nat, p₂ ≺ p₁ → nat) → nat :=
 prod.cases_on p₁ (λ (x y : nat),

--- a/tests/lean/run/kha_inst_bug.lean
+++ b/tests/lean/run/kha_inst_bug.lean
@@ -2,4 +2,4 @@ open nat
 
 example (a b : ℕ) : a - b = a - min a b :=
 if h : a ≥ b then by rw [min_eq_right h]
-else by rw [sub_eq_zero_of_le (le_of_not_ge h), min_eq_left (le_of_not_ge h), nat.sub_self]
+else by rw [nat.sub_eq_zero_of_le (le_of_not_ge h), min_eq_left (le_of_not_ge h), nat.sub_self]

--- a/tests/lean/run/sufficies.lean
+++ b/tests/lean/run/sufficies.lean
@@ -6,4 +6,4 @@ nat.cases_on n
   (λ n h,
     suffices 1 ≤ succ (succ (bit0 n)), from
       eq.symm (nat.bit0_succ_eq n) ▸ this,
-    succ_le_succ (zero_le (succ (bit0 n))))
+    succ_le_succ (succ (bit0 n)).zero_le)


### PR DESCRIPTION
Protect more lemmas in the `nat` namespace so that they don't overload (current or reasonable future) lemmas in the root namespace if `nat` is open. I didn't protect any lemmas that mention `succ` or `pred`.