### PR TITLE
[Merged by Bors] - feat: allow sorry macro to textualize

### DIFF
--- a/src/library/sorry.cpp
+++ b/src/library/sorry.cpp
@@ -36,6 +36,12 @@ public:
         return sorry_type(sry);
     }
 
+    virtual bool can_textualize() const { return true; }
+
+    virtual void textualize(tlean_exporter & x) const {
+        x.out() << "#SORRY_MACRO";
+    }
+
     virtual optional<expr> expand(expr const &, abstract_type_context &) const override {
         return {};
     }


### PR DESCRIPTION
Reason: so we can run mathport on projects that have sorries,
such as lean-liquid.