### PR TITLE
[Merged by Bors] - fix(library/init/meta/tactic.lean): turn comment into docstring

### DIFF
--- a/library/init/meta/tactic.lean
+++ b/library/init/meta/tactic.lean
@@ -516,7 +516,7 @@ meta constant mk_eq_trans   : expr → expr → tactic expr
 meta constant mk_eq_mp      : expr → expr → tactic expr
 /-- (mk_eq_mpr h₁ h₂) is a more efficient version of (mk_app `eq.mpr [h₁, h₂]) -/
 meta constant mk_eq_mpr      : expr → expr → tactic expr
-/- Given a local constant t, if t has type (lhs = rhs) apply substitution.
+/-- Given a local constant t, if t has type (lhs = rhs) apply substitution.
    Otherwise, try to find a local constant that has type of the form (t = t') or (t' = t).
    The tactic fails if the given expression is not a local constant. -/
 meta constant subst_core     : expr → tactic unit


### PR DESCRIPTION
This seems to be a slip, rather than a deliberate decision to not make the comment above `subst_core` into its docstring. It's very rare that I try to read meta code, but today I was trying to understand how `subst` worked and ran into the fact that `subst_core` had no docstring.