### PR TITLE
[Merged by Bors] - feat: record comments in ast

### DIFF
--- a/src/frontends/lean/parser.h
+++ b/src/frontends/lean/parser.h
@@ -457,6 +457,7 @@ public:
     std::string const & get_str_val() const { return m_scanner.get_str_val(); }
     token_info const & get_token_info() const { return m_scanner.get_token_info(); }
     std::string const & get_stream_name() const { return m_scanner.get_stream_name(); }
+    std::vector<ast_comment> const & get_comments() const { return m_scanner.get_comments(); }
 
     unsigned get_small_nat();
     virtual pair<ast_id, unsigned> parse_small_nat() override final;

--- a/src/frontends/lean/scanner.h
+++ b/src/frontends/lean/scanner.h
@@ -7,6 +7,7 @@ Author: Leonardo de Moura
 #pragma once
 #include <string>
 #include <iostream>
+#include <vector>
 #include "kernel/pos_info_provider.h"
 #include "util/name.h"
 #include "util/flet.h"

--- a/src/frontends/lean/scanner.h
+++ b/src/frontends/lean/scanner.h
@@ -21,6 +21,15 @@ enum class token_kind {Keyword, CommandKeyword, Identifier, Numeral, Decimal,
         String, Char, QuotedSymbol,
         DocBlock, ModDocBlock, FieldNum, FieldName, Eof};
 
+struct ast_comment {
+    pos_info m_start, m_end;
+    std::string m_text;
+
+    ast_comment() {}
+    ast_comment(pos_info start, pos_info end, std::string const & text) :
+        m_start(start), m_end(end), m_text(text) {}
+};
+
 /**
     \brief Scanner. The behavior of the scanner is controlled using a token set.
 
@@ -53,6 +62,8 @@ protected:
     mpq                 m_num_val;
     std::string         m_buffer;
     std::string         m_aux_buffer;
+
+    std::vector<ast_comment> m_comments;
 
     bool                m_in_notation;
     bool                m_field_notation{true};
@@ -101,6 +112,8 @@ public:
     pos_info get_pos_info() const { return {m_line, m_pos}; }
     pos_info get_last_end_pos_info() const { return {m_eline, m_epos}; }
     token_kind scan(environment const & env);
+
+    std::vector<ast_comment> const & get_comments() const { return m_comments; }
 
     mpq const & get_num_val() const { return m_num_val; }
     name const & get_name_val() const { return m_name_val; }


### PR DESCRIPTION
See https://github.com/leanprover-community/mathport/issues/101

I think it was Sebastian who originally suggested this approach of just recording the comments together with their range in the source file.  In synport we can just add them back to the final syntax at the some appropriate place (see `Syntax.updateLeading`; we already record range information for pexprs).

cc @digama0 @dselsam 