### PR TITLE
[Merged by Bors] - feat(ast,scanner): add end-pos support 

### DIFF
--- a/src/frontends/lean/calc.cpp
+++ b/src/frontends/lean/calc.cpp
@@ -134,10 +134,12 @@ static expr parse_next_pred(parser & p, expr const & dummy) {
         p.next();
         expr rhs  = p.parse_expr();
         expr r = mk_implies(p, dummy, rhs, pos);
-        p.set_ast_pexpr(p.new_ast(get_arrow_tk(), pos).push(id).push(p.get_id(rhs)).m_id, r);
+        p.finalize_ast(
+            p.new_ast(get_arrow_tk(), pos).push(id).push(p.get_id(rhs)).m_id,
+            r);
         return r;
     } else {
-        p.set_ast_pexpr(id, dummy);
+        p.finalize_ast(id, dummy);
         return p.parse_led(dummy);
     }
 }
@@ -176,7 +178,7 @@ expr parse_calc(parser & p, pos_info const & calc_pos) {
     } else {
         r = step_proof(step);
     }
-    p.set_ast_pexpr(data.m_id, r);
+    p.finalize_ast(data.m_id, r);
     return r;
 }
 

--- a/src/frontends/lean/decl_attributes.cpp
+++ b/src/frontends/lean/decl_attributes.cpp
@@ -56,7 +56,7 @@ ast_id decl_attributes::parse_core(parser & p, bool compact) {
             expr pre_val = p.parse_expr();
             pre_val = mk_typed_expr(mk_constant(get_nat_name()), pre_val, pre_val.get_tag());
             ast_id id = p.get_id(pre_val);
-            p.set_ast_pexpr(id, pre_val);
+            p.finalize_ast(id, pre_val);
             attr_ast.push(id);
             expr nat = mk_constant(get_nat_name());
             expr val = p.elaborate("_attribute", list<expr>(), pre_val).first;

--- a/src/frontends/lean/definition_cmds.cpp
+++ b/src/frontends/lean/definition_cmds.cpp
@@ -66,7 +66,7 @@ expr parse_equation_lhs(parser & p, ast_data & parent, expr const & fn, buffer<e
     expr lhs = p.mk_app(p.save_pos(mk_explicit(fn), lhs_pos), lhs_args, lhs_pos);
     bool skip_main_fn = true;
     lhs = p.patexpr_to_pattern(lhs, skip_main_fn, locals);
-    p.set_ast_pexpr(data.m_id, lhs);
+    p.finalize_ast(data.m_id, lhs);
     return lhs;
 }
 

--- a/src/frontends/lean/match_expr.cpp
+++ b/src/frontends/lean/match_expr.cpp
@@ -57,7 +57,7 @@ expr parse_match(parser & p, unsigned, expr const *, pos_info const & pos) {
             eqns.push_back(Fun(fn, mk_no_equation()));
             expr f = p.save_pos(mk_equations(header, eqns.size(), eqns.data()), pos);
             expr r = p.mk_app(f, ts, pos);
-            p.set_ast_pexpr(data.m_id, r);
+            p.finalize_ast(data.m_id, r);
             return r;
         }
         if (is_eqn_prefix(p))
@@ -100,7 +100,7 @@ expr parse_match(parser & p, unsigned, expr const *, pos_info const & pos) {
     p.check_token_next(get_end_tk(), "invalid 'match' expression, 'end' expected");
     expr f = p.save_pos(mk_equations(header, eqns.size(), eqns.data()), pos);
     expr r = p.mk_app(f, ts, pos);
-    p.set_ast_pexpr(data.m_id, r);
+    p.finalize_ast(data.m_id, r);
     return r;
 }
 

--- a/src/frontends/lean/parser.cpp
+++ b/src/frontends/lean/parser.cpp
@@ -206,7 +206,7 @@ void parser::check_break_at_pos(break_at_pos_exception::token_context ctxt) {
 void parser::check_break_before(break_at_pos_exception::token_context ctxt) {
     if (!get_complete())
         ctxt = break_at_pos_exception::token_context::none;
-    if (m_break_at_pos && *m_break_at_pos < end_pos())
+    if (m_break_at_pos && *m_break_at_pos < pos())
         throw break_at_pos_exception(*m_break_at_pos, "", ctxt);
 }
 

--- a/src/frontends/lean/parser.cpp
+++ b/src/frontends/lean/parser.cpp
@@ -206,7 +206,7 @@ void parser::check_break_at_pos(break_at_pos_exception::token_context ctxt) {
 void parser::check_break_before(break_at_pos_exception::token_context ctxt) {
     if (!get_complete())
         ctxt = break_at_pos_exception::token_context::none;
-    if (m_break_at_pos && *m_break_at_pos < pos())
+    if (m_break_at_pos && *m_break_at_pos < end_pos())
         throw break_at_pos_exception(*m_break_at_pos, "", ctxt);
 }
 

--- a/src/frontends/lean/parser.h
+++ b/src/frontends/lean/parser.h
@@ -370,7 +370,8 @@ public:
     local_expr_decls const & get_local_expr_decls() const { return m_local_decls; }
 
     /** \brief Return the current position information */
-    virtual pos_info pos() const override final { return pos_info(m_scanner.get_line(), m_scanner.get_pos()); }
+    virtual pos_info pos() const override final { return m_scanner.get_pos_info(); }
+    pos_info end_pos() const { return m_scanner.get_last_end_pos_info(); }
     virtual expr save_pos(expr const & e, pos_info p) override final;
     expr rec_save_pos(expr const & e, pos_info p) override final;
     expr rec_save_pos(expr const & e, optional<pos_info> p) override final { return p ? rec_save_pos(e, *p) : e; }

--- a/src/frontends/lean/parser.h
+++ b/src/frontends/lean/parser.h
@@ -309,7 +309,7 @@ public:
     void init_scanner();
 
     ast_data & new_ast(name type, pos_info start, name value = {});
-    void set_ast_pexpr(ast_id id, expr const & e);
+    void finalize_ast(ast_id id, expr const & e);
     bool is_ast_invalid() { return m_ast_invalid; }
     void set_ast_expr(ast_id id, expr e);
     ast_data & get_ast(ast_id id) { return *m_ast[id]; }

--- a/src/frontends/lean/scanner.cpp
+++ b/src/frontends/lean/scanner.cpp
@@ -713,7 +713,7 @@ void finalize_scanner() {
 auto scanner::scan(environment const & env) -> token_kind {
     m_tokens = &get_token_table(env);
     m_eline = m_line;
-    m_epos = m_spos;
+    m_epos = m_upos;
     while (true) {
         uchar c = curr();
         m_pos  = m_upos;

--- a/src/frontends/lean/scanner.cpp
+++ b/src/frontends/lean/scanner.cpp
@@ -712,6 +712,8 @@ void finalize_scanner() {
 
 auto scanner::scan(environment const & env) -> token_kind {
     m_tokens = &get_token_table(env);
+    m_eline = m_line;
+    m_epos = m_spos;
     while (true) {
         uchar c = curr();
         m_pos  = m_upos;
@@ -773,6 +775,8 @@ scanner::scanner(std::istream & strm, char const * strm_name):
     if (m_sline == 0) m_sline = 1;
     m_line = m_sline;
     m_pos = 0;
+    m_epos = 0;
+    m_eline = 0;
     lean_assert(pos_info(get_line(), get_pos()) == pos_info(1, 0));
 }
 

--- a/src/frontends/lean/scanner.h
+++ b/src/frontends/lean/scanner.h
@@ -45,6 +45,9 @@ protected:
     int                 m_pos;   // start position of the token
     int                 m_line;  // line of the token
 
+    int                 m_epos;  // end position of the *last* token
+    int                 m_eline; // end line of the *last* token
+
     name                m_name_val;
     token_info          m_token_info;
     mpq                 m_num_val;
@@ -94,7 +97,9 @@ public:
 
     int get_line() const { return m_line; }
     int get_pos() const { return m_pos; }
-    pos_info get_pos_info() const { return pos_info(m_line, m_pos); }
+    int get_last_end_pos() const { return m_epos; }
+    pos_info get_pos_info() const { return {m_line, m_pos}; }
+    pos_info get_last_end_pos_info() const { return {m_eline, m_epos}; }
     token_kind scan(environment const & env);
 
     mpq const & get_num_val() const { return m_num_val; }

--- a/src/frontends/lean/tactic_notation.cpp
+++ b/src/frontends/lean/tactic_notation.cpp
@@ -294,8 +294,7 @@ struct parse_tactic_fn {
             if (m_use_istep) r = mk_tactic_istep(m_p, r, pos, pos, m_tac_class);
         }
         if (save_info) r = concat(mk_tactic_save_info(m_p, pos, m_tac_class), r, pos);
-        id_ast.m_end = m_p.end_pos();
-        m_p.set_ast_pexpr(id, r);
+        m_p.finalize_ast(id, r);
         return r;
     }
 
@@ -318,7 +317,7 @@ struct parse_tactic_fn {
                 expr info_tac = mk_tactic_save_info(m_p, pos, m_tac_class);
                 next_tac = concat(info_tac, next_tac, pos);
             }
-            m_p.set_ast_pexpr(id, next_tac);
+            m_p.finalize_ast(id, next_tac);
             return next_tac;
         } else if (m_p.curr_is_token(get_lbracket_tk())) {
             auto pos = m_p.pos();
@@ -338,7 +337,7 @@ struct parse_tactic_fn {
             expr r = mk_lean_list(m_p, args, pos);
             expr type = mk_app(mk_constant(get_list_name()), mk_tactic_unit(m_tac_class));
             r = m_p.save_pos(mk_typed_expr(type, r), pos);
-            m_p.set_ast_pexpr(data.m_id, r);
+            m_p.finalize_ast(data.m_id, r);
             return r;
         } else {
             if (m_p.curr_is_token(get_by_tk())) {
@@ -354,7 +353,7 @@ struct parse_tactic_fn {
                     expr info_tac = mk_tactic_save_info(m_p, pos, m_tac_class);
                     tac = concat(info_tac, tac, pos);
                 }
-                m_p.set_ast_pexpr(data.m_id, tac);
+                m_p.finalize_ast(data.m_id, tac);
                 return tac;
             } else {
                 return parse_elem_core(save_info);
@@ -372,8 +371,7 @@ struct parse_tactic_fn {
             data.push(m_p.get_id(curr));
             r         = orelse(r, curr, start_pos);
         }
-        data.m_end = m_p.end_pos();
-        m_p.set_ast_pexpr(data.m_id, r);
+        m_p.finalize_ast(data.m_id, r);
         return r;
     }
 
@@ -397,8 +395,7 @@ struct parse_tactic_fn {
                 ex.report_goal_pos(*pos);
             throw;
         }
-        data.m_end = m_p.end_pos();
-        m_p.set_ast_pexpr(data.m_id, r);
+        m_p.finalize_ast(data.m_id, r);
         return r;
     }
 
@@ -585,7 +582,7 @@ struct parse_begin_end_block_fn {
                 r = copy_tag(r, mk_tactic_execute(r, m_tac_class));
             }
         }
-        m_p.set_ast_pexpr(group.m_id, r);
+        m_p.finalize_ast(group.m_id, r);
         return r;
     }
 };
@@ -629,7 +626,7 @@ expr parse_by(parser & p, unsigned, expr const *, pos_info const & pos) {
         expr type = mk_tactic_unit(get_tactic_name());
         expr r    = p.save_pos(mk_typed_expr(type, tac), tac_pos);
         r = p.save_pos(mk_by(r), pos);
-        p.set_ast_pexpr(id, r);
+        p.finalize_ast(id, r);
         return r;
     } catch (break_at_pos_exception & ex) {
         ex.report_goal_pos(tac_pos);
@@ -676,7 +673,7 @@ expr parse_interactive_tactic_block(parser & p, unsigned, expr const *, pos_info
         r = p.mk_app({p.save_pos(mk_constant(get_has_bind_and_then_name()), pos), r, next}, pos);
     }
     p.check_token_next(get_rbracket_tk(), "invalid auto-quote tactic block, ']' expected");
-    p.set_ast_pexpr(data.m_id, r);
+    p.finalize_ast(data.m_id, r);
     return r;
 }
 

--- a/src/frontends/lean/tactic_notation.cpp
+++ b/src/frontends/lean/tactic_notation.cpp
@@ -294,6 +294,7 @@ struct parse_tactic_fn {
             if (m_use_istep) r = mk_tactic_istep(m_p, r, pos, pos, m_tac_class);
         }
         if (save_info) r = concat(mk_tactic_save_info(m_p, pos, m_tac_class), r, pos);
+        id_ast.m_end = m_p.end_pos();
         m_p.set_ast_pexpr(id, r);
         return r;
     }
@@ -371,6 +372,7 @@ struct parse_tactic_fn {
             data.push(m_p.get_id(curr));
             r         = orelse(r, curr, start_pos);
         }
+        data.m_end = m_p.end_pos();
         m_p.set_ast_pexpr(data.m_id, r);
         return r;
     }
@@ -395,6 +397,7 @@ struct parse_tactic_fn {
                 ex.report_goal_pos(*pos);
             throw;
         }
+        data.m_end = m_p.end_pos();
         m_p.set_ast_pexpr(data.m_id, r);
         return r;
     }

--- a/src/frontends/lean/user_notation.cpp
+++ b/src/frontends/lean/user_notation.cpp
@@ -89,7 +89,7 @@ static environment add_user_notation(environment const & env, name const & d, un
                     data.push(id);
                     expr r = to_expr(obj);
                     r.set_tag(nulltag);
-                    p.set_ast_pexpr(data.m_id, r);
+                    p.finalize_ast(data.m_id, r);
                     return r;
                 } catch (formatted_exception const & ex) {
                     if (ex.get_pos() && *ex.get_pos() >= pos) {

--- a/src/library/tactic/user_attribute.cpp
+++ b/src/library/tactic/user_attribute.cpp
@@ -76,7 +76,7 @@ public:
         p2.get_ast(id).m_value = m_decl;
         expr param = to_expr(obj);
         param.set_tag(nulltag);
-        p2.set_ast_pexpr(id, param);
+        p2.finalize_ast(id, param);
         parent.push(id);
         return attr_data_ptr(new user_attribute_data(param));
     }

--- a/src/library/vm/vm_parser.cpp
+++ b/src/library/vm/vm_parser.cpp
@@ -73,7 +73,7 @@ expr parse_interactive_param(parser & p, ast_data & parent, expr const & param_t
             r = mk_as_is(r);
         }
         r.set_tag(nulltag);
-        p.set_ast_pexpr(id, r);
+        p.finalize_ast(id, r);
         parent.push(id);
         return r;
     } catch (exception & ex) {


### PR DESCRIPTION
This adds end position support to the scanner and therefore the AST nodes. There's actually "two different" proposals in this PR for how this is implemented outside the scanner (in the two separate commits); the first is very light and definitely works, but is only implemented for `tactic`s, `<|>` and `;` (my usecase in Alectryon).

The second commit hijacks `set_ast_pexpr` to also set the AST's position `m_end`, but I'm not sure in what variety of ways this method is used and so it may give (and as far as I can see, somewhat does) give some false results, but it's at least correct in the above 3 settings.

I also modified `check_break_before` to use this new end-pos; this means that, for example, something like this:

```lean
example : 0 = 1 :=
begin
  symmetry           ,
  sorry

  --some comment
end
```

if you have the cursor anywhere between the `symmetry` and the comma, the tactic state will show the state <after> the symmetry, and similarly after the `sorry` token ends (although the "goals accomplished!" text can sometimes not show up). I think that I should do something similar for `check_break_at_pos`, but I left it for now as I don't wanna accidentally break too much. 

