### PR TITLE
[Merged by Bors] - refactor(init/core): backport remove reserve notation

### DIFF
--- a/library/data/stream.lean
+++ b/library/data/stream.lean
@@ -196,7 +196,7 @@ by rw [nth_succ, tail_iterate]
 
 section bisim
   variable (R : stream α → stream α → Prop)
-  local infix ~ := R
+  local infix ` ~ `:50 := R
 
   def is_bisimulation := ∀ ⦃s₁ s₂⦄, s₁ ~ s₂ → head s₁ = head s₂ ∧ tail s₁ ~ tail s₂
 

--- a/library/init/core.lean
+++ b/library/init/core.lean
@@ -10,77 +10,6 @@ prelude
 notation `Prop` := Sort 0
 notation f ` $ `:1 a:0 := f a
 
-/- Reserving notation. We do this so that the precedence of all of the operators
-can be seen in one place and to prevent core notation being accidentally overloaded later.  -/
-
-/- Notation for logical operations and relations -/
-
-reserve prefix `¬`:40
-reserve prefix `~`:40    -- not used
-reserve infixr ` ∧ `:35
-reserve infixr ` /\ `:35
-reserve infixr ` \/ `:30
-reserve infixr ` ∨ `:30
-reserve infix ` <-> `:20
-reserve infix ` ↔ `:20
-reserve infix ` = `:50   -- eq
-reserve infix ` == `:50  -- heq
-reserve infix ` ≠ `:50
-reserve infix ` ≈ `:50   -- has_equiv.equiv
-reserve infix ` ~ `:50   -- used as local notation for relations
-reserve infix ` ≡ `:50   -- not used
-reserve infixl ` ⬝ `:75  -- not used
-reserve infixr ` ▸ `:75  -- eq.subst
-reserve infixr ` ▹ `:75  -- not used
-
-/- types and type constructors -/
-
-reserve infixr ` ⊕ `:30  -- sum (defined in init/data/sum/basic.lean)
-reserve infixr ` × `:35
-
-/- arithmetic operations -/
-
-reserve infixl ` + `:65
-reserve infixl ` - `:65
-reserve infixl ` * `:70
-reserve infixl ` / `:70
-reserve infixl ` % `:70
-reserve prefix `-`:75
-reserve infixr ` ^ `:80
-
-reserve infixr ` ∘ `:90  -- function composition
-
-reserve infix ` <= `:50
-reserve infix ` ≤ `:50
-reserve infix ` < `:50
-reserve infix ` >= `:50
-reserve infix ` ≥ `:50
-reserve infix ` > `:50
-
-/- boolean operations -/
-
-reserve infixl ` && `:70
-reserve infixl ` || `:65
-
-/- set operations -/
-
-reserve infix ` ∈ `:50
-reserve infix ` ∉ `:50
-reserve infixl ` ∩ `:70
-reserve infixl ` ∪ `:65
-reserve infix ` ⊆ `:50
-reserve infix ` ⊇ `:50
-reserve infix ` ⊂ `:50
-reserve infix ` ⊃ `:50
-reserve infix ` \ `:70   -- symmetric difference
-
-/- other symbols -/
-
-reserve infix ` ∣ `:50   -- has_dvd.dvd. Note this is different to `|`.
-reserve infixl ` ++ `:65 -- has_append.append
-reserve infixr ` :: `:67 -- list.cons
-reserve infixl `; `:1    -- has_andthen.andthen
-
 universes u v w
 
 /--
@@ -154,7 +83,7 @@ A hypothesis `h : ¬ P` can be used in term mode as a function, so if `w : P` th
 Related mathlib tactic: `contrapose`.
 -/
 def not (a : Prop) := a → false
-prefix `¬` := not
+prefix `¬`:40 := not
 
 inductive eq {α : Sort u} (a : α) : α → Prop
 | refl [] : eq a
@@ -224,7 +153,7 @@ lemma and.elim_right {a b : Prop} (h : and a b) : b := h.2
 
 /- eq basic support -/
 
-infix = := eq
+infix ` = `:50 := eq
 
 attribute [refl] eq.refl
 
@@ -235,7 +164,7 @@ attribute [refl] eq.refl
 lemma eq.subst {α : Sort u} {P : α → Prop} {a b : α} (h₁ : a = b) (h₂ : P a) : P b :=
 eq.rec h₂ h₁
 
-notation h1 ▸ h2 := eq.subst h1 h2
+infixr ` ▸ `:75 := eq.subst
 
 @[trans] lemma eq.trans {α : Sort u} {a b c : α} (h₁ : a = b) (h₂ : b = c) : a = c :=
 h₂ ▸ h₁
@@ -243,7 +172,7 @@ h₂ ▸ h₁
 @[symm] lemma eq.symm {α : Sort u} {a b : α} (h : a = b) : b = a :=
 h ▸ rfl
 
-infix == := heq
+infix ` == `:50 := heq
 
 /- This is a `def`, so that it can be used as pattern in the equation compiler. -/
 @[pattern] def heq.rfl {α : Sort u} {a : α} : a == a := heq.refl a
@@ -347,7 +276,7 @@ inductive list (T : Type u)
 | nil : list
 | cons (hd : T) (tl : list) : list
 
-notation h :: t  := list.cons h t
+infixr ` :: `:67 := list.cons
 notation `[` l:(foldr `, ` (h t, list.cons h t) list.nil `]`) := l
 
 inductive nat
@@ -404,43 +333,43 @@ class has_pow (α : Type u) (β : Type v) :=
 export has_andthen (andthen)
 export has_pow (pow)
 
-infix ∈        := has_mem.mem
-notation a ∉ s := ¬ has_mem.mem a s
-infix +        := has_add.add
-infix *        := has_mul.mul
-infix -        := has_sub.sub
-infix /        := has_div.div
-infix ∣        := has_dvd.dvd
-infix %        := has_mod.mod
-prefix -       := has_neg.neg
-infix <=       := has_le.le
-infix ≤        := has_le.le
-infix <        := has_lt.lt
-infix ++       := has_append.append
-infix ;        := andthen
-notation `∅`   := has_emptyc.emptyc
-infix ∪        := has_union.union
-infix ∩        := has_inter.inter
-infix ⊆        := has_subset.subset
-infix ⊂        := has_ssubset.ssubset
-infix \        := has_sdiff.sdiff
-infix ≈        := has_equiv.equiv
-infixr ^       := has_pow.pow
+infix ` ∈ `:50   := has_mem.mem
+notation a ` ∉ `:50 s:50 := ¬ has_mem.mem a s
+infixl ` + `:65  := has_add.add
+infixl ` * `:70  := has_mul.mul
+infixl ` - `:65  := has_sub.sub
+infixl ` / `:70  := has_div.div
+infix ` ∣ `:50   := has_dvd.dvd -- Note this is different to `|`.
+infixl ` % `:70  := has_mod.mod
+prefix `-`:75    := has_neg.neg
+infix ` <= `:50  := has_le.le
+infix ` ≤ `:50   := has_le.le
+infix ` < `:50   := has_lt.lt
+infixl ` ++ `:65 := has_append.append
+infixl `; `:1    := andthen
+notation `∅`     := has_emptyc.emptyc
+infixl ` ∪ `:65  := has_union.union
+infixl ` ∩ `:70  := has_inter.inter
+infix ` ⊆ `:50   := has_subset.subset
+infix ` ⊂ `:50   := has_ssubset.ssubset
+infix ` \ `:70   := has_sdiff.sdiff
+infix ` ≈ `:50   := has_equiv.equiv
+infixr ` ^ `:80  := has_pow.pow
 
 export has_append (append)
 
 @[reducible] def ge {α : Type u} [has_le α] (a b : α) : Prop := has_le.le b a
 @[reducible] def gt {α : Type u} [has_lt α] (a b : α) : Prop := has_lt.lt b a
 
-infix >=       := ge
-infix ≥        := ge
-infix >        := gt
+infix ` >= `:50 := ge
+infix ` ≥ `:50  := ge
+infix ` > `:50  := gt
 
 @[reducible] def superset {α : Type u} [has_subset α] (a b : α) : Prop := has_subset.subset b a
 @[reducible] def ssuperset {α : Type u} [has_ssubset α] (a b : α) : Prop := has_ssubset.ssubset b a
 
-infix ⊇        := superset
-infix ⊃        := ssuperset
+infix ` ⊇ `:50 := superset
+infix ` ⊃ `:50 := ssuperset
 
 def bit0 {α : Type u} [s  : has_add α] (a  : α)                 : α := a + a
 def bit1 {α : Type u} [s₁ : has_one α] [s₂ : has_add α] (a : α) : α := (bit0 a) + 1
@@ -501,10 +430,9 @@ be stronger than application.
 
 def std.prec.max_plus : nat := std.prec.max + 10
 
-reserve postfix `⁻¹`:std.prec.max_plus  -- input with \sy or \-1 or \inv
-postfix ⁻¹     := has_inv.inv
+postfix `⁻¹`:std.prec.max_plus := has_inv.inv  -- input with \sy or \-1 or \inv
 
-notation α × β := prod α β
+infixr ` × `:35 := prod
 -- notation for n-ary tuples
 
 /- sizeof -/

--- a/library/init/data/bool/basic.lean
+++ b/library/init/data/bool/basic.lean
@@ -35,5 +35,5 @@ import init.core
 | ff tt  := tt
 | _  _   := ff
 
-notation x || y := bor x y
-notation x && y := band x y
+infixl ` || `:65 := bor
+infixl ` && `:70 := band

--- a/library/init/data/quot.lean
+++ b/library/init/data/quot.lean
@@ -200,7 +200,7 @@ quotient.lift_on₂ q₁ q₂
       (λ a₁a₂, setoid.trans (setoid.symm a₁b₁) (setoid.trans a₁a₂ a₂b₂))
       (λ b₁b₂, setoid.trans a₁b₁ (setoid.trans b₁b₂ (setoid.symm a₂b₂)))))
 
-local infix `~` := rel
+local infix ` ~ `:50 := rel
 
 private lemma rel.refl : ∀ q : quotient s, q ~ q :=
 λ q, quot.induction_on q (λ a, setoid.refl a)

--- a/library/init/data/sum/basic.lean
+++ b/library/init/data/sum/basic.lean
@@ -8,7 +8,7 @@ The sum type, aka disjoint union.
 prelude
 import init.logic
 
-notation α ⊕ β := sum α β
+infixr ` ⊕ `:30 := sum
 
 universes u v
 

--- a/library/init/function.lean
+++ b/library/init/function.lean
@@ -23,8 +23,8 @@ and type of `f (g x)` depends on `x` and `g x`. -/
   (f : Π {x : α} (y : β x), φ y) (g : Π x, β x) : Π x, φ (g x) :=
 λ x, f (g x)
 
-infixr  ` ∘ `      := function.comp
-infixr  ` ∘' `:80  := function.dcomp
+infixr ` ∘ `:90  := function.comp
+infixr ` ∘' `:80 := function.dcomp
 
 @[reducible] def comp_right (f : β → β → β) (g : α → β) : β → α → β :=
 λ b a, f b (g a)

--- a/library/init/funext.lean
+++ b/library/init/funext.lean
@@ -15,7 +15,7 @@ variables {α : Sort u} {β : α → Sort v}
 
 protected def equiv (f₁ f₂ : Π x : α, β x) : Prop := ∀ x, f₁ x = f₂ x
 
-local infix `~` := function.equiv
+local infix ` ~ `:50 := function.equiv
 
 protected theorem equiv.refl (f : Π x : α, β x) : f ~ f := assume x, rfl
 
@@ -55,7 +55,7 @@ end
 
 attribute [intro!] funext
 
-local infix `~` := function.equiv
+local infix ` ~ `:50 := function.equiv
 
 instance pi.subsingleton {α : Sort u} {β : α → Sort v} [∀ a, subsingleton (β a)] : subsingleton (Π a, β a) :=
 ⟨λ f₁ f₂, funext (λ a, subsingleton.elim (f₁ a) (f₂ a))⟩

--- a/library/init/logic.lean
+++ b/library/init/logic.lean
@@ -98,7 +98,7 @@ lemma cast_eq {α : Sort u} (h : α = α) (a : α) : cast h a = a := rfl
 /- ne -/
 
 @[reducible] def ne {α : Sort u} (a b : α) := ¬(a = b)
-notation a ≠ b := ne a b
+infix ` ≠ `:50 := ne
 
 @[simp] lemma ne.def {α : Sort u} (a b : α) : a ≠ b = ¬ (a = b) := rfl
 
@@ -183,8 +183,8 @@ lemma cast_heq : ∀ {α β : Sort u} (h : α = β) (a : α), cast h a == a
 
 /- and -/
 
-notation a /\ b := and a b
-notation a ∧ b  := and a b
+infixr ` /\ `:35 := and
+infixr ` ∧ `:35 := and
 
 variables {a b c d : Prop}
 
@@ -198,8 +198,8 @@ lemma and.symm : a ∧ b → b ∧ a := and.swap
 
 /- or -/
 
-notation a \/ b := or a b
-notation a ∨ b := or a b
+infixr ` \/ `:30 := or
+infixr ` ∨ `:30 := or
 
 namespace or
   lemma elim (h₁ : a ∨ b) (h₂ : a → c) (h₃ : b → c) : c :=
@@ -225,8 +225,8 @@ that is, have the same truth value. -/
 structure iff (a b : Prop) : Prop :=
 intro :: (mp : a → b) (mpr : b → a)
 
-notation a <-> b := iff a b
-notation a ↔ b := iff a b
+infix ` <-> `:20 := iff
+infix ` ↔ `:20 := iff
 
 lemma iff.elim : ((a → b) → (b → a) → c) → (a ↔ b) → c := iff.rec
 

--- a/src/frontends/lean/notation_cmd.cpp
+++ b/src/frontends/lean/notation_cmd.cpp
@@ -141,11 +141,6 @@ static auto parse_mixfix_notation(parser & p, mixfix_kind k, bool overload, nota
 
     pos_info prec_pos;
     if (p.curr_is_token(get_colon_tk())) {
-        // Remark: we do not throw an exception, if it is local notation.
-        // We allow local notation to override reserved one.
-        if (!g_allow_local && reserved_pt)
-            throw parser_error("invalid notation declaration, invalid ':' occurrence "
-                               "(declaration matches reserved notation)", p.pos());
         p.next();
         prec_pos = p.pos();
         prec = parse_precedence(p);

--- a/src/frontends/lean/token_table.cpp
+++ b/src/frontends/lean/token_table.cpp
@@ -15,6 +15,7 @@ static unsigned g_arrow_prec      = 25;
 static unsigned g_max_prec        = 1024;
 static unsigned g_Max_prec        = 1024*1024;
 static unsigned g_plus_prec       = 65;
+static unsigned g_dcolon_prec     = 67;
 unsigned get_max_prec() { return g_max_prec; }
 unsigned get_Max_prec() { return g_Max_prec; }
 unsigned get_arrow_prec() { return g_arrow_prec; }
@@ -94,7 +95,7 @@ void init_token_table(token_table & t) {
          {"//", 0}, {"|", 0}, {"with", 0}, {"without", 0}, {"..", 0}, {"...", 0}, {",", 0},
          {".", 0}, {":", 0}, {"!", 0}, {"calc", 0}, {":=", 0}, {"--", 0}, {"#", g_max_prec},
          {"/-", 0}, {"/--", 0}, {"/-!", 0}, {"/-\"", 0}, {"begin", g_max_prec}, {"using", 0},
-         {"@@", g_max_prec}, {"@", g_max_prec},
+         {"@@", g_max_prec}, {"@", g_max_prec}, {"::", g_dcolon_prec},
          {"sorry", g_max_prec}, {"+", g_plus_prec}, {"->", g_arrow_prec}, {"<-", 0},
          {"match", 0}, {"^.", g_max_prec+1},
          {"renaming", 0}, {"extends", 0}, {nullptr, 0}};

--- a/src/kernel/expr.h
+++ b/src/kernel/expr.h
@@ -367,7 +367,7 @@ public:
     virtual unsigned hash() const;
     virtual void write(serializer & s) const = 0;
     virtual bool can_textualize() const { return false; }
-    virtual void textualize(tlean_exporter & x) const { throw exception("macro::textualize not implemented by default"); }
+    virtual void textualize(tlean_exporter &) const { throw exception("macro::textualize not implemented by default"); }
     typedef std::function<expr(deserializer&, unsigned, expr const *)> reader;
 };
 

--- a/tests/lean/712.lean.expected.out
+++ b/tests/lean/712.lean.expected.out
@@ -1,6 +1,6 @@
 _ `~~~`:50 _:50 := eq #1 #0
 _ `~~~`:50 _:50 := eq #1 #0
-712.lean:15:11: error: invalid notation declaration, invalid ':' occurrence (declaration matches reserved notation)
+712.lean:15:6: error: invalid infixl declaration, declaration conflicts with reserved notation
 _ `~~~`:100 _:100 := eq #1 #0
 `[`:1024 _:1 `][`:10 _:20 `]`:0 := eq #1 #0
 712.lean:24:24: error: invalid notation declaration, invalid ':' occurrence (declaration prefix matches reserved notation)

--- a/tests/lean/hole_issue2.lean
+++ b/tests/lean/hole_issue2.lean
@@ -13,7 +13,7 @@ noncomputable definition count {A} (a : A) (b : bag A) : nat :=
 quotient.lift_on b (λ l, list.count a l)
   (λ l₁ l₂ h, sorry)
 definition subbag {A} (b₁ b₂ : bag A) := ∀ a, count a b₁ ≤ count a b₂
-infix ⊆ := subbag
+infix ` ⊆ ` := subbag
 
 noncomputable definition decidable_subbag_1 {A} (b₁ b₂ : bag A) : decidable (b₁ ⊆ b₂) :=
 quotient.rec_on_subsingleton₂ b₁ b₂ (λ l₁ l₂,

--- a/tests/lean/run/585c.lean
+++ b/tests/lean/run/585c.lean
@@ -6,7 +6,7 @@ inductive perm {α} : list α → list α → Prop
 | swap  : Π (x y : α) (l : list α), perm (y::x::l) (x::y::l)
 | trans : Π {l₁ l₂ l₃ : list α}, perm l₁ l₂ → perm l₂ l₃ → perm l₁ l₃
 
-infix ~ := perm
+infix ` ~ `:50 := perm
 
 @[refl] protected axiom perm.refl {α} : ∀ (l : list α), l ~ l
 

--- a/tests/lean/run/calc_auto_trans_eq.lean
+++ b/tests/lean/run/calc_auto_trans_eq.lean
@@ -1,5 +1,5 @@
 constant R : Π {A : Type}, A → A → Prop
-infix `~` := R
+infix ` ~ `:50 := R
 
 example {A : Type} {a b c d : list nat} (H₁ : a ~ b) (H₂ : b = c) (H₃ : c = d) : a ~ d :=
 calc a ~ b : H₁

--- a/tests/lean/run/simp_univ_poly.lean
+++ b/tests/lean/run/simp_univ_poly.lean
@@ -4,7 +4,7 @@ universes u v
 def equinumerous (α : Type u) (β : Type v) :=
 ∃ f : α → β, function.bijective f
 
-local infix ` ≈ ` := equinumerous
+local infix ` ≈ `:50 := equinumerous
 
 @[refl] lemma refl {α} : α ≈ α := sorry
 @[trans] lemma trans {α β γ} :

--- a/tests/lean/run/soundness.lean
+++ b/tests/lean/run/soundness.lean
@@ -31,7 +31,7 @@ namespace PropF
   notation `⊥`           := Bot
 
   def Neg (A)      := A ⇒ ⊥
-  notation ~ A     := Neg A
+  notation `~` A   := Neg A
   def Top          := ~⊥
   notation `⊤`     := Top
   def BiImpl (A B) := A ⇒ B ∧ B ⇒ A


### PR DESCRIPTION
This removes all uses of `reserve notation` in lean core (mostly in `init.core`), which is not supported in lean 4. The main intent here is to make sure that later syntax declarations come with the precedence information attached directly, instead of being pre-declared.

Additionally, lean was modified to allow writing:
```lean
reserve infix `foo`:3
infix `foo`:3 := bar
```
Previously this was an error, you are *required* to omit the `:3` in the second declaration. Now you are allowed to write it but it still checks that it is `3` (so ``infix `foo`:4`` would be an error).

Finally, `::` is now a built in token instead of being defined in the first few lines of `init.core`. This is needed because without the `reserve notation` declaring it, it's not a token at all, even though `::` is used in structure syntax, e.g. `structure foo := mk :: (a : Prop)`. Since there are some structures that have to be defined before `list.cons` and its notation, this causes a parse error.