### PR TITLE
feat: export pretty-printed tactic states in ast

### DIFF
--- a/src/library/ast_exporter.cpp
+++ b/src/library/ast_exporter.cpp
@@ -169,8 +169,10 @@ struct ast_exporter : abstract_ast_exporter {
             m_tactic_log->m_exported.store(true);
             lock_guard<mutex> l(m_tactic_log->m_mutex);
             auto& invocs = m_tactic_log->get_invocs(l);
+            auto& ts_pps = m_tactic_log->get_ts_pps(l);
             if (!invocs.empty()) {
                 r["tactics"] = invocs;
+                r["pretty-printed-tactics"] = ts_pps;
                 auto& ss = r["states"] = json::array();
                 for (auto& s : m_tactic_log->get_states(l)) {
                     auto gs = json::array();

--- a/src/library/ast_exporter.cpp
+++ b/src/library/ast_exporter.cpp
@@ -172,7 +172,7 @@ struct ast_exporter : abstract_ast_exporter {
             auto& ts_pps = m_tactic_log->get_ts_pps(l);
             if (!invocs.empty()) {
                 r["tactics"] = invocs;
-                r["pretty-printed-tactics"] = ts_pps;
+                r["statePPs"] = ts_pps;
                 auto& ss = r["states"] = json::array();
                 for (auto& s : m_tactic_log->get_states(l)) {
                     auto gs = json::array();

--- a/src/library/tactic/tactic_log.h
+++ b/src/library/tactic/tactic_log.h
@@ -87,6 +87,7 @@ public:
 
 private:
     mutable std::vector<tactic_invocation> m_invocs;
+    mutable std::vector<std::string> m_ts_pps; // tactic state pretty-printeds
     using state_map = std::unordered_map<summary, tactic_state_id, summary_hash, summary_eq>;
     mutable state_map m_state_map;
     mutable std::vector<summary> m_states;
@@ -98,9 +99,10 @@ public:
     mutable std::atomic_bool m_exported{false};
     tactic_log() {}
 
-    tactic_state_id get_id(summary const & s) const;
+    tactic_state_id get_id(tactic_state const & ts, summary const & s) const;
     tactic_state_id push_invocation(ast_id id, tactic_state_id start, tactic_state_id end, bool success) const;
     inline std::vector<tactic_invocation> & get_invocs(lock_guard<mutex> &) const { return m_invocs; }
+    inline std::vector<std::string> & get_ts_pps(lock_guard<mutex> &) const { return m_ts_pps; }
     inline std::vector<summary> & get_states(lock_guard<mutex> &) const { return m_states; }
     void detach() const;
 };

--- a/src/library/tactic/tactic_log.h
+++ b/src/library/tactic/tactic_log.h
@@ -7,6 +7,7 @@ Author: Mario Carneiro
 #pragma once
 #include <atomic>
 #include <vector>
+#include <string>
 #include <unordered_map>
 #include "library/abstract_parser.h"
 #include "library/tactic/tactic_state.h"


### PR DESCRIPTION
This small commit, in combination with the ast parsing in mathport, together make it straightforward to produce high-quality datasets of tactic applications.