### PR TITLE
[Merged by Bors] - chore(frontents/lean/parser.cpp): change binder collection order

### DIFF
--- a/src/frontends/lean/parser.cpp
+++ b/src/frontends/lean/parser.cpp
@@ -1037,7 +1037,7 @@ expr parser::parse_binder(unsigned rbp) {
 /* Lean allow binders of the form <tt>ID_1 ... ID_n 'op' S</tt>
    Where 'op' is an infix operator, and s an expression (i.e., "collection").
    This notation expands to:
-     (ID_1 ... ID_n : _) (H_1 : ID_1 'op' S) ... (H_n : ID_n 'op' S)
+     (ID_1 : _) (H_1 : ID_1 'op' S) ... (ID_n : _) (H_n : ID_n 'op' S)
 
    This method return true if the next token is an infix operator,
    and populates r with the locals above.
@@ -1064,24 +1064,18 @@ ast_id parser::parse_binder_collection(buffer<pair<pos_info, name>> const & name
     next(); // consume tk
     expr S        = parse_expr(rbp);
     ast_id id = new_ast("collection", names[0].first, acc.get_name()).push(get_id(S)).m_id;
-    unsigned old_sz = r.size();
-    /* Add (ID_1 ... ID_n : _) to r */
     for (auto p : names) {
+        /* Add (ID_i : _) to r */
         expr arg_type = save_pos(mk_expr_placeholder(), p.first);
-        expr local = save_pos(mk_local(p.second, arg_type, bi), p.first);
-        add_local(local);
-        r.push_back(local);
-    }
-    /* Add (H_1 : ID_1 'op' S) ... (H_n : ID_n 'op' S) */
-    unsigned i = old_sz;
-    for (auto p : names) {
-        expr ID      = r[i];
+        expr ID = save_pos(mk_local(p.second, arg_type, bi), p.first);
+        add_local(ID);
+        r.push_back(ID);
+        /* Add (H_i : ID_i 'op' S) */
         expr args[2] = {ID, S};
         expr ID_op_S = instantiate_rev(pred, 2, args);
         expr local = save_pos(mk_local("H", ID_op_S, bi), p.first);
         add_local(local);
         r.push_back(local);
-        i++;
     }
     return id;
 }


### PR DESCRIPTION
This changes the binder order of multiple variable binder collections like `∀ (x y < n), true` from `∀ (x y : _) (_ : x < n) (_ : y < n), true` to `∀ (x : _) (_ : x < n) (y : _) (_ : y < n), true`. This makes it easier to expand these binders into simple binder collections as in `∀ (x y < n), true ~> ∀ x < n, ∀ y < n, true`; otherwise the multiple-variable binder collection syntax needs special attention in mathlib4 and mathport.

Incidentally, there are apparently zero uses of this syntax in the core library and test suite, but mathlib probably has a couple occurrences that will have to be adjusted following this change.