### PR TITLE
[Merged by Bors] - fix(library/init/meta/relation_tactics): drop `tactic.reflexivity'`

### DIFF
--- a/library/init/algebra/order.lean
+++ b/library/init/algebra/order.lean
@@ -204,9 +204,9 @@ class linear_order (α : Type u) extends partial_order α :=
 (decidable_lt : decidable_rel ((<) : α → α → Prop) :=
     @decidable_lt_of_decidable_le _ _ decidable_le)
 (max : α → α → α := @max_default α _ _)
-(max_def : max = @max_default α _ decidable_le . tactic.reflexivity')
+(max_def : max = @max_default α _ decidable_le . tactic.interactive.reflexivity)
 (min : α → α → α := @min_default α _ _)
-(min_def : min = @min_default α _ decidable_le . tactic.reflexivity')
+(min_def : min = @min_default α _ decidable_le . tactic.interactive.reflexivity)
 
 variables [linear_order α]
 

--- a/library/init/meta/relation_tactics.lean
+++ b/library/init/meta/relation_tactics.lean
@@ -21,8 +21,6 @@ do tgt   ← target >>= instantiate_mvars,
 meta def reflexivity (md := semireducible) : tactic unit :=
 relation_tactic md environment.refl_for "reflexivity"
 
-meta def reflexivity' : tactic unit := reflexivity
-
 meta def symmetry (md := semireducible) : tactic unit :=
 relation_tactic md environment.symm_for "symmetry"
 


### PR DESCRIPTION
We have `tactic.reflexivity'` in `mathlib`, and we can use `tactic.interactive.reflexivity` here.