### PR TITLE
[Merged by Bors] - feat(extras/latex/lstlean): `ϖ` and `ᵒ`

### DIFF
--- a/extras/latex/lstlean.tex
+++ b/extras/latex/lstlean.tex
@@ -86,6 +86,7 @@ literate=
 {χ}{{\ensuremath{\mathrm{\chi}}}}1
 {ψ}{{\ensuremath{\mathrm{\psi}}}}1
 {ω}{{\ensuremath{\mathrm{\omega}}}}1
+{ϖ}{{\ensuremath{\mathrm{\mathnormal{\varpi}}}}}1 % KMB added for perfectoid stuff
 
 {Γ}{{\ensuremath{\mathrm{\Gamma}}}}1
 {Δ}{{\ensuremath{\mathrm{\Delta}}}}1
@@ -132,6 +133,7 @@ literate=
 {⬝}{{\color{symbolcolor}\ensuremath{\cdot}}}1
 {•}{{\color{symbolcolor}\ensuremath{\cdot}}}1
 {∘}{{\color{symbolcolor}\ensuremath{\circ}}}1
+{ᵒ}{{\color{symbolcolor}\ensuremath{^\circ}}}1
 {`}{{\ensuremath{{}^\backprime}}}1
 {'}{{\ensuremath{{}^\prime}}}1
 


### PR DESCRIPTION
This is Kevin's version of `lstlean.tex`, apparently having circulated from Patrick.