### PR TITLE
[Merged by Bors] - fix(library/util): unfold rec args as semireducible

### DIFF
--- a/src/library/util.cpp
+++ b/src/library/util.cpp
@@ -351,7 +351,7 @@ unsigned get_num_inductive_hypotheses_for(environment const & env, name const & 
     lean_assert(rec_mask.empty());
     name I_name = *inductive::is_intro_rule(env, n);
     inductive::inductive_decl decl = *inductive::is_inductive_decl(env, I_name);
-    type_context_old tc(env);
+    type_context_old tc(env, transparency_mode::Semireducible);
     type_context_old::tmp_locals locals(tc);
     expr type   = tc.whnf(env.get(n).get_type());
     unsigned r  = 0;

--- a/tests/lean/run/inductive_unfold.lean
+++ b/tests/lean/run/inductive_unfold.lean
@@ -1,0 +1,2 @@
+inductive T : Prop
+| mk : id T → T


### PR DESCRIPTION
This was causing an assertion violation. It is not clear what the best
fix is, since the code seems to be of two minds about what can be
unfolded, but since the ginductive has a whole error message explaining that
semireducible definitions are supposed to be unfolded, I went with that.