### PR TITLE
refactor(init/algebra/order): remove decidable instances from linear_order

### DIFF
--- a/library/init/algebra/functions.lean
+++ b/library/init/algebra/functions.lean
@@ -9,20 +9,18 @@ import init.algebra.order init.meta
 
 universe u
 
-export linear_order (min max)
-
 section
 open decidable tactic
-variables {α : Type u} [linear_order α]
+variables {α : Type u} [linear_order α] [decidable_rel ((≤) : α → α → Prop)]
 
-lemma min_def (a b : α) : min a b = if a ≤ b then a else b :=
-by rw [congr_fun linear_order.min_def a, min_default]
-lemma max_def (a b : α) : max a b = if b ≤ a then a else b :=
-by rw [congr_fun linear_order.max_def a, max_default]
+-- lemma min_def (a b : α) : min a b = if a ≤ b then a else b :=
+-- by rw [congr_fun linear_order.min_def a, min_default]
+-- lemma max_def (a b : α) : max a b = if b ≤ a then a else b :=
+-- by rw [congr_fun linear_order.max_def a, max_default]
 
 private meta def min_tac_step : tactic unit :=
 solve1 $ intros
->> `[simp only [min_def, max_def]]
+>> `[simp only [min, max]]
 >> try `[simp [*, if_pos, if_neg]]
 >> try `[apply le_refl]
 >> try `[apply le_of_not_le, assumption]
@@ -65,7 +63,7 @@ begin
 end
 
 lemma min_left_comm : ∀ (a b c : α), min a (min b c) = min b (min a c) :=
-left_comm (@min α _) (@min_comm α _) (@min_assoc α _)
+left_comm (@min α _ _) (@min_comm α _ _) (@min_assoc α _ _)
 
 @[simp]
 lemma min_self (a : α) : min a a = a :=
@@ -95,7 +93,7 @@ begin
 end
 
 lemma max_left_comm : ∀ (a b c : α), max a (max b c) = max b (max a c) :=
-left_comm (@max α _) (@max_comm α _) (@max_assoc α _)
+left_comm (@max α _ _) (@max_comm α _ _) (@max_assoc α _ _)
 
 @[simp]
 lemma max_self (a : α) : max a a = a :=

--- a/library/init/data/int/order.lean
+++ b/library/init/data/int/order.lean
@@ -195,10 +195,7 @@ instance : linear_order int :=
   le_antisymm     := @int.le_antisymm,
   lt              := int.lt,
   lt_iff_le_not_le := @int.lt_iff_le_not_le,
-  le_total        := int.le_total,
-  decidable_eq    := int.decidable_eq,
-  decidable_le    := int.decidable_le,
-  decidable_lt    := int.decidable_lt }
+  le_total        := int.le_total, }
 
 lemma eq_nat_abs_of_zero_le {a : ℤ} (h : 0 ≤ a) : a = nat_abs a :=
 let ⟨n, e⟩ := eq_coe_of_zero_le h in by rw e; refl

--- a/library/init/data/nat/lemmas.lean
+++ b/library/init/data/nat/lemmas.lean
@@ -175,10 +175,7 @@ instance : linear_order ℕ :=
   le_antisymm := @nat.le_antisymm,
   le_total := @nat.le_total,
   lt := nat.lt,
-  lt_iff_le_not_le := @nat.lt_iff_le_not_le,
-  decidable_lt               := nat.decidable_lt,
-  decidable_le               := nat.decidable_le,
-  decidable_eq               := nat.decidable_eq }
+  lt_iff_le_not_le := @nat.lt_iff_le_not_le, }
 
 protected lemma eq_zero_of_le_zero {n : nat} (h : n ≤ 0) : n = 0 :=
 le_antisymm h n.zero_le

--- a/tests/lean/run/order_defaults.lean
+++ b/tests/lean/run/order_defaults.lean
@@ -1,21 +1,17 @@
-example : preorder unit := {
-    le := λ _ _, true,
-    le_refl := λ _, trivial,
-    le_trans := λ _ _ _ _ _, trivial,
-}
+example : preorder unit :=
+{ le := λ _ _, true,
+  le_refl := λ _, trivial,
+  le_trans := λ _ _ _ _ _, trivial, }
 
-example : partial_order unit := {
-    le := λ _ _, true,
-    le_refl := λ _, trivial,
-    le_trans := λ _ _ _ _ _, trivial,
-    le_antisymm := by intros a b; intros; cases a; cases b; refl
-}
+example : partial_order unit :=
+{ le := λ _ _, true,
+  le_refl := λ _, trivial,
+  le_trans := λ _ _ _ _ _, trivial,
+  le_antisymm := by intros a b; intros; cases a; cases b; refl }
 
-example : linear_order unit := {
-    le := λ _ _, true,
-    le_refl := λ _, trivial,
-    le_trans := λ _ _ _ _ _, trivial,
-    le_antisymm := by intros a b; intros; cases a; cases b; refl,
-    le_total := λ _ _, or.inl trivial,
-    decidable_le := infer_instance
-}
+example : linear_order unit :=
+{ le := λ _ _, true,
+  le_refl := λ _, trivial,
+  le_trans := λ _ _ _ _ _, trivial,
+  le_antisymm := by intros a b; intros; cases a; cases b; refl,
+  le_total := λ _ _, or.inl trivial }


### PR DESCRIPTION
I have not yet investigated what this does to mathlib!