### PR TITLE
[Merged by Bors] - fix: sort level parameters after collection

### DIFF
--- a/src/library/aux_definition.cpp
+++ b/src/library/aux_definition.cpp
@@ -91,7 +91,6 @@ expr closure_helper::collect(expr const & e) {
 
 void closure_helper::finalize_collection() {
     lean_assert(!m_finalized_collection);
-    std::sort(m_level_params.begin(), m_level_params.end());
     name_map<expr> new_types;
     for (unsigned i = 0; i < m_params.size(); i++) {
         expr x = m_params[i];
@@ -109,6 +108,7 @@ void closure_helper::finalize_collection() {
         expr new_param = m_ctx.push_local(mlocal_pp_name(x), new_type, local_info(x));
         m_norm_params.push_back(new_param);
     }
+    std::sort(m_level_params.begin(), m_level_params.end());
     m_finalized_collection = true;
 }
 

--- a/tests/lean/run/655c.lean
+++ b/tests/lean/run/655c.lean
@@ -1,0 +1,18 @@
+universes u v w
+
+-- fails to create a helper definition
+-- TODO
+-- def foldr_cps {α β γ : Sort*} (g : α → β → β) (z : β) : list α → (β → γ) → γ
+-- | list.nil k := k z
+-- | (list.cons x xs) k := foldr_cps xs (λz', k (g x z'))
+
+-- succeeds
+def foldr_cps' {α β γ : Sort*} (g : α → β → β) (z : β) (l : list α) : (β → γ) → γ :=
+@list.rec_on α (λ _, (β → γ) → γ) l
+  (λ k : β → γ, k z)
+  (λ x xs r k, r (λ z', k (g x z')))
+
+-- fails to create a helper definition
+def foldr_cps'' {α : Type u} {β : Sort v} {γ : Sort w} (g : α → β → β) (z : β) : list α → (β → γ) → γ
+| list.nil k := k z
+| (list.cons x xs) k := foldr_cps'' xs (λz', k (g x z'))


### PR DESCRIPTION
Fixes half of the issue in #655, now it works if you specify the universe parameters explicitly.

If you don't specify them explicitly, then the auxiliary meta definition is declared before we have replaced the universe metavariables by u_1,u_2,... (called finalization), which happens at the very end of elaboration.  Making that work as well would probably require large changes in the elaborator.