### PR TITLE
[Merged by Bors] - fix(library/init/meta/tactic): improve by_contradiction

### DIFF
--- a/library/init/meta/tactic.lean
+++ b/library/init/meta/tactic.lean
@@ -1480,9 +1480,10 @@ notation `dec_trivial` := of_as_true (by tactic.triv)
 
 meta def by_contradiction (H : name) : tactic expr :=
 do tgt ← target,
-  (match_not tgt $> ()) <|>
+  tgt_wh ← whnf tgt, -- to ensure that `not` in `ne` is found
+  (match_not tgt_wh $> ()) <|>
   (mk_mapp `decidable.by_contradiction [some tgt, none] >>= eapply >> skip) <|>
-  applyc ``classical.by_contradiction <|>
+  (mk_mapp `classical.by_contradiction [some tgt] >>= eapply >> skip) <|>
   fail "tactic by_contradiction failed, target is not a proposition",
   intro H
 

--- a/library/init/meta/tactic.lean
+++ b/library/init/meta/tactic.lean
@@ -1480,7 +1480,7 @@ notation `dec_trivial` := of_as_true (by tactic.triv)
 
 meta def by_contradiction (H : name) : tactic expr :=
 do tgt ← target,
-  tgt_wh ← whnf tgt, -- to ensure that `not` in `ne` is found
+  tgt_wh ← whnf tgt reducible, -- to ensure that `not` in `ne` is found
   (match_not tgt_wh $> ()) <|>
   (mk_mapp `decidable.by_contradiction [some tgt, none] >>= eapply >> skip) <|>
   (mk_mapp `classical.by_contradiction [some tgt] >>= eapply >> skip) <|>

--- a/tests/lean/by_contradiction.lean
+++ b/tests/lean/by_contradiction.lean
@@ -24,3 +24,26 @@ by do
   by_contradiction `H,
   trace_state,
   contradiction
+
+-- following tests use interactive mode so that we can use `guard_hyp`
+
+
+/-- `by_contradiction` should unfold reducible defs like `ne` to find a leading `not`. --/
+example (a b : nat) : a ≠ b → a ≠ b :=
+begin
+  intros,
+  by_contradiction H,
+  guard_hyp H : a = b,
+  contradiction
+end
+
+def my_ne (a b : nat) := a ≠ b
+
+/-- Semireducible defs are not unfolded -/
+example (a b : nat) : a ≠ b → my_ne a b :=
+begin
+  intros,
+  by_contradiction H,
+  guard_hyp H : ¬my_ne a b,
+  contradiction
+end


### PR DESCRIPTION
Two fixes here:

* With a goal of `x ≠ y` this now produces `h : x = y` not `h : ¬(x ≠ y)`. Previously this would only happen if `ne.def` was unfolded first
* `classical.by_contradiction` is now elaborated in the same way as `decidable.by_contradiction`.

---

I have no idea if `whnf` is the best way to solve the first bullet.