### PR TITLE
feat: export tleans in parallel

### DIFF
--- a/src/library/ast_exporter.cpp
+++ b/src/library/ast_exporter.cpp
@@ -198,7 +198,6 @@ std::string json_of_lean(std::string const & lean_fn) {
 void export_ast(parser const & p) {
     if (p.m_ast.empty() || p.m_ast_invalid) return;
     auto ast_fn = json_of_lean(p.m_file_name);
-    std::cerr << "exporting " << ast_fn << std::endl;
     exclusive_file_lock output_lock(ast_fn);
     std::ofstream out(ast_fn);
     ast_exporter(p.m_ast, p.m_tag_ast_table, p.m_tactic_log.get()).write_ast(out);

--- a/src/library/module_mgr.h
+++ b/src/library/module_mgr.h
@@ -54,6 +54,7 @@ struct module_info {
     };
     task<parse_result> m_result;
     gtask m_ast_export;
+    gtask m_tlean_export;
 
     optional<module_parser_result> m_snapshots;
 
@@ -97,6 +98,7 @@ class module_mgr {
     bool m_use_old_oleans = false;
     bool m_report_widgets = true;
     bool m_export_ast = false;
+    bool m_export_tlean = false;
 
     search_path m_path;
     environment m_initial_env;
@@ -144,6 +146,7 @@ public:
     void set_report_widgets(bool report_widgets) { m_report_widgets = report_widgets; }
     bool get_report_widgets() const { return m_report_widgets; }
     void set_export_ast(bool export_ast) { m_export_ast = export_ast; }
+    void set_export_tlean(bool export_tlean) { m_export_tlean = export_tlean; }
 
     environment get_initial_env() const { return m_initial_env; }
     options get_options() const { return m_ios.get_options(); }

--- a/src/shell/lean.cpp
+++ b/src/shell/lean.cpp
@@ -641,6 +641,7 @@ int main(int argc, char ** argv) {
         module_mgr mod_mgr(&vfs, lt.get_root(), path.get_path(), env, ios);
         mod_mgr.set_use_old_oleans(use_old_oleans);
         mod_mgr.set_export_ast(export_ast);
+        mod_mgr.set_export_tlean(export_tlean);
         set_global_module_mgr(mod_mgr);
 
         if (run_arg) {
@@ -759,19 +760,6 @@ int main(int argc, char ** argv) {
         //     // this code is now broken
         //     env = lean::set_native_module_path(env, lean::name(native_output));
         // }
-
-        if (export_tlean) {
-            for (auto & mod : mods) {
-                auto res = get(mod.m_mod_info->m_result);
-                auto tlean_fn = tlean_of_lean(mod.m_id);
-                std::cerr << "exporting " << tlean_fn << std::endl;
-                exclusive_file_lock output_lock(tlean_fn);
-                std::ofstream out(tlean_fn);
-                write_module_tlean(*res.m_loaded_module, out);
-                out.close();
-                if (!out) throw exception(sstream() << "failed to write tlean file: " << tlean_fn);
-            }
-        }
 
         if (export_txt && !mods.empty()) {
             buffer<std::shared_ptr<module_info const>> mod_infos;


### PR DESCRIPTION
Previously, the tleans were exported in sequence with a single-thread. On computers with many cores, the exporting cost was a significant and unnecessary bottleneck.