### PR TITLE
[Merged by Bors] - fix(library/module): add_decl adds parent namespaces

### DIFF
--- a/src/frontends/lean/decl_cmds.cpp
+++ b/src/frontends/lean/decl_cmds.cpp
@@ -146,7 +146,6 @@ static environment declare_var(parser & p, environment env,
         }
         if (meta.m_modifiers.m_is_protected)
             env = add_protected(env, full_n);
-        env = ensure_decl_namespaces(env, full_n);
         /* Apply attributes last so that they may access any information on the new decl */
         env = meta.m_attrs.apply(env, p.ios(), full_n);
         return env;

--- a/src/frontends/lean/definition_cmds.cpp
+++ b/src/frontends/lean/definition_cmds.cpp
@@ -44,12 +44,6 @@ Author: Leonardo de Moura
 #include "frontends/lean/definition_cmds.h"
 
 namespace lean {
-environment ensure_decl_namespaces(environment const & env, name const & full_n) {
-    if (full_n.is_atomic())
-        return env;
-    return add_namespace(env, full_n.get_prefix());
-}
-
 expr parse_equation_lhs(parser & p, ast_data & parent, expr const & fn, buffer<expr> & locals) {
     auto lhs_pos = p.pos();
     buffer<expr> lhs_args;
@@ -286,10 +280,6 @@ declare_definition(parser_info const & p, environment const & env, decl_cmd_kind
         new_env = add_protected(new_env, c_real_name);
 
     new_env = add_alias(new_env, meta.m_modifiers.m_is_protected, c_name, c_real_name);
-
-    if (!meta.m_modifiers.m_is_private) {
-        new_env = ensure_decl_namespaces(new_env, c_real_name);
-    }
 
     new_env = compile_decl(p, new_env, c_name, c_real_name, pos);
     if (meta.m_doc_string) {

--- a/src/frontends/lean/definition_cmds.h
+++ b/src/frontends/lean/definition_cmds.h
@@ -12,6 +12,4 @@ namespace lean {
 environment definition_cmd_core(parser & p, decl_cmd_kind k, ast_id cmd_id, cmd_meta const & meta);
 
 environment single_definition_cmd_core(parser_info & p, decl_cmd_kind kind, ast_data * parent, cmd_meta meta);
-
-environment ensure_decl_namespaces(environment const & env, name const & full_n);
 }

--- a/src/library/module.cpp
+++ b/src/library/module.cpp
@@ -18,6 +18,7 @@ Author: Leonardo de Moura
 #include "util/sstream.h"
 #include "util/buffer.h"
 #include "util/interrupt.h"
+#include "util/name.h"
 #include "util/name_map.h"
 #include "util/file_lock.h"
 #include "kernel/type_checker.h"
@@ -530,7 +531,7 @@ environment add(environment const & env, certified_declaration const & d) {
     if (!check_computable(new_env, _d.get_name()))
         new_env = mark_noncomputable(new_env, _d.get_name());
     if (!is_private(new_env, _d.get_name()))
-        new_env = add_parent_namespaces(new_env, _d.get_name());
+        new_env = add_parent_namespaces(new_env, strip_internal_suffixes(_d.get_name()));
     new_env = update_module_defs(new_env, _d);
     new_env = add(new_env, std::make_shared<decl_modification>(_d, env.trust_lvl()));
 

--- a/src/library/module.cpp
+++ b/src/library/module.cpp
@@ -24,6 +24,7 @@ Author: Leonardo de Moura
 #include "kernel/quotient/quotient.h"
 #include "library/module.h"
 #include "library/noncomputable.h"
+#include "library/private.h"
 #include "library/sorry.h"
 #include "library/constants.h"
 #include "library/kernel_serializer.h"
@@ -528,6 +529,8 @@ environment add(environment const & env, certified_declaration const & d) {
     declaration _d = d.get_declaration();
     if (!check_computable(new_env, _d.get_name()))
         new_env = mark_noncomputable(new_env, _d.get_name());
+    if (!is_private(new_env, _d.get_name()))
+        new_env = add_parent_namespaces(new_env, _d.get_name());
     new_env = update_module_defs(new_env, _d);
     new_env = add(new_env, std::make_shared<decl_modification>(_d, env.trust_lvl()));
 

--- a/src/library/scoped_ext.cpp
+++ b/src/library/scoped_ext.cpp
@@ -143,6 +143,12 @@ environment add_namespace(environment const & env, name const & ns) {
     }
 }
 
+environment add_parent_namespaces(environment const & env, name const & full_n) {
+    if (full_n.is_atomic())
+        return env;
+    return add_namespace(env, full_n.get_prefix());
+}
+
 environment push_scope(environment const & env, io_state const & ios, scope_kind k, name const & n) {
     name new_n = get_namespace(env);
     if (k == scope_kind::Namespace)

--- a/src/library/scoped_ext.cpp
+++ b/src/library/scoped_ext.cpp
@@ -144,7 +144,7 @@ environment add_namespace(environment const & env, name const & ns) {
 }
 
 environment add_parent_namespaces(environment const & env, name const & full_n) {
-    if (full_n.is_atomic())
+    if (full_n.is_anonymous() || full_n.is_atomic())
         return env;
     return add_namespace(env, full_n.get_prefix());
 }

--- a/src/library/scoped_ext.h
+++ b/src/library/scoped_ext.h
@@ -40,6 +40,9 @@ bool has_open_scopes(environment const & env);
 /** \brief Add a new namespace (if it does not exist) */
 environment add_namespace(environment const & env, name const & ns);
 
+/** \brief Add all parents of a given name as new namespaces */
+environment add_parent_namespaces(environment const & env, name const & full_n);
+
 name const & get_namespace(environment const & env);
 name const & get_scope_header(environment const & env);
 /** \brief Return the current stack of namespaces.

--- a/src/util/name.cpp
+++ b/src/util/name.cpp
@@ -558,11 +558,24 @@ name read_name(deserializer & d) {
 bool is_internal_name(name const & n) {
     name it = n;
     while (!it.is_anonymous()) {
-        if (!it.is_anonymous() && it.is_string() && it.get_string() && it.get_string()[0] == '_')
+        if (it.is_string() && it.get_string() && it.get_string()[0] == '_')
             return true;
         it = it.get_prefix();
     }
     return false;
+}
+
+name strip_internal_suffixes(name const & n) {
+    name it = n;
+    bool is_internal = false;
+    while (!it.is_anonymous() && !(it.is_string() && it.get_string() &&
+        !(it.get_string()[0] == '_' ||
+            // HACK(Mario): foo.equations._eqn_1 ~> foo
+            (is_internal && strcmp(it.get_string(), "equations") == 0)))) {
+        it = it.get_prefix();
+        is_internal = true;
+    }
+    return it;
 }
 
 void initialize_name() {

--- a/src/util/name.h
+++ b/src/util/name.h
@@ -271,6 +271,9 @@ inline deserializer & operator>>(deserializer & d, name & n) { n = read_name(d);
 /** \brief Return true if it is a lean internal name, i.e., the name starts with a `_` */
 bool is_internal_name(name const & n);
 
+/** \brief Remove internal suffixes from the name (non-string components or names starting with `_`) */
+name strip_internal_suffixes(name const & n);
+
 void initialize_name();
 void finalize_name();
 }

--- a/tests/lean/run/add_decl_namespace.lean
+++ b/tests/lean/run/add_decl_namespace.lean
@@ -1,0 +1,14 @@
+
+namespace A
+
+def x := 1
+
+def _root_.B.x := 1
+
+end A
+
+def C.x := 1
+
+run_cmd tactic.add_aux_decl `D.x `(ℕ) `(1) ff
+
+open A B C D


### PR DESCRIPTION
This fixes an issue where declarations `foo.bar.x` added using `tactic.add_decl` will not have their parents `foo` and `foo.bar` registered as namespaces, so `open foo` will fail. We fix this by moving the logic for adding these namespaces from the frontend command to the low level command, so that all ways to add declarations get the same treatment.