### PR TITLE
[Merged by Bors] - chore(library/init/data/prod): drop `prod.has_lt`

### DIFF
--- a/library/init/data/prod.lean
+++ b/library/init/data/prod.lean
@@ -27,19 +27,6 @@ instance [h₁ : decidable_eq α] [h₂ : decidable_eq β] : decidable_eq (α ×
   | (is_false n₁) := is_false (assume h, prod.no_confusion h (λ e₁' e₂', absurd e₁' n₁))
   end
 
-instance [has_lt α] [has_lt β] : has_lt (α × β) :=
-⟨λ s t, s.1 < t.1 ∨ (s.1 = t.1 ∧ s.2 < t.2)⟩
-
-instance prod_has_decidable_lt
-         [has_lt α] [has_lt β]
-         [decidable_eq α] [decidable_eq β]
-         [decidable_rel ((<) : α → α → Prop)]
-         [decidable_rel ((<) : β → β → Prop)] : Π s t : α × β, decidable (s < t) :=
-λ t s, or.decidable
-
-lemma prod.lt_def [has_lt α] [has_lt β] (s t : α × β) : (s < t) = (s.1 < t.1 ∨ (s.1 = t.1 ∧ s.2 < t.2)) :=
-rfl
-
 end
 
 def {u₁ u₂ v₁ v₂} prod.map {α₁ : Type u₁} {α₂ : Type u₂} {β₁ : Type v₁} {β₂ : Type v₂}

--- a/tests/lean/run/local_shadowing_projection.lean
+++ b/tests/lean/run/local_shadowing_projection.lean
@@ -1,3 +1,5 @@
+instance : has_lt (nat × nat) := { lt := λ a b, a.1 < b.1 ∨ a.1 = b.1 ∧ a.2 < b.2 }
+
 def prod.cmp (a b : nat × nat) : ordering :=
 cmp a b
 

--- a/tests/lean/run/rb_map1.lean
+++ b/tests/lean/run/rb_map1.lean
@@ -32,6 +32,7 @@ end
 
 section
 open native.rb_map
+instance : has_lt (nat × nat) := { lt := λ a b, a.1 < b.1 ∨ a.1 = b.1 ∧ a.2 < b.2 }
 -- Mapping from (nat × nat) → nat
 meta definition m3 := insert (insert (mk (nat × nat) nat) (1, 2) 3) (2, 2) 4
 


### PR DESCRIPTION
The old `prod.has_lt` defined the lexicographical order on `α × β` while we use `x ≤ y ↔ x.1 ≤ y.1 ∧ x.2 ≤ y.2` in `mathlib`.