### PR TITLE
[Merged by Bors] - fix(library): backport remove `export A (hiding B)`

### DIFF
--- a/library/init/meta/expr.lean
+++ b/library/init/meta/expr.lean
@@ -577,7 +577,7 @@ end expr
 /-- An dictionary from `data` to expressions. -/
 @[reducible] meta def expr_map (data : Type) := rb_map expr data
 namespace expr_map
-export native.rb_map (hiding mk)
+export native.rb_map
 
 meta def mk (data : Type) : expr_map data := rb_map.mk expr data
 end expr_map

--- a/library/init/meta/expr.lean
+++ b/library/init/meta/expr.lean
@@ -577,7 +577,8 @@ end expr
 /-- An dictionary from `data` to expressions. -/
 @[reducible] meta def expr_map (data : Type) := rb_map expr data
 namespace expr_map
-export native.rb_map
+export native.rb_map (mk_core size empty insert erase contains find min max fold
+  keys values to_list mfold of_list set_of_list map for filter)
 
 meta def mk (data : Type) : expr_map data := rb_map.mk expr data
 end expr_map

--- a/library/init/meta/rb_map.lean
+++ b/library/init/meta/rb_map.lean
@@ -79,7 +79,7 @@ rb_map.mk key data
 
 @[reducible] meta def nat_map (data : Type) := rb_map nat data
 namespace nat_map
-export rb_map (hiding mk)
+export rb_map
 
 meta def mk (data : Type) : nat_map data := rb_map.mk nat data
 end nat_map
@@ -176,7 +176,7 @@ end native
 open native
 @[reducible] meta def name_map (data : Type) := rb_map name data
 namespace name_map
-export native.rb_map (hiding mk)
+export native.rb_map
 
 meta def mk (data : Type) : name_map data := rb_map.mk_core data name.cmp
 end name_map

--- a/library/init/meta/rb_map.lean
+++ b/library/init/meta/rb_map.lean
@@ -79,7 +79,8 @@ rb_map.mk key data
 
 @[reducible] meta def nat_map (data : Type) := rb_map nat data
 namespace nat_map
-export rb_map
+export rb_map (mk_core size empty insert erase contains find min max fold
+  keys values to_list mfold of_list set_of_list map for filter)
 
 meta def mk (data : Type) : nat_map data := rb_map.mk nat data
 end nat_map
@@ -176,7 +177,8 @@ end native
 open native
 @[reducible] meta def name_map (data : Type) := rb_map name data
 namespace name_map
-export native.rb_map
+export native.rb_map (mk_core size empty insert erase contains find min max fold
+  keys values to_list mfold of_list set_of_list map for filter)
 
 meta def mk (data : Type) : name_map data := rb_map.mk_core data name.cmp
 end name_map

--- a/library/init/meta/tactic.lean
+++ b/library/init/meta/tactic.lean
@@ -50,7 +50,7 @@ meta instance : has_to_string tactic_state :=
 @[reducible] meta def tactic_result := interaction_monad.result tactic_state
 
 namespace tactic
-  export interaction_monad (hiding failed fail)
+  export interaction_monad
   /-- Cause the tactic to fail with no error message. -/
   meta def failed {α : Type} : tactic α := interaction_monad.failed
   meta def fail {α : Type u} {β : Type v} [has_to_format β] (msg : β) : tactic α :=

--- a/library/init/meta/tactic.lean
+++ b/library/init/meta/tactic.lean
@@ -50,7 +50,8 @@ meta instance : has_to_string tactic_state :=
 @[reducible] meta def tactic_result := interaction_monad.result tactic_state
 
 namespace tactic
-  export interaction_monad (result result_to_string mk_exception silent_fail orelse' bracket)
+  export interaction_monad (result result.success result.exception result.cases_on
+    result_to_string mk_exception silent_fail orelse' bracket)
   /-- Cause the tactic to fail with no error message. -/
   meta def failed {α : Type} : tactic α := interaction_monad.failed
   meta def fail {α : Type u} {β : Type v} [has_to_format β] (msg : β) : tactic α :=

--- a/library/init/meta/tactic.lean
+++ b/library/init/meta/tactic.lean
@@ -50,7 +50,7 @@ meta instance : has_to_string tactic_state :=
 @[reducible] meta def tactic_result := interaction_monad.result tactic_state
 
 namespace tactic
-  export interaction_monad
+  export interaction_monad (result result_to_string mk_exception silent_fail orelse' bracket)
   /-- Cause the tactic to fail with no error message. -/
   meta def failed {α : Type} : tactic α := interaction_monad.failed
   meta def fail {α : Type u} {β : Type v} [has_to_format β] (msg : β) : tactic α :=


### PR DESCRIPTION
There are no occurrences of `export A (hiding B)` in mathlib and it is not supported in lean 4, so just remove them here, by replacing them with a more verbose explicit `export`.