### PR TITLE
[Merged by Bors] - fix(heuristic_inst_name): give the heuristic name awareness of anonymous fields

### DIFF
--- a/src/frontends/lean/decl_util.cpp
+++ b/src/frontends/lean/decl_util.cpp
@@ -145,11 +145,14 @@ optional<name> heuristic_inst_name(name const & ns, expr const & type) {
     } else if (is_pi(arg_head)) {
         arg_name = "pi";
     } else if (is_field_notation(arg_head)) {
-        expr lhs = macro_arg(arg_head, 0);
-        arg_name = get_field_notation_field_name(arg_head);
+        if (is_anonymous_field_notation(arg_head))
+            arg_name = name("field").append_after(get_field_notation_field_idx(arg_head));
+        else
+            arg_name = get_field_notation_field_name(arg_head);
 
         // The field projection does not have the full name.
         // If we can guess the type of the lhs, prepend it.
+        expr lhs = macro_arg(arg_head, 0);
         if (is_local(lhs)) {
             expr type = get_app_fn(mlocal_type(lhs));
             if (is_constant(type))

--- a/tests/lean/heuristic_name_field_anonymous.lean
+++ b/tests/lean/heuristic_name_field_anonymous.lean
@@ -1,0 +1,9 @@
+class A {α : Type*} (x : α)
+
+instance {α : Type*} {p : α → Prop} (x : subtype p) : A x.1 := A.mk
+
+example := @subtype.field_1.A
+
+instance {α : Type*} {p : α → Prop} (x : subtype p) : A x.val := A.mk
+
+example := @subtype.val.A


### PR DESCRIPTION
This fixes an assertion error when compiling the most recent mathlib using a debug build of Lean.