### PR TITLE
[Merged by Bors] - fix(src/library/tactic/rewrite_tactic): move LHS metavar check

### DIFF
--- a/src/library/tactic/rewrite_tactic.cpp
+++ b/src/library/tactic/rewrite_tactic.cpp
@@ -57,13 +57,13 @@ static vm_obj rewrite_core(expr h, expr e, rewrite_cfg const & cfg, tactic_state
     h_type = annotated_head_beta_reduce(h_type);
     if (!is_eq(h_type, A, lhs, rhs))
         return tactic::mk_exception("rewrite tactic failed, lemma is not an equality nor a iff", s);
-    if (is_metavar(lhs))
-        return tactic::mk_exception("rewrite tactic failed, lemma lhs is a metavariable", s);
     if (cfg.m_symm) {
         h      = mk_eq_symm(ctx, h);
         h_type = mk_eq(ctx, rhs, lhs);
         std::swap(lhs, rhs);
     }
+    if (is_metavar(lhs))
+        return tactic::mk_exception("rewrite tactic failed, lemma lhs is a metavariable", s);
     e = ctx.instantiate_mvars(e);
     expr pattern = lhs;
     lean_trace("rewrite", tout() << "before kabstract\n";);

--- a/tests/lean/rw_symm_mvar.lean
+++ b/tests/lean/rw_symm_mvar.lean
@@ -1,0 +1,7 @@
+theorem nat.mul_div_left' (n : ℕ) {m : ℕ} (H : 0 < m) : n = n * m / m :=
+by rwa nat.mul_div_left
+
+example (x y : ℕ) (h : 0 < x) (h1 : y = 1) : y * x / x = 1:=
+begin
+  rwa ← nat.mul_div_left' _ h,
+end


### PR DESCRIPTION
The LHS metavar check for rw occurred before symmetry (the `←`) was applied, leading to the bug where `rw ← h` might fail with "rewrite tactic failed, lemma lhs is a metavariable" but `rw h.symm` would succeed.

---

The metavar check is there because it otherwise would give an unhelpful error message such as
```
14:3: rewrite tactic failed, did not find instance of the pattern in the target expression
  ?m_1
```
This appears to be because `kabstract` searches for matches based on the head of the pattern.