### PR TITLE
[Merged by Bors] - fix(library/constructions/drec): use always_assert

### DIFF
--- a/src/library/constructions/drec.cpp
+++ b/src/library/constructions/drec.cpp
@@ -129,7 +129,7 @@ struct mk_drec_fn {
                     app_args.push_back(local);
                 } else {
                     // inductive hypothesis
-                    lean_assert(j - num_fields < recursive_params.size());
+                    lean_always_assert(j - num_fields < recursive_params.size());
                     expr const & recursive_param = recursive_params[j - num_fields];
                     expr ih_type = mlocal_type(local);
                     buffer<expr> ih_params;

--- a/src/library/util.cpp
+++ b/src/library/util.cpp
@@ -351,7 +351,7 @@ unsigned get_num_inductive_hypotheses_for(environment const & env, name const & 
     lean_assert(rec_mask.empty());
     name I_name = *inductive::is_intro_rule(env, n);
     inductive::inductive_decl decl = *inductive::is_inductive_decl(env, I_name);
-    type_context_old tc(env);
+    type_context_old tc(env, transparency_mode::Semireducible);
     type_context_old::tmp_locals locals(tc);
     expr type   = tc.whnf(env.get(n).get_type());
     unsigned r  = 0;

--- a/tests/lean/run/inductive_unfold.lean
+++ b/tests/lean/run/inductive_unfold.lean
@@ -1,0 +1,2 @@
+inductive T : Prop
+| mk : id T → T


### PR DESCRIPTION
See https://github.com/leanprover-community/lean/pull/653#issuecomment-977713732