### PR TITLE
[Merged by Bors] - fix(doc/make/index.md): Pull from leanprover-community for release build

### DIFF
--- a/doc/make/index.md
+++ b/doc/make/index.md
@@ -19,7 +19,7 @@ Generic Build Instructions
 Setting up a basic release build using `make`:
 
 ```bash
-git clone https://github.com/leanprover/lean
+git clone https://github.com/leanprover-community/lean
 cd lean
 mkdir -p build/release
 cd build/release


### PR DESCRIPTION
I am on an M1 mac. Installing via the [recommended method](https://leanprover-community.github.io/install/macos.html) fails due to elan install failing. Pulling from the leanprover git also failed to work with the tutorials (I think, I'm still new to lean). But pulling from leanprover-community seems to work once I set up PATH correctly.

Notice that the leanprover-community/lean repo is already used for the debug build. Is there a reason its not used for the release build?