### PR TITLE
chore(frontends/lean/decl_util): Prop instances pretty-printing

### DIFF
--- a/src/frontends/lean/decl_util.cpp
+++ b/src/frontends/lean/decl_util.cpp
@@ -132,7 +132,7 @@ optional<name> heuristic_inst_name(name const & ns, expr const & type) {
     if (is_constant(arg_head)) {
         arg_name = const_name(arg_head);
     } else if (is_sort(arg_head) || is_sort_wo_universe(arg_head)) {
-        arg_name = "sort";
+        arg_name = sort_level(arg_head) == mk_level_zero() ? "Prop" : "sort";
     } else if (is_pi(arg_head)) {
         arg_name = "pi";
     } else if (is_field_notation(arg_head)) {

--- a/src/frontends/lean/decl_util.cpp
+++ b/src/frontends/lean/decl_util.cpp
@@ -132,7 +132,14 @@ optional<name> heuristic_inst_name(name const & ns, expr const & type) {
     if (is_constant(arg_head)) {
         arg_name = const_name(arg_head);
     } else if (is_sort(arg_head) || is_sort_wo_universe(arg_head)) {
-        arg_name = sort_level(arg_head) == mk_level_zero() ? "Prop" : "sort";
+        level u = sort_level(arg_head);
+        if (u == mk_level_zero()) {
+            arg_name = "Prop";
+        } else if (dec_level(u)) {
+            arg_name = "Type";
+        } else {
+            arg_name = "sort";
+        }
     } else if (is_pi(arg_head)) {
         arg_name = "pi";
     } else if (is_field_notation(arg_head)) {


### PR DESCRIPTION
currently, instances such as `boolean_algebra Prop` get the automatic name `sort.*`; this PR changes this behaviour to `Prop.*`.