### PR TITLE
[Merged by Bors] - feat(library/init/meta): import unfreezing tactic from mathlib

### DIFF
--- a/library/init/meta/default.lean
+++ b/library/init/meta/default.lean
@@ -17,6 +17,7 @@ import init.meta.comp_value_tactics init.meta.smt
 import init.meta.async_tactic init.meta.ref
 import init.meta.hole_command init.meta.congr_tactic
 import init.meta.local_context init.meta.type_context
+import init.meta.instance_cache
 import init.meta.module_info
 import init.meta.expr_address
 import init.meta.tagged_format

--- a/library/init/meta/instance_cache.lean
+++ b/library/init/meta/instance_cache.lean
@@ -1,0 +1,110 @@
+/-
+Copyright (c) 2018 Mario Carneiro. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Mario Carneiro
+-/
+prelude
+import init.meta.tactic init.meta.interactive
+
+/-!
+# Instance cache tactics
+
+For performance reasons, Lean does not automatically update its database
+of class instances during a proof. The group of tactics in this file
+helps to force such updates.
+
+-/
+open lean.parser
+open interactive interactive.types
+
+local postfix `?`:9001 := optional
+local postfix *:9001 := many
+
+namespace tactic
+/-- Reset the instance cache for the main goal. -/
+meta def reset_instance_cache : tactic unit := do
+unfreeze_local_instances,
+freeze_local_instances
+
+/-- Unfreeze the local instances while executing `tac` on the main goal. -/
+meta def unfreezing {α} (tac : tactic α) : tactic α :=
+focus1 $ unfreeze_local_instances *> tac <* all_goals freeze_local_instances
+
+/--
+Unfreeze local instances while executing `tac`,
+if the passed expression is amongst the frozen instances.
+-/
+meta def unfreezing_hyp (h : expr) (tac : tactic unit) : tactic unit :=
+do frozen ← frozen_local_instances,
+   if h ∈ frozen.get_or_else [] then unfreezing tac else tac
+
+namespace interactive
+
+/--
+`unfreezingI { tac }` executes tac while temporarily unfreezing the instance cache.
+-/
+meta def unfreezingI (tac : itactic) :=
+unfreezing tac
+
+/-- Reset the instance cache. This allows any new instances
+added to the context to be used in typeclass inference. -/
+meta def resetI := reset_instance_cache
+
+/-- Like `revert`, but can also revert instance arguments. -/
+meta def revertI (ids : parse ident*) : tactic unit :=
+unfreezingI (revert ids)
+
+/-- Like `subst`, but can also substitute in instance arguments. -/
+meta def substI (q : parse texpr) : tactic unit :=
+unfreezingI (subst q)
+
+/-- Like `cases`, but can also be used with instance arguments. -/
+meta def casesI (p : parse cases_arg_p) (q : parse with_ident_list) : tactic unit :=
+unfreezingI (cases p q)
+
+/-- Like `intro`, but uses the introduced variable
+in typeclass inference. -/
+meta def introI (p : parse ident_?) : tactic unit :=
+intro p >> reset_instance_cache
+
+/-- Like `intros`, but uses the introduced variable(s)
+in typeclass inference. -/
+meta def introsI (p : parse ident_*) : tactic unit :=
+intros p >> reset_instance_cache
+
+/-- Used to add typeclasses to the context so that they can
+be used in typeclass inference. The syntax is the same as `have`. -/
+meta def haveI (h : parse ident?) (q₁ : parse (tk ":" *> texpr)?) (q₂ : parse (tk ":=" *> texpr)?) :
+  tactic unit :=
+do h ← match h with
+  | none   := get_unused_name "_inst"
+  | some a := return a
+  end,
+  «have» (some h) q₁ q₂,
+  match q₂ with
+  | none    := swap >> reset_instance_cache >> swap
+  | some p₂ := reset_instance_cache
+  end
+
+/-- Used to add typeclasses to the context so that they can
+be used in typeclass inference. The syntax is the same as `let`. -/
+meta def letI
+  (h : parse ident?) (q₁ : parse (tk ":" *> texpr)?) (q₂ : parse $ (tk ":=" *> texpr)?) :
+  tactic unit :=
+do h ← match h with
+  | none   := get_unused_name "_inst"
+  | some a := return a
+  end,
+  «let» (some h) q₁ q₂,
+  match q₂ with
+  | none    := swap >> reset_instance_cache >> swap
+  | some p₂ := reset_instance_cache
+  end
+
+/-- Like `exact`, but uses all variables in the context
+for typeclass inference. -/
+meta def exactI (q : parse texpr) : tactic unit :=
+reset_instance_cache >> exact q
+
+end interactive
+end tactic

--- a/library/init/meta/tactic.lean
+++ b/library/init/meta/tactic.lean
@@ -757,7 +757,7 @@ meta constant set_tag (g : expr) (t : tag) : tactic unit
 /-- Return tag associated with `g`. Return `[]` if there is no tag. -/
 meta constant get_tag (g : expr) : tactic tag
 
-/-- By default, Lean only considers local instances in the header of declarations.
+/-! By default, Lean only considers local instances in the header of declarations.
     This has two main benefits.
     1- Results produced by the type class resolution procedure can be easily cached.
     2- The set of local instances does not have to be recomputed.
@@ -766,11 +766,14 @@ meta constant get_tag (g : expr) : tactic tag
     1- Frozen local instances cannot be reverted.
     2- Local instances defined inside of a declaration are not considered during type
        class resolution.
+-/
 
-    This tactic resets the set of local instances. After executing this tactic,
-    the set of local instances will be recomputed and the cache will be frequently
-    reset. Note that, the cache is still used when executing a single tactic that
-    may generate many type class resolution problems (e.g., `simp`). -/
+/--
+Avoid this function!  Use `unfreezingI`/`resetI`/etc. instead!
+
+Unfreezes the current set of local instances.
+After this tactic, the instance cache is disabled.
+-/
 meta constant unfreeze_local_instances : tactic unit
 /--
 Freeze the current set of local instances.
@@ -957,8 +960,8 @@ revert_lst [l]
 
 /- Revert "all" hypotheses. Actually, the tactic only reverts
    hypotheses occurring after the last frozen local instance.
-   Recall that frozen local instances cannot be reverted.
-   We can use `unfreeze_local_instances` to workaround this limitation. -/
+   Recall that frozen local instances cannot be reverted,
+   use `unfreezing revert_all` instead. -/
 meta def revert_all : tactic nat :=
 do lctx ← local_context,
    lis  ← frozen_local_instances,
@@ -1741,7 +1744,7 @@ are the new names.
 
 This tactic can only rename hypotheses which occur after the last frozen local
 instance. If you need to rename earlier hypotheses, try
-`unfreeze_local_instances`.
+`unfreezing (rename_many ...)`.
 
 If `strict` is true, we fail if `name_map` refers to hypotheses that do not
 appear in the local context or that appear before a frozen local instance.
@@ -1774,7 +1777,7 @@ do let hyp_name : expr → name :=
        , format.line
        , "This is because these hypotheses either do not occur in the\n"
        , "context or they occur before a frozen local instance.\n"
-       , "In the latter case, try `tactic.unfreeze_local_instances`."
+       , "In the latter case, try `unfreezingI { ... }`."
        ]
    },
    -- The new names for all hypotheses in ctx_suffix.

--- a/src/library/type_context.cpp
+++ b/src/library/type_context.cpp
@@ -343,7 +343,8 @@ pair<local_context, expr> type_context_old::revert_core(buffer<expr> & to_revert
         for (expr const & h : to_revert) {
             for (local_instance const & li : *lis) {
                 if (mlocal_name(h) == mlocal_name(li.get_local())) {
-                    throw exception(sstream() << "failed to revert '" << h << "', it is a frozen local instance (possible solution: use tactic `tactic.unfreeze_local_instances` to reset the set of local instances)");
+                    throw exception(sstream() << "failed to revert '" << h
+                        << "', it is a frozen local instance (possible solution: use tactic `unfreezing` to temporarily reset the set of local instances)");
                 }
             }
         }

--- a/src/library/type_context.h
+++ b/src/library/type_context.h
@@ -619,10 +619,7 @@ public:
        4- (Drawback) Local instances cannot be reverted anymore.
 
        This method is invoked after we parse the header of a declaration.
-
-       TODO(Leo):
-       add tactic `unfreeze_local_instances : tactic unit` which unfreezes the set of frozen local instances
-       for the current goal. */
+    */
     void freeze_local_instances();
     void unfreeze_local_instances();
     list<local_instance> get_local_instances() const { return m_local_instances; }

--- a/tests/lean/rename.lean.expected.out
+++ b/tests/lean/rename.lean.expected.out
@@ -2,7 +2,7 @@ rename.lean:23:2: error: Cannot rename these hypotheses:
 d
 This is because these hypotheses either do not occur in the
 context or they occur before a frozen local instance.
-In the latter case, try `tactic.unfreeze_local_instances`.
+In the latter case, try `unfreezingI { ... }`.
 state:
 α : Sort ?,
 β : Sort ?,
@@ -13,7 +13,7 @@ rename.lean:32:2: error: Cannot rename these hypotheses:
 α
 This is because these hypotheses either do not occur in the
 context or they occur before a frozen local instance.
-In the latter case, try `tactic.unfreeze_local_instances`.
+In the latter case, try `unfreezingI { ... }`.
 state:
 α : Prop,
 _inst_1 : decidable α,

--- a/tests/lean/revert_frozen_dep.lean.expected.out
+++ b/tests/lean/revert_frozen_dep.lean.expected.out
@@ -1,4 +1,4 @@
-revert_frozen_dep.lean:3:2: error: failed to revert '_inst_1', it is a frozen local instance (possible solution: use tactic `tactic.unfreeze_local_instances` to reset the set of local instances)
+revert_frozen_dep.lean:3:2: error: failed to revert '_inst_1', it is a frozen local instance (possible solution: use tactic `unfreezing` to temporarily reset the set of local instances)
 state:
 α : id Type,
 _inst_1 : has_add α


### PR DESCRIPTION
And remove misleading mentions of `unfreeze_local_instances` from error messages.