### PR TITLE
[Merged by Bors] - fix(library/tactic): improve out_param support in simp

### DIFF
--- a/src/frontends/lean/elaborator.cpp
+++ b/src/frontends/lean/elaborator.cpp
@@ -313,36 +313,8 @@ expr elaborator::mk_instance_core(expr const & C, expr const & ref) {
     return mk_instance_core(m_ctx.lctx(), C, ref);
 }
 
-/* We say a type class (Pi X, (C a_1 ... a_n)), where X may be empty, is
-   ready to synthesize if it does not contain metavariables,
-   or if the a_i's that contain metavariables are marked as output params. */
-bool elaborator::ready_to_synthesize(expr inst_type) {
-    if (!has_expr_metavar(inst_type))
-        return true;
-    while (is_pi(inst_type))
-        inst_type = binding_body(inst_type);
-    buffer<expr> C_args;
-    expr const & C = get_app_args(inst_type, C_args);
-    if (!is_constant(C))
-        return false;
-    expr it = m_ctx.infer(C);
-    buffer<bool> is_out_param;
-    class_out_param_deps(it, is_out_param);
-    int i = 0;
-    for (expr const & C_arg : C_args) {
-        if (!is_pi(it))
-            return false; /* failed */
-        if (has_expr_metavar(C_arg) && !is_out_param[i])
-            return false;
-
-        it = binding_body(it);
-        i++;
-    }
-    return true;
-}
-
 expr elaborator::mk_instance(expr const & C, expr const & ref) {
-    if (!ready_to_synthesize(C)) {
+    if (!m_ctx.ready_to_synthesize(C)) {
         expr inst = mk_metavar(C, ref);
         m_instances = cons(inst, m_instances);
         return inst;
@@ -3598,7 +3570,7 @@ void elaborator::synthesize_numeral_types() {
 }
 
 bool elaborator::synthesize_type_class_instance_core(expr const & mvar, expr const & inferred_inst, expr const & inst_type) {
-    if (!ready_to_synthesize(inst_type))
+    if (!m_ctx.ready_to_synthesize(inst_type))
         return false;
     metavar_decl mdecl = m_ctx.mctx().get_metavar_decl(mvar);
     expr ref = mvar;
@@ -3627,7 +3599,7 @@ void elaborator::synthesize_type_class_instances_step() {
     for (expr const & mvar : m_instances) {
         expr inst      = instantiate_mvars(mvar);
         expr inst_type = instantiate_mvars(infer_type(inst));
-        if (!ready_to_synthesize(inst_type)) {
+        if (!m_ctx.ready_to_synthesize(inst_type)) {
             to_keep.push_back(mvar);
         } else {
             to_process.emplace_back(mvar, inst, inst_type);

--- a/src/frontends/lean/elaborator.h
+++ b/src/frontends/lean/elaborator.h
@@ -272,8 +272,6 @@ private:
     tactic_state mk_tactic_state_for(expr const & mvar);
     void invoke_tactic(expr const & mvar, expr const & tac);
 
-    bool ready_to_synthesize(expr inst_type);
-
     void process_hole(expr const & mvar, expr const & arg);
     void process_holes();
 

--- a/src/library/tactic/simp_util.h
+++ b/src/library/tactic/simp_util.h
@@ -35,77 +35,96 @@ class instantiate_emetas_fn {
         return some_expr(result);
     }
 
+    enum emeta_result {
+        FAILED, // This metavariable is definitely not solvable.
+        WAITING, // This metavariable might be solved, if other variables are solved.
+        DONE, // This metavariable is already solved.
+        PROGRESS, // This metavariable has been solved in the last iteration.
+    };
+
+    /*
+     * \brief Try to solve the metavariable by unification, synthesizing instances or calling the prover.
+     */
+    emeta_result solve_emeta(tmp_type_context & tmp_ctx, expr const & mvar, bool const & is_instance) {
+        unsigned mvar_idx = to_meta_idx(mvar);
+        expr mvar_type = tmp_ctx.instantiate_mvars(tmp_ctx.infer(mvar));
+        if (tmp_ctx.is_eassigned(mvar_idx)) return DONE;
+
+        if (is_instance && tmp_ctx.ctx().ready_to_synthesize(mvar_type)) {
+            // Use the *temporary* context for the instance search
+            // in order to also fill in any previous temporary metas created by matching.
+            if (auto v = tmp_ctx.mk_class_instance(mvar_type)) {
+                if (!tmp_ctx.is_def_eq(mvar, *v)) {
+                    lean_simp_trace(tmp_ctx, name({"simplify", "failure"}),
+                                    tout() << "unable to assign instance for: " << mvar_type << "\n";);
+                    return FAILED;
+                } else {
+                    return PROGRESS;
+                }
+            } else {
+                lean_simp_trace(tmp_ctx, name({"simplify", "failure"}),
+                                tout() << "unable to synthesize instance for: " << mvar_type << "\n";);
+                return FAILED;
+            }
+        }
+        if (tmp_ctx.is_eassigned(mvar_idx)) return DONE;
+
+        // `mk_class_instance` can deal with temporary metavariables, but other tactics
+        // (including `simp` itself when called recursively to solve goals) usually can't.
+        if (has_idx_metavar(mvar_type)) {
+            return WAITING;
+        }
+
+        if (optional<expr> pf = try_auto_param(tmp_ctx, mvar_type)) {
+            lean_verify(tmp_ctx.is_def_eq(mvar, *pf));
+            return PROGRESS;
+        }
+
+        if (tmp_ctx.ctx().is_prop(mvar_type)) {
+            if (auto pf = m_prover(tmp_ctx, mvar_type)) {
+                lean_verify(tmp_ctx.is_def_eq(mvar, *pf));
+                return PROGRESS;
+            } else {
+                lean_simp_trace(tmp_ctx, name({"simplify", "failure"}),
+                                tout() << "failed to prove: " << mvar << " : " << mvar_type << "\n";);
+                return FAILED;
+            }
+        } else {
+            // This variable can't be inferred by itself, but it might still be possible through unifying another variable.
+            // (For example, as `out_param Type` to an instance that hasn't passed through `solve_emeta`;
+            // such cases where the type is already known but the value isn't, won't be caught by the `has_idx_metavar` check above.)
+            lean_simp_trace(tmp_ctx, name({"simplify", "failure"}),
+                            tout() << "failed to assign: " << mvar << " : " << mvar_type << "\n";);
+            return WAITING;
+        }
+    }
+
 public:
     instantiate_emetas_fn(Prover & prover):
         m_prover(prover) {}
 
     bool operator()(tmp_type_context & tmp_ctx, list<expr> const & emetas, list<bool> const & instances) {
         // Repeat until we stop making progress or all variables are instantiated.
-        bool progress = false;
-        bool done = false;
+        bool any_progress = false;
+        bool any_waiting = false;
         do {
-            progress = false; // Set to true if we instantiate a variable.
-            done = true; // Set to false if we skip a variable.
+            any_progress = false;
+            any_waiting = false;
+            bool any_failed = false; // Early exit if there's something definitively impossible to solve.
             for_each2(emetas, instances, [&](expr const & mvar, bool const & is_instance) {
-                    unsigned mvar_idx = to_meta_idx(mvar);
-                    expr mvar_type = tmp_ctx.instantiate_mvars(tmp_ctx.infer(mvar));
-
-                    if (tmp_ctx.is_eassigned(mvar_idx)) return;
-
-                    if (is_instance && tmp_ctx.ctx().ready_to_synthesize(mvar_type)) {
-                        // Use the *temporary* context for the instance search
-                        // in order to also fill in any previous temporary metas created by matching.
-                        if (auto v = tmp_ctx.mk_class_instance(mvar_type)) {
-                            if (!tmp_ctx.is_def_eq(mvar, *v)) {
-                                lean_simp_trace(tmp_ctx, name({"simplify", "failure"}),
-                                                tout() << "unable to assign instance for: " << mvar_type << "\n";);
-                                done = false;
-                                return;
-                            } else {
-                                progress = true;
-                            }
-                        } else {
-                            lean_simp_trace(tmp_ctx, name({"simplify", "failure"}),
-                                            tout() << "unable to synthesize instance for: " << mvar_type << "\n";);
-                            done = false;
-                            return;
-                        }
-                    }
-                    if (tmp_ctx.is_eassigned(mvar_idx)) return;
-
-                    // `mk_class_instance` can deal with temporary metavariables, but other tactics
-                    // (including `simp` itself when called recursively to solve goals) usually can't.
-                    if (has_idx_metavar(mvar_type)) {
-                        done = false;
-                        return;
-                    }
-
-                    if (optional<expr> pf = try_auto_param(tmp_ctx, mvar_type)) {
-                        lean_verify(tmp_ctx.is_def_eq(mvar, *pf));
-                        progress = true;
-                        return;
-                    }
-
-                    if (tmp_ctx.ctx().is_prop(mvar_type)) {
-                        if (auto pf = m_prover(tmp_ctx, mvar_type)) {
-                            lean_verify(tmp_ctx.is_def_eq(mvar, *pf));
-                            progress = true;
-                            return;
-                        } else {
-                            lean_simp_trace(tmp_ctx, name({"simplify", "failure"}),
-                                            tout() << "failed to prove: " << mvar << " : " << mvar_type << "\n";);
-                            done = false;
-                            return;
-                        }
-                    } else {
-                        lean_simp_trace(tmp_ctx, name({"simplify", "failure"}),
-                                        tout() << "failed to assign: " << mvar << " : " << mvar_type << "\n";);
-                        done = false;
-                        return;
+                    if (any_failed) return;
+                    switch (solve_emeta(tmp_ctx, mvar, is_instance)) {
+                        case DONE: break;
+                        case PROGRESS: any_progress = true; break;
+                        case WAITING: any_waiting = true; break;
+                        case FAILED: any_failed = true; break;
                     }
                 });
-        } while (progress && !done);
-        return done;
+            if (any_failed) {
+                return false;
+            }
+        } while (any_progress && any_waiting);
+        return !any_waiting;
     }
 };
 }

--- a/src/library/tactic/simp_util.h
+++ b/src/library/tactic/simp_util.h
@@ -52,7 +52,7 @@ public:
 
                     if (tmp_ctx.is_eassigned(mvar_idx)) return;
 
-                    if (is_instance) {
+                    if (is_instance && tmp_ctx.ctx().ready_to_synthesize(mvar_type)) {
                         // Use the *temporary* context for the instance search
                         // in order to also fill in any previous temporary metas created by matching.
                         if (auto v = tmp_ctx.mk_class_instance(mvar_type)) {

--- a/src/library/type_context.cpp
+++ b/src/library/type_context.cpp
@@ -4271,6 +4271,11 @@ expr tmp_type_context::instantiate_mvars(expr const & e) {
     return m_ctx.instantiate_mvars(e);
 }
 
+optional<expr> tmp_type_context::mk_class_instance(expr const & cls_type) {
+    type_context_old::tmp_mode_scope_with_data tmp_scope(m_ctx, m_tmp_data);
+    return m_ctx.mk_class_instance(cls_type);
+}
+
 void tmp_type_context::assign(expr const & m, expr const & v) {
     type_context_old::tmp_mode_scope_with_data tmp_scope(m_ctx, m_tmp_data);
     m_ctx.assign(m, v);

--- a/src/library/type_context.cpp
+++ b/src/library/type_context.cpp
@@ -4176,6 +4176,34 @@ optional<expr> type_context_old::mk_class_instance(expr const & type_0) {
     return result;
 }
 
+/* We say a type class (Pi X, (C a_1 ... a_n)), where X may be empty, is
+   ready to synthesize if it does not contain metavariables,
+   or if the a_i's that contain metavariables are marked as output params. */
+bool type_context_old::ready_to_synthesize(expr inst_type) {
+    if (!has_expr_metavar(inst_type))
+        return true;
+    while (is_pi(inst_type))
+        inst_type = binding_body(inst_type);
+    buffer<expr> C_args;
+    expr const & C = get_app_args(inst_type, C_args);
+    if (!is_constant(C))
+        return false;
+    expr it = infer(C);
+    buffer<bool> is_out_param;
+    class_out_param_deps(it, is_out_param);
+    int i = 0;
+    for (expr const & C_arg : C_args) {
+        if (!is_pi(it))
+            return false; /* failed */
+        if (has_expr_metavar(C_arg) && !is_out_param[i])
+            return false;
+
+        it = binding_body(it);
+        i++;
+    }
+    return true;
+}
+
 optional<expr> type_context_old::mk_subsingleton_instance(expr const & type) {
     if (optional<optional<expr>> r = m_cache->get_subsingleton(type))
         return *r;

--- a/src/library/type_context.h
+++ b/src/library/type_context.h
@@ -740,6 +740,8 @@ public:
 
     optional<name> is_class(expr const & type);
     optional<expr> mk_class_instance(expr const & type);
+    /* Are sufficiently many metavariables instantiated for synthesis? */
+    bool ready_to_synthesize(expr inst_type);
     optional<expr> mk_subsingleton_instance(expr const & type);
     /* Create type class instance in a different local context */
     optional<expr> mk_class_instance_at(local_context const & lctx, expr const & type);

--- a/src/library/type_context.h
+++ b/src/library/type_context.h
@@ -1081,6 +1081,7 @@ public:
     bool is_eassigned(unsigned i) const;
     void clear_eassignment();
     expr instantiate_mvars(expr const & e);
+    optional<expr> mk_class_instance(expr const & cls_type);
 };
 
 /** Create a formatting function that can 'decode' metavar_decl_refs and local_decl_refs

--- a/tests/lean/run/simp_out_param.lean
+++ b/tests/lean/run/simp_out_param.lean
@@ -7,9 +7,7 @@ class broken₁ (A : Type*) :=
 (f : A → A)
 open broken₁
 
-class broken₂ (A : Type*) (a : out_param $ A)
-  -- The following doesn't need to be an `out_param` when #657 is merged:
-  [out_param $ broken₁ A] :=
+class broken₂ (A : Type*) (a : out_param $ A) [broken₁ A] :=
 (f_eq : ∀ x, f x = a)
 open broken₂
 

--- a/tests/lean/run/simp_out_param.lean
+++ b/tests/lean/run/simp_out_param.lean
@@ -1,0 +1,25 @@
+prelude
+import init.meta.interactive
+
+namespace unbundled
+
+class broken₁ (A : Type*) :=
+(f : A → A)
+open broken₁
+
+class broken₂ (A : Type*) (a : out_param $ A)
+  -- The following doesn't need to be an `out_param` when #657 is merged:
+  [out_param $ broken₁ A] :=
+(f_eq : ∀ x, f x = a)
+open broken₂
+
+-- Even if the goal doesn't contain an instance of `broken₂`, the parameter `a`
+-- to `f_eq` should still be inferrable since it's an `out_param`.
+example (A : Type*) (a : A) [broken₁ A] [broken₂ A a] (x : A) : f x = a :=
+by rewrite [f_eq]
+
+example (A : Type*) (a : A) [broken₁ A] [broken₂ A a] (x : A) : f x = a :=
+by simp only [f_eq]
+-- Previous error: "simplify tactic failed to simplify", `f_eq` failed because "fail to instantiate emetas"
+
+end unbundled

--- a/tests/lean/simp_out_params_ready.lean
+++ b/tests/lean/simp_out_params_ready.lean
@@ -1,3 +1,7 @@
+prelude
+import init.data.int.basic
+import init.meta.interactive
+
 namespace in_param
 
 class A (α β : Type) -- no out_param!

--- a/tests/lean/simp_out_params_ready.lean
+++ b/tests/lean/simp_out_params_ready.lean
@@ -1,0 +1,24 @@
+namespace in_param
+
+class A (α β : Type) -- no out_param!
+instance inst : A ℕ ℤ := ⟨⟩
+def p (_ : Type) : Prop := false
+@[simp] lemma l {α β} [A α β] : p α ↔ p β := iff.rfl
+
+-- `simp` should fail to apply `l` here since the `β` parameter to `l` can't be inferred,
+-- instead of trying to synthesize an instance `A ℕ ?m_1`, find `inst` and unify `?m_1 =?= ℤ`,
+-- turning the goal into `p ℤ`
+example : p ℕ := by simp
+
+end in_param
+
+namespace out_param
+
+-- However, if `β` is marked as an out_param, the goal should turn into `p ℤ`
+class A (α : Type) (β : out_param Type) -- no out_param!
+instance inst : A ℕ ℤ := ⟨⟩
+def p (_ : Type) : Prop := false
+@[simp] lemma l {α β} [A α β] : p α ↔ p β := iff.rfl
+example : p ℕ := by simp
+
+end out_param

--- a/tests/lean/simp_out_params_ready.lean.expected.out
+++ b/tests/lean/simp_out_params_ready.lean.expected.out
@@ -1,0 +1,6 @@
+simp_out_params_ready.lean:11:20: error: simplify tactic failed to simplify
+state:
+⊢ p ℕ
+simp_out_params_ready.lean:22:20: error: tactic failed, there are unsolved goals
+state:
+⊢ p ℤ

--- a/tests/lean/simp_out_params_ready.lean.expected.out
+++ b/tests/lean/simp_out_params_ready.lean.expected.out
@@ -1,6 +1,6 @@
-simp_out_params_ready.lean:11:20: error: simplify tactic failed to simplify
+simp_out_params_ready.lean:15:20: error: simplify tactic failed to simplify
 state:
 ⊢ p ℕ
-simp_out_params_ready.lean:22:20: error: tactic failed, there are unsolved goals
+simp_out_params_ready.lean:26:20: error: tactic failed, there are unsolved goals
 state:
 ⊢ p ℤ


### PR DESCRIPTION
When a `simp` lemma matches with the goal, all remaining arguments, occurring as temporary metavariables, were inferred left-to-right by `instantiate_emetas`, stopping at the first metavariable that can't be inferred through matching with the goal, instance synthesis, or using the prover argument to `simp`. This meant a `simp` lemma with a parameter corresponding to the `out_param` of a typeclass will be rejected, unless that class occurs in the goal.

I modified `instantiate_emetas` to instead repeat until either all metavariables are inferred, or no progress is made on instantiating. I had to use a temporary type context to infer instances, in order to correctly unify the `out_param`s with the temporary metavariables occurring earlier in the `simp` lemma. If I understand the comments about temporary type contexts correctly, this is the same as `rw` does, so this should not cause any regressions.