### PR TITLE
[Merged by Bors] - refactor(init/core): backport remove unification hints

### DIFF
--- a/library/init/core.lean
+++ b/library/init/core.lean
@@ -622,10 +622,5 @@ inductive bin_tree (α : Type u)
 
 attribute [elab_simple] bin_tree.node bin_tree.leaf
 
-/- Basic unification hints -/
-@[unify] def add_succ_defeq_succ_add_hint (x y z : nat) : unification_hint :=
-{ pattern     := x + nat.succ y ≟ nat.succ z,
-  constraints := [z ≟ x + y] }
-
 /-- Like `by apply_instance`, but not dependent on the tactic framework. -/
 @[reducible] def infer_instance {α : Sort u} [i : α] : α := i

--- a/library/init/data/int/basic.lean
+++ b/library/init/data/int/basic.lean
@@ -524,13 +524,13 @@ protected lemma distrib_left : ∀ a b c : ℤ, a * (b + c) = a * b + a * c
                                             rw ← sub_nat_nat_add, reflexivity end
 | (of_nat m) -[1+ n]    (of_nat k) := begin simp [neg_of_nat_eq_sub_nat_nat_zero],
                                             rw [int.add_comm, ← sub_nat_nat_add], reflexivity end
-| (of_nat m) -[1+ n]   -[1+ k]     := begin simp, rw [← nat.left_distrib, succ_add] end
+| (of_nat m) -[1+ n]   -[1+ k]     := begin simp, rw [← nat.left_distrib, add_succ, succ_add] end
 | -[1+ m]    (of_nat n) (of_nat k) := begin simp [nat.mul_comm], rw [← nat.right_distrib, nat.mul_comm] end
 | -[1+ m]    (of_nat n) -[1+ k]    := begin simp [neg_of_nat_eq_sub_nat_nat_zero],
                                             rw [int.add_comm, ← sub_nat_nat_add], reflexivity end
 | -[1+ m]    -[1+ n]    (of_nat k) := begin simp [neg_of_nat_eq_sub_nat_nat_zero],
                                             rw [← sub_nat_nat_add], reflexivity end
-| -[1+ m]    -[1+ n]   -[1+ k]     := begin simp, rw [← nat.left_distrib, succ_add] end
+| -[1+ m]    -[1+ n]   -[1+ k]     := begin simp, rw [← nat.left_distrib, add_succ, succ_add] end
 
 protected lemma distrib_right (a b c : ℤ) : (a + b) * c = a * c + b * c :=
 begin rw [int.mul_comm, int.distrib_left], simp [int.mul_comm] end

--- a/library/init/data/int/order.lean
+++ b/library/init/data/int/order.lean
@@ -173,7 +173,7 @@ lt.elim ha (assume n, assume hn,
 lt.elim hb (assume m, assume hm,
   lt.intro (show 0 + ↑(nat.succ (nat.succ n * m + n)) = a * b,
     begin rw [← hn, ← hm], simp [int.coe_nat_zero],
-          rw [← int.coe_nat_mul], simp [nat.mul_succ, nat.succ_add] end)))
+          rw [← int.coe_nat_mul], simp [nat.mul_succ, nat.add_succ, nat.succ_add] end)))
 
 protected lemma zero_lt_one : (0 : ℤ) < 1 := trivial
 

--- a/library/init/data/nat/bitwise.lean
+++ b/library/init/data/nat/bitwise.lean
@@ -34,7 +34,7 @@ by unfold bodd bodd_div2; cases bodd_div2 n; cases fst; refl
 begin
     induction n with n IH,
     { simp, cases bodd m; refl },
-    { simp [IH], cases bodd m; cases bodd n; refl }
+    { simp [add_succ, IH], cases bodd m; cases bodd n; refl }
 end
 
 @[simp] lemma bodd_mul (m n : ℕ) : bodd (m * n) = bodd m && bodd n :=

--- a/library/init/data/nat/lemmas.lean
+++ b/library/init/data/nat/lemmas.lean
@@ -19,7 +19,7 @@ protected lemma add_comm : ∀ n m : ℕ, n + m = m + n
 
 protected lemma add_assoc : ∀ n m k : ℕ, (n + m) + k = n + (m + k)
 | n m 0        := rfl
-| n m (succ k) := by rw [add_succ, add_succ, add_assoc]
+| n m (succ k) := by rw [add_succ, add_succ, add_assoc]; refl
 
 protected lemma add_left_comm : ∀ (n m k : ℕ), n + (m + k) = m + (n + k) :=
 left_comm nat.add nat.add_comm nat.add_assoc
@@ -1133,7 +1133,7 @@ theorem add_mul_div_left (x z : ℕ) {y : ℕ} (H : 0 < y) : (x + y * z) / y = x
 begin
   induction z with z ih,
   { rw [nat.mul_zero, nat.add_zero, nat.add_zero] },
-  { rw [mul_succ, ← nat.add_assoc, add_div_right _ H, ih] }
+  { rw [mul_succ, ← nat.add_assoc, add_div_right _ H, ih], refl }
 end
 
 theorem add_mul_div_right (x y : ℕ) {z : ℕ} (H : 0 < z) : (x + y * z) / z = x / z + y :=

--- a/tests/lean/inject.lean.expected.out
+++ b/tests/lean/inject.lean.expected.out
@@ -1,7 +1,8 @@
 lift.equations._eqn_1 : ∀ {m k : ℕ} (f : fi m → fi k) (v : fi (m + 0)), @lift m k f 0 v = f v
-lift.equations._eqn_2 : ∀ {m k : ℕ} (f : fi m → fi k) (n : ℕ), @lift m k f n.succ (@f0 (m + n)) = @f0 (k + n)
+lift.equations._eqn_2 :
+  ∀ {m k : ℕ} (f : fi m → fi k) (n : ℕ), @lift m k f n.succ (@f0 (m.add n)) = @f0 (k.add n)
 lift.equations._eqn_3 :
-  ∀ {m k : ℕ} (f : fi m → fi k) (n : ℕ) (i : fi (m + n)), @lift m k f n.succ i.fs = (@lift m k f n i).fs
+  ∀ {m k : ℕ} (f : fi m → fi k) (n : ℕ) (i : fi (m.add n)), @lift m k f n.succ i.fs = (@lift m k f n i).fs
 to_nat.equations._eqn_1 : ∀ (n : ℕ), (@f0 n).to_nat = 0
 to_nat.equations._eqn_2 : ∀ (n : ℕ) (i : fi n), i.fs.to_nat = i.to_nat.succ
 inject.equations._eqn_1 : ∀ (n : ℕ) (i : fi n), @inject n.succ i.fs (@f0 i.to_nat) = @f0 n

--- a/tests/lean/run/unification_hints.lean
+++ b/tests/lean/run/unification_hints.lean
@@ -37,3 +37,8 @@ by assumption
 #print ex2
 
 end add
+
+/- Basic unification hints -/
+@[unify] def add_succ_defeq_succ_add_hint (x y z : nat) : unification_hint :=
+{ pattern     := x + nat.succ y ≟ nat.succ z,
+  constraints := [z ≟ x + y] }

--- a/tests/lean/unification_hints1.lean.expected.out
+++ b/tests/lean/unification_hints1.lean.expected.out
@@ -4,7 +4,6 @@ g x y =?= f z
 g x y =?= f z
 unification successful
 unification hints:
-(has_add.add, nat.succ) #2 + succ #1 =?= succ #0 {#0 =?= #2 + #1}
 (toy.f, toy.g) f z =?= g #1 #0 {}
 A_canonical.carrier =?= A
 unification failed
@@ -12,6 +11,5 @@ A_canonical.carrier =?= A
 A_canonical.carrier =?= A
 unification successful
 unification hints:
-(has_add.add, nat.succ) #2 + succ #1 =?= succ #0 {#0 =?= #2 + #1}
 (toy.f, toy.g) toy.f toy.z =?= toy.g #1 #0 {}
 (canonical.A, canonical.Canonical.carrier) A =?= Canonical.carrier #0 {#0 =?= A_canonical}

--- a/tests/lean/unification_hints2.lean.expected.out
+++ b/tests/lean/unification_hints2.lean.expected.out
@@ -1,6 +1,6 @@
 m n : ℕ,
 i : F m
-⊢ F.raise n.succ m i = F.suc (m + n) (F.raise n m i)
+⊢ F.raise n.succ m i = F.suc (m.add n) (F.raise n m i)
 unification_hints2.lean:7:0: warning: declaration '[anonymous]' uses sorry
 α : Type u,
 a b : α,


### PR DESCRIPTION
This one is a no-brainer. It is well known that lean 3 practically does not use unification hints at all. There is exactly one use of the `@[unify]` attribute in lean 3 / mathlib, so let's just remove it. Lean 4 does support unification hints but the syntax is different enough and there is only one example so alignment isn't really worth it.

This might have unforeseen fallout in mathlib. We will see how much we were actually relying on this unification hint.