### PR TITLE
[Merged by Bors] - refactor(library/init/algebra): add `max`/`min` fields to `linear_order`

### DIFF
--- a/library/init/algebra/functions.lean
+++ b/library/init/algebra/functions.lean
@@ -9,16 +9,20 @@ import init.algebra.order init.meta
 
 universe u
 
-definition min {α : Type u} [linear_order α] (a b : α) : α := if a ≤ b then a else b
-definition max {α : Type u} [linear_order α] (a b : α) : α := if b ≤ a then a else b
+export linear_order (min max)
 
 section
 open decidable tactic
 variables {α : Type u} [linear_order α]
 
+lemma min_def (a b : α) : min a b = if a ≤ b then a else b :=
+by rw [congr_fun linear_order.min_def a, min_default]
+lemma max_def (a b : α) : max a b = if b ≤ a then a else b :=
+by rw [congr_fun linear_order.max_def a, max_default]
+
 private meta def min_tac_step : tactic unit :=
 solve1 $ intros
->> `[unfold min max]
+>> `[simp only [min_def, max_def]]
 >> try `[simp [*, if_pos, if_neg]]
 >> try `[apply le_refl]
 >> try `[apply le_of_not_le, assumption]

--- a/library/init/algebra/order.lean
+++ b/library/init/algebra/order.lean
@@ -187,6 +187,14 @@ section linear_order
 ### Definition of `linear_order` and lemmas about types with a linear order
 -/
 
+/-- Default definition of `max`. -/
+def max_default {α : Type u} [has_le α] [decidable_rel ((≤) : α → α → Prop)] (a b : α) :=
+if b ≤ a then a else b
+
+/-- Default definition of `min`. -/
+def min_default {α : Type u} [has_le α] [decidable_rel ((≤) : α → α → Prop)] (a b : α) :=
+if a ≤ b then a else b
+
 /-- A linear order is reflexive, transitive, antisymmetric and total relation `≤`.
 We assume that every linear ordered type has decidable `(≤)`, `(<)`, and `(=)`. -/
 class linear_order (α : Type u) extends partial_order α :=
@@ -195,6 +203,10 @@ class linear_order (α : Type u) extends partial_order α :=
 (decidable_eq : decidable_eq α := @decidable_eq_of_decidable_le _ _ decidable_le)
 (decidable_lt : decidable_rel ((<) : α → α → Prop) :=
     @decidable_lt_of_decidable_le _ _ decidable_le)
+(max : α → α → α := @max_default α _ _)
+(max_def : max = @max_default α _ decidable_le . tactic.reflexivity')
+(min : α → α → α := @min_default α _ _)
+(min_def : min = @min_default α _ decidable_le . tactic.reflexivity')
 
 variables [linear_order α]
 

--- a/library/init/meta/relation_tactics.lean
+++ b/library/init/meta/relation_tactics.lean
@@ -21,6 +21,8 @@ do tgt   ← target >>= instantiate_mvars,
 meta def reflexivity (md := semireducible) : tactic unit :=
 relation_tactic md environment.refl_for "reflexivity"
 
+meta def reflexivity' : tactic unit := reflexivity
+
 meta def symmetry (md := semireducible) : tactic unit :=
 relation_tactic md environment.symm_for "symmetry"
 


### PR DESCRIPTION
This way we can solve some diamonds (e.g., `sup` coming from `@lattice_of_linear_order (with_top α) _` is not defeq to the one coming from `with_top.lattice`).