### PR TITLE
chore(library/scoped_ext): resolve `open` like `decl`

### DIFF
--- a/library/init/meta/converter/interactive.lean
+++ b/library/init/meta/converter/interactive.lean
@@ -29,7 +29,7 @@ tactic.solve1 $ c >> tactic.try (tactic.any_goals tactic.reflexivity)
 namespace interactive
 open lean
 open lean.parser
-open interactive
+open _root_.interactive
 open interactive.types
 open tactic_result
 
@@ -179,7 +179,7 @@ namespace tactic
 namespace interactive
 open lean
 open lean.parser
-open interactive
+open _root_.interactive
 open interactive.types
 open tactic
 local postfix `?`:9001 := optional

--- a/library/init/meta/interactive.lean
+++ b/library/init/meta/interactive.lean
@@ -83,7 +83,7 @@ in match q with
 end
 
 namespace interactive
-open interactive interactive.types expr
+open _root_.interactive interactive.types expr
 
 /--
 itactic: parse a nested "interactive" tactic. That is, parse
@@ -1257,7 +1257,7 @@ prod.snd <$> (mk_simp_set_core no_dflt attr_names hs ff)
 end mk_simp_set
 
 namespace interactive
-open interactive interactive.types expr
+open _root_.interactive interactive.types expr
 
 meta def simp_core_aux (cfg : simp_config) (discharger : tactic unit) (s : simp_lemmas) (u : list name) (hs : list expr) (tgt : bool) : tactic name_set :=
 do (to_remove, lmss) ← @list.mfoldl tactic _ (list expr × name_set) _ (λ ⟨hs, lms⟩ h,
@@ -1515,7 +1515,7 @@ structure unfold_config extends simp_config :=
 (constructor_eq     := ff)
 
 namespace interactive
-open interactive interactive.types expr
+open _root_.interactive interactive.types expr
 
 /--
 Given defined constants `e₁ ... eₙ`, `unfold e₁ ... eₙ` iteratively unfolds all occurrences in the target of the main goal, using equational lemmas associated with the definitions.

--- a/library/init/meta/smt/interactive.lean
+++ b/library/init/meta/smt/interactive.lean
@@ -38,7 +38,7 @@ meta instance : interactive.executor smt_tactic :=
 
 namespace interactive
 open lean.parser
-open interactive
+open _root_.interactive
 open interactive.types
 local postfix `?`:9001 := optional
 local postfix *:9001 := many

--- a/library/init/meta/tactic.lean
+++ b/library/init/meta/tactic.lean
@@ -119,7 +119,7 @@ meta def executor.execute_with_explicit (m : Type → Type u)
 executor.execute_with
 
 /-- Default `executor` instance for `tactic`s themselves -/
-meta instance : executor tactic :=
+meta instance executor_tactic : executor tactic :=
 { config_type := unit,
   inhabited := ⟨()⟩,
   execute_with := λ _, id }

--- a/src/library/scoped_ext.cpp
+++ b/src/library/scoped_ext.cpp
@@ -74,18 +74,6 @@ bool is_namespace(environment const & env, name const & n) {
     return get_extension(env).m_namespace_set.contains(n);
 }
 
-optional<name> to_valid_namespace_name(environment const & env, name const & n) {
-    scope_mng_ext const & ext = get_extension(env);
-    if (ext.m_namespace_set.contains(n))
-        return optional<name>(n);
-    for (auto const & ns : ext.m_namespaces) {
-        name r = ns + n;
-        if (ext.m_namespace_set.contains(r))
-            return optional<name>(r);
-    }
-    return optional<name>();
-}
-
 std::vector<name> get_namespace_completion_candidates(environment const & env) {
     std::vector<name> ret;
     scope_mng_ext const & ext = get_extension(env);

--- a/src/library/scoped_ext.h
+++ b/src/library/scoped_ext.h
@@ -53,16 +53,6 @@ name const & get_scope_header(environment const & env);
 list<name> const & get_namespaces(environment const & env);
 bool in_section(environment const & env);
 
-/** \brief Check if \c n may be a reference to a namespace, if it is return it.
-    The procedure checks if \c n is a registered namespace, if it is not, it tries
-    to prefix \c n with each prefix in the current scope. Example: suppose the scope is:
-       namespace foo
-         namespace bla
-           namespace boo
-              ...
-    Then, the procedure tries n, 'foo.bla.boo'+n, 'foo.bla'+n, 'foo'+n. */
-optional<name> to_valid_namespace_name(environment const & env, name const & n);
-
 std::vector<name> get_namespace_completion_candidates(environment const & env);
 
 /** \brief Mark the given namespace as opened */

--- a/tests/lean/run/resolve_open.lean
+++ b/tests/lean/run/resolve_open.lean
@@ -1,0 +1,29 @@
+prelude
+import init.core
+
+def A.a := 1
+def B.b := 1
+def C.c := 1
+def foo.A.a := 2
+def foo.B.b := 2
+def foo.bar.A.a := 3
+
+namespace foo
+namespace bar
+
+section open A B C
+example : a = 3 := rfl
+example : b = 2 := rfl
+example : c = 1 := rfl
+end
+
+section open _root_.A
+example : a = 1 := rfl
+end
+
+section open _root_.foo.A
+example : a = 2 := rfl
+end
+
+end bar
+end foo


### PR DESCRIPTION
This changes the namespace resolution for namespaces in `open foo` to prefer the current stack of namespaces over the root, to match name resolution in declarations. Like declarations, you can use `open _root_.foo` to override this and open the namespace named `foo` even if you are in a namespace `bar` and the namespace `bar.foo` exists.