### PR TITLE
[Merged by Bors] - feat(src/library/noncomputable): for constructors, only check arguments after inductive type's parameters

### DIFF
--- a/src/library/compiler/erase_irrelevant.cpp
+++ b/src/library/compiler/erase_irrelevant.cpp
@@ -423,8 +423,9 @@ class erase_irrelevant_fn : public compiler_step_visitor {
                 return visit_subtype_val(args);
             } else if (is_ginductive_pack(env(), n) || is_ginductive_unpack(env(), n)) {
                 return visit_pack_unpack(fn, args);
-            } else if (auto I_name = inductive::is_intro_rule(env(), n)) {
-                return visit_constructor(e, *I_name, fn, args);
+            } else if (!is_vm_builtin_function(n)) {
+                if (auto I_name = inductive::is_intro_rule(env(), n))
+                    return visit_constructor(e, *I_name, fn, args);
             }
         }
         return compiler_step_visitor::visit_app(e);

--- a/src/library/noncomputable.cpp
+++ b/src/library/noncomputable.cpp
@@ -167,8 +167,18 @@ struct get_noncomputable_reason_fn {
                 }
             }
             visit(fn);
-            for (expr const & arg : args)
-                visit(arg);
+            if (is_constant(fn) && inductive::is_intro_rule(m_tc.env(), const_name(fn))) {
+                // Only visit computational relevant arguments of the constructor.
+                buffer<bool> rel_fields;
+                get_constructor_relevant_fields(m_tc.env(), const_name(fn), rel_fields);
+                lean_assert(args.size() <= rel_fields.size());
+                for (unsigned i = 0; i < args.size(); i++)
+                    if (rel_fields[i])
+                        visit(args[i]);
+            } else {
+                for (expr const & arg : args)
+                    visit(arg);
+            }
         }
     }
 

--- a/src/library/noncomputable.cpp
+++ b/src/library/noncomputable.cpp
@@ -167,21 +167,15 @@ struct get_noncomputable_reason_fn {
                 }
             }
             visit(fn);
+            unsigned start = 0;
             if (is_constant(fn)) {
                 if (auto I_name = inductive::is_intro_rule(m_tc.env(), const_name(fn))) {
-                    // Only visit computational relevant arguments of the constructor.
-                    unsigned nparams = *inductive::get_num_params(m_tc.env(), *I_name);
-                    buffer<bool> rel_fields;
-                    get_constructor_relevant_fields(m_tc.env(), const_name(fn), rel_fields);
-                    lean_assert(args.size() <= nparams + rel_fields.size());
-                    for (unsigned i = 0; i < rel_fields.size(); i++)
-                        if (rel_fields[i] && nparams + i < args.size())
-                            visit(args[nparams + i]);
-                    return;
+                    // For constructors, only visit arguments after the inductive type's parameters
+                    start = *inductive::get_num_params(m_tc.env(), *I_name);
                 }
             }
-            for (expr const & arg : args)
-                visit(arg);
+            for (unsigned i = start; i < args.size(); i++)
+                visit(args[i]);
         }
     }
 

--- a/src/library/noncomputable.cpp
+++ b/src/library/noncomputable.cpp
@@ -16,6 +16,7 @@ Author: Leonardo de Moura
 #include "library/trace.h"
 #include "library/quote.h"
 #include "library/constants.h"
+#include "library/vm/vm.h"
 // TODO(Leo): move inline attribute declaration to library
 #include "library/compiler/inliner.h"
 namespace lean {
@@ -168,7 +169,7 @@ struct get_noncomputable_reason_fn {
             }
             visit(fn);
             unsigned start = 0;
-            if (is_constant(fn)) {
+            if (is_constant(fn) && !is_vm_builtin_function(const_name(fn))) {
                 if (auto I_name = inductive::is_intro_rule(m_tc.env(), const_name(fn))) {
                     // For constructors, only visit arguments after the inductive type's parameters
                     start = *inductive::get_num_params(m_tc.env(), *I_name);

--- a/tests/lean/noncomputable_constructor_param.lean
+++ b/tests/lean/noncomputable_constructor_param.lean
@@ -1,0 +1,38 @@
+inductive A {α : Type*} (x : α)
+| c1 (x y z : ℕ) : A
+| c2 : A
+| c3 (x : ℕ) : A
+
+def foo0 (h : ∃ (x : ℕ), x = x) : A (classical.some h) := A.c2
+
+def foo1 (h : ∃ (x : ℕ), x = x) : A (classical.some h) := A.c3 4
+
+def foo3 (h : ∃ (x : ℕ), x = x) : A (classical.some h) := A.c1 1 2 3
+
+noncomputable
+def foo4 (h : ∃ (x : ℕ), x = x) : A (classical.some h) := A.c3 (classical.some h)
+
+noncomputable
+def foo5 (h : ∃ (x : ℕ), x = x) : A (classical.some h) := A.c1 1 (classical.some h) 3
+
+class computable {α : Type*} (x : α) :=
+(compute : α)
+(compute_eq : compute = x)
+
+export computable
+
+attribute [inline] compute
+
+instance {α : Type*} (x : α) (h : ∃ (y : α), y = x) : computable (classical.some h) :=
+⟨x, (classical.some_spec h).symm⟩
+
+def foo6 (h : ∃ (n : ℕ), n = 37) := compute (classical.some h)
+
+noncomputable
+def foo7 (h : ∃ (n : ℕ), n = 37) := classical.some h
+
+inductive B (α : Type*)
+| c (x : α) : B
+
+noncomputable
+def foo8 (h : ∃ (n : ℕ), n = 37) := B.c (classical.some h)


### PR DESCRIPTION
This adds functionality to the noncomputability checker to skip arguments to a constructor that correspond to parameters for its corresponding inductive type. These have no computational relevance. This brings it more in line with `src/library/compiler/simp_inductive`, which only looks at computationally relevant arguments after the parameters. This also appears to be closer to Lean 4's behavior.