### PR TITLE
doc(library/init/meta/interactive): improve repeat documentation

### DIFF
--- a/library/init/meta/interactive.lean
+++ b/library/init/meta/interactive.lean
@@ -881,8 +881,8 @@ end
 
 /--
 `repeat { t }` applies `t` to each goal. If the application succeeds,
-the tactic is applied recursively to all the generated subgoals until it eventually fails.
-The recursion stops in a subgoal when the tactic has failed to make progress.
+the tactic is applied recursively to all the generated subgoals until it eventually fails or `t` 
+closes the goal.
 The tactic `repeat { t }` never fails.
 -/
 meta def repeat : itactic → tactic unit :=

--- a/library/init/meta/interactive.lean
+++ b/library/init/meta/interactive.lean
@@ -881,8 +881,8 @@ end
 
 /--
 `repeat { t }` applies `t` to each goal. If the application succeeds,
-the tactic is applied recursively to all the generated subgoals until it eventually fails or `t` 
-closes the goal.
+the tactic is applied recursively to all the generated subgoals until it eventually fails or
+there are no more subgoals.
 The tactic `repeat { t }` never fails.
 -/
 meta def repeat : itactic → tactic unit :=


### PR DESCRIPTION
Per the discussion [here](https://leanprover.zulipchat.com/#narrow/stream/113489-new-members/topic/.E2.9C.94.20repeat/near/253898059), the `repeat { t }` tactic does not actually depend on whether or not `t` makes progress, and the iteration will terminate if `t` finishes a goal. I have edited the docstring to hopefully make this more clear.