### PR TITLE
[Merged by Bors] - feat(modifiers): `noncomputable!` to force noncomputability

### DIFF
--- a/library/init/meta/interactive_base.lean
+++ b/library/init/meta/interactive_base.lean
@@ -177,12 +177,15 @@ meta constant decl_attributes : Type
 
 meta constant decl_attributes.apply : decl_attributes → name → parser unit
 
+meta inductive noncomputable_modifier
+| computable | «noncomputable» | force_noncomputable
+
 meta structure decl_modifiers :=
 (is_private       : bool)
 (is_protected     : bool)
 (is_meta          : bool)
 (is_mutual        : bool)
-(is_noncomputable : bool)
+(is_noncomputable : noncomputable_modifier)
 
 meta structure decl_meta_info :=
 (attrs      : decl_attributes)

--- a/src/frontends/lean/decl_cmds.cpp
+++ b/src/frontends/lean/decl_cmds.cpp
@@ -569,14 +569,13 @@ static environment modifiers_cmd(parser & p, ast_id & cmd_id, cmd_meta const & _
             ast.push(0);
         }
         if (!meta.m_attrs && !meta.m_modifiers && p.curr_is_token_or_id(get_theory_tk())) {
-            cmd_id = p.new_ast(get_theory_tk(), p.pos()).push(mods.m_id).m_id;
-            // `noncomputable theory` or `noncomputable! theory`
-            p.next();
             if (force_noncomputable) {
-                p.set_noncomputable_policy(noncomputable_policy::ForceNoncomputable);
-            } else {
-                p.set_noncomputable_policy(noncomputable_policy::Auto);
+                throw parser_error("invalid 'noncomputable! theory', unsupported noncomputability policy", p.pos());
             }
+            // `noncomputable theory`
+            cmd_id = p.new_ast(get_theory_tk(), p.pos()).push(mods.m_id).m_id;
+            p.next();
+            p.set_noncomputable_policy(noncomputable_policy::Auto);
             return p.env();
         } else {
             if (force_noncomputable) {

--- a/src/frontends/lean/decl_cmds.cpp
+++ b/src/frontends/lean/decl_cmds.cpp
@@ -555,15 +555,18 @@ static environment modifiers_cmd(parser & p, ast_id & cmd_id, cmd_meta const & _
     }
 
     if (p.curr_is_token(get_noncomputable_tk())) {
-        if (!tk) tk = p.new_ast(get_noncomputable_tk(), p.pos()).m_id;
+        auto& ast = p.new_ast(get_noncomputable_tk(), p.pos());
+        if (!tk) tk = ast.m_id;
         mods.push(tk);
         tk = 0;
         p.next();
         bool force_noncomputable = false;
         if (p.curr_is_token_or_id(get_exclam_tk())) {
-            p.new_ast(get_exclam_tk(), p.pos());
+            ast.push(p.new_ast(get_exclam_tk(), p.pos()).m_id);
             p.next();
             force_noncomputable = true;
+        } else {
+            ast.push(0);
         }
         if (!meta.m_attrs && !meta.m_modifiers && p.curr_is_token_or_id(get_theory_tk())) {
             cmd_id = p.new_ast(get_theory_tk(), p.pos()).push(mods.m_id).m_id;

--- a/src/frontends/lean/decl_util.cpp
+++ b/src/frontends/lean/decl_util.cpp
@@ -566,20 +566,12 @@ environment add_alias(environment const & env, bool is_protected, name const & c
     }
 }
 
-noncomputable_modifier effective_noncomputable_modifier(noncomputable_policy policy, noncomputable_modifier modifier) {
-    if (policy == noncomputable_policy::ForceNoncomputable) {
-        return noncomputable_modifier::ForceNoncomputable;
-    } else {
-        return modifier;
-    }
-}
-
 bool should_force_noncomputable(noncomputable_modifier modifier) {
     return modifier == noncomputable_modifier::ForceNoncomputable;
 }
 
 bool should_validate_noncomputable(noncomputable_policy policy, noncomputable_modifier modifier) {
-    if (policy == noncomputable_policy::Auto || policy == noncomputable_policy::ForceNoncomputable)
+    if (policy == noncomputable_policy::Auto)
         return false;
     if (modifier == noncomputable_modifier::ForceNoncomputable)
         return false;

--- a/src/frontends/lean/decl_util.h
+++ b/src/frontends/lean/decl_util.h
@@ -21,7 +21,7 @@ enum class decl_cmd_kind { Theorem, Definition, Example, Instance, Var, Abbrevia
 
    This declaration should remain in sync with `interactive.noncomputable_modifier`. */
 enum class noncomputable_modifier {
-    /* Check that the definition is not noncomputable. */
+    /* Check that the definition is not noncomputable. (Default) */
     Computable,
     /* Check that the definition is noncomputable. */
     Noncomputable,
@@ -32,16 +32,13 @@ enum class noncomputable_modifier {
 /* Global policy for noncomputability checking.
    The precise interpretation is influenced by a declaration's noncomputable_modifier */
 enum class noncomputable_policy {
-    /* Validate that the user-supplied modifier matches the result of the noncomputability checker.  */
+    /* Validate that the user-supplied modifier matches the result of the noncomputability checker
+       if it's not ForceNoncomputable. (Default) */
     Validate,
-    /* Ignore the user-supplied modifier and rely on the result of the noncomputability checker. */
-    Auto,
-    /* Ignore noncomputability checker, force noncomputability, and inhibit VM compilation. */
-    ForceNoncomputable
+    /* Ignore the user-supplied modifier and rely on the result of the noncomputability checker
+       if it's not ForceNoncomputable. Enabled with the `noncomputable theory` command. */
+    Auto
 };
-
-/* Use the policy to compute the effective noncomputable modifier. */
-noncomputable_modifier effective_noncomputable_modifier(noncomputable_policy policy, noncomputable_modifier modifier);
 
 /* Whether a declaration should be forced to be marked noncomputable in the environment. */
 bool should_force_noncomputable(noncomputable_modifier modifier);

--- a/src/frontends/lean/decl_util.h
+++ b/src/frontends/lean/decl_util.h
@@ -17,15 +17,50 @@ class elaborator;
 
 enum class decl_cmd_kind { Theorem, Definition, Example, Instance, Var, Abbreviation };
 
+/* Enum for the noncomputability modifier for a declaration.
+
+   This declaration should remain in sync with `interactive.noncomputable_modifier`. */
+enum class noncomputable_modifier {
+    /* Check that the definition is not noncomputable. */
+    Computable,
+    /* Check that the definition is noncomputable. */
+    Noncomputable,
+    /* Ignore noncomputability checker, force noncomputability, and inhibit VM compilation. */
+    ForceNoncomputable
+};
+
+/* Global policy for noncomputability checking.
+   The precise interpretation is influenced by a declaration's noncomputable_modifier */
+enum class noncomputable_policy {
+    /* Validate that the user-supplied modifier matches the result of the noncomputability checker.  */
+    Validate,
+    /* Ignore the user-supplied modifier and rely on the result of the noncomputability checker. */
+    Auto,
+    /* Ignore noncomputability checker, force noncomputability, and inhibit VM compilation. */
+    ForceNoncomputable
+};
+
+/* Use the policy to compute the effective noncomputable modifier. */
+noncomputable_modifier effective_noncomputable_modifier(noncomputable_policy policy, noncomputable_modifier modifier);
+
+/* Whether a declaration should be forced to be marked noncomputable in the environment. */
+bool should_force_noncomputable(noncomputable_modifier modifier);
+
+/* Given the policy and modifier, whether the noncomputable_modifier should be checked to match
+   whether the declaration has been marked noncomputable in the environment.
+
+   Postcondition if true: modifier is either Computable or Noncomputable. */
+bool should_validate_noncomputable(noncomputable_policy policy, noncomputable_modifier modifier);
+
 struct decl_modifiers {
     bool m_is_private{false};
     bool m_is_protected{false};
     bool m_is_meta{false};
     bool m_is_mutual{false};
-    bool m_is_noncomputable{false};
+    noncomputable_modifier m_noncomputable{noncomputable_modifier::Computable};
 
     operator bool() const {
-        return m_is_private || m_is_protected || m_is_meta || m_is_mutual || m_is_noncomputable;
+        return m_is_private || m_is_protected || m_is_meta || m_is_mutual || m_noncomputable != noncomputable_modifier::Computable;
     }
 };
 

--- a/src/frontends/lean/definition_cmds.cpp
+++ b/src/frontends/lean/definition_cmds.cpp
@@ -228,8 +228,8 @@ static void validate_noncomputable(noncomputable_policy policy, environment cons
         && !is_marked_noncomputable(env, c_real_name)) {
         report_message(message(file_name, pos, WARNING,
                                (sstream() << "definition '" << c_name << "' was incorrectly marked as noncomputable").str()));
+        return;
     }
-    return;
 }
 
 static environment compile_decl(parser_info const & p, environment const & env,
@@ -934,10 +934,7 @@ environment single_definition_cmd_core(parser_info & p, decl_cmd_kind kind, ast_
     }
 }
 
-environment definition_cmd_core(parser & p, decl_cmd_kind kind, ast_id cmd_id, cmd_meta const & _meta) {
-    auto meta = _meta;
-    meta.m_modifiers.m_noncomputable = effective_noncomputable_modifier(p.get_noncomputable_policy(),
-                                                                        meta.m_modifiers.m_noncomputable);
+environment definition_cmd_core(parser & p, decl_cmd_kind kind, ast_id cmd_id, cmd_meta const & meta) {
     auto& data = p.get_ast(cmd_id).push(meta.m_modifiers_id);
     if (meta.m_modifiers.m_is_mutual) {
         data.push(p.new_ast("mutual", p.pos()).m_id);

--- a/src/frontends/lean/definition_cmds.cpp
+++ b/src/frontends/lean/definition_cmds.cpp
@@ -210,22 +210,26 @@ static certified_declaration check(parser_info const & p, environment const & en
     }
 }
 
-static bool check_noncomputable(bool ignore_noncomputable, environment const & env, name const & c_name, name const & c_real_name, bool is_noncomputable,
-                                std::string const & file_name, pos_info const & pos) {
-    if (ignore_noncomputable)
-        return true;
-    if (!is_noncomputable && is_marked_noncomputable(env, c_real_name)) {
+/* Validate whether the noncomputable modifier matches the noncomputable marking for declaration c_name in env. */
+static void validate_noncomputable(noncomputable_policy policy, environment const & env,
+                                   name const & c_name, name const & c_real_name, noncomputable_modifier noncomputable_mod,
+                                   std::string const & file_name, pos_info const & pos) {
+    if (!should_validate_noncomputable(policy, noncomputable_mod))
+        return;
+    if (noncomputable_mod == noncomputable_modifier::Computable
+        && is_marked_noncomputable(env, c_real_name)) {
         auto reason = get_noncomputable_reason(env, c_real_name);
         lean_assert(reason);
         report_message(message(file_name, pos, ERROR,
                                (sstream() << "definition '" << c_name << "' is noncomputable, it depends on '" << *reason << "'").str()));
-        return false;
+        return;
     }
-    if (is_noncomputable && !is_marked_noncomputable(env, c_real_name)) {
+    if (noncomputable_mod != noncomputable_modifier::Computable
+        && !is_marked_noncomputable(env, c_real_name)) {
         report_message(message(file_name, pos, WARNING,
                                (sstream() << "definition '" << c_name << "' was incorrectly marked as noncomputable").str()));
     }
-    return true;
+    return;
 }
 
 static environment compile_decl(parser_info const & p, environment const & env,
@@ -272,9 +276,9 @@ declare_definition(parser_info const & p, environment const & env, decl_cmd_kind
          (is_abbrev ? mk_definition(c_real_name, to_list(lp_names), type, *val, reducibility_hints::mk_abbreviation(), is_trusted) :
           mk_definition(new_env, c_real_name, to_list(lp_names), type, *val, use_conv_opt, is_trusted)));
     auto cdef         = check(p, new_env, c_name, def, pos);
-    new_env           = module::add(new_env, cdef);
+    new_env           = module::add(new_env, cdef, should_force_noncomputable(meta.m_modifiers.m_noncomputable));
 
-    check_noncomputable(p.ignore_noncomputable(), new_env, c_name, c_real_name, meta.m_modifiers.m_is_noncomputable, p.get_file_name(), pos);
+    validate_noncomputable(p.get_noncomputable_policy(), new_env, c_name, c_real_name, meta.m_modifiers.m_noncomputable, p.get_file_name(), pos);
 
     if (meta.m_modifiers.m_is_protected)
         new_env = add_protected(new_env, c_real_name);
@@ -733,7 +737,7 @@ static expr elaborate_proof(
 }
 
 static void check_example(environment const & decl_env, options const & opts,
-                          decl_modifiers modifiers, bool noncomputable_theory,
+                          decl_modifiers modifiers, noncomputable_policy noncomputable_pol,
                           level_param_names const & univ_params, list<expr> const & params,
                           expr const & fn, expr const & val0,
                           metavar_context const & mctx, local_context const & lctx,
@@ -762,9 +766,9 @@ static void check_example(environment const & decl_env, options const & opts,
         auto new_env = elab.env();
         auto def = mk_definition(new_env, decl_name, to_list(univ_params_buf), type, val, use_conv_opt, is_trusted);
         auto cdef = check(new_env, def);
-        new_env = module::add(new_env, cdef);
-        check_noncomputable(noncomputable_theory, new_env, decl_name, def.get_name(), modifiers.m_is_noncomputable,
-                                 pos_provider.get_file_name(), pos_provider.get_some_pos());
+        new_env = module::add(new_env, cdef, should_force_noncomputable(modifiers.m_noncomputable));
+        validate_noncomputable(noncomputable_pol, new_env, decl_name, def.get_name(), modifiers.m_noncomputable,
+                               pos_provider.get_file_name(), pos_provider.get_some_pos());
     } catch (throwable & ex) {
         message_builder error_msg(tc, decl_env, get_global_ios(),
                                   pos_provider.get_file_name(), pos_provider.get_some_pos(),
@@ -857,10 +861,10 @@ environment single_definition_cmd_core(parser_info & p, decl_cmd_kind kind, ast_
             auto lctx = elab.lctx();
             auto pos_provider = p.get_parser_pos_provider(p.cmd_pos());
             bool use_info_manager = get_global_info_manager() != nullptr;
-            bool noncomputable_theory = p.ignore_noncomputable();
+            noncomputable_policy noncomputable_pol = p.get_noncomputable_policy();
             std::string file_name = p.get_file_name();
             add_library_task<unit>([=] {
-                check_example(env, opts, meta.m_modifiers, noncomputable_theory,
+                check_example(env, opts, meta.m_modifiers, noncomputable_pol,
                               lp_name_list, new_params_list, fn, val, mctx, lctx,
                               pos_provider, use_info_manager, file_name);
                 return unit();
@@ -930,7 +934,10 @@ environment single_definition_cmd_core(parser_info & p, decl_cmd_kind kind, ast_
     }
 }
 
-environment definition_cmd_core(parser & p, decl_cmd_kind kind, ast_id cmd_id, cmd_meta const & meta) {
+environment definition_cmd_core(parser & p, decl_cmd_kind kind, ast_id cmd_id, cmd_meta const & _meta) {
+    auto meta = _meta;
+    meta.m_modifiers.m_noncomputable = effective_noncomputable_modifier(p.get_noncomputable_policy(),
+                                                                        meta.m_modifiers.m_noncomputable);
     auto& data = p.get_ast(cmd_id).push(meta.m_modifiers_id);
     if (meta.m_modifiers.m_is_mutual) {
         data.push(p.new_ast("mutual", p.pos()).m_id);

--- a/src/frontends/lean/inductive_cmds.cpp
+++ b/src/frontends/lean/inductive_cmds.cpp
@@ -680,7 +680,7 @@ class inductive_cmd_fn {
     }
 
     void check_modifiers() const {
-        if (m_meta_info.m_modifiers.m_is_noncomputable)
+        if (m_meta_info.m_modifiers.m_noncomputable != noncomputable_modifier::Computable)
             throw_error("invalid 'noncomputable' modifier for inductive type");
         if (m_meta_info.m_modifiers.m_is_private)
             throw_error("invalid 'private' modifier for inductive type");

--- a/src/frontends/lean/parser.cpp
+++ b/src/frontends/lean/parser.cpp
@@ -164,7 +164,7 @@ parser::parser(environment const & env, io_state const & ios,
     m_scanner(strm, m_file_name.c_str()),
     m_ast{new ast_data(0, {}, {}), new ast_data(AST_TOP_ID, {}, "file")} {
     m_next_inst_idx = 1;
-    m_ignore_noncomputable = false;
+    m_noncomputable_policy = noncomputable_policy::Validate;
     m_in_quote = false;
     m_in_pattern = false;
     m_has_params = false;
@@ -2904,7 +2904,7 @@ std::shared_ptr<snapshot> parser::mk_snapshot() {
     return std::make_shared<snapshot>(
             m_env, m_ngen, m_local_level_decls, m_local_decls,
             m_level_variables, m_variables, m_include_vars,
-            m_ios.get_options(), m_imports_parsed, m_ignore_noncomputable, m_parser_scope_stack, m_next_inst_idx, pos());
+            m_ios.get_options(), m_imports_parsed, m_noncomputable_policy, m_parser_scope_stack, m_next_inst_idx, pos());
 }
 
 optional<pos_info> parser::get_pos_info(expr const & e) const {
@@ -2958,7 +2958,7 @@ void parser::from_snapshot(snapshot const & s) {
     m_variables          = s.m_vars;
     m_include_vars       = s.m_include_vars;
     m_imports_parsed     = s.m_imports_parsed;
-    m_ignore_noncomputable = s.m_noncomputable_theory;
+    m_noncomputable_policy = s.m_noncomputable_policy;
     m_parser_scope_stack = s.m_parser_scope_stack;
     m_next_inst_idx      = s.m_next_inst_idx;
     m_ast_invalid        = true; // invalidate AST because we don't snapshot it

--- a/src/frontends/lean/parser.h
+++ b/src/frontends/lean/parser.h
@@ -56,9 +56,7 @@ protected:
     // profiling
     bool                   m_profile;
 
-    // If the following flag is true we do not raise error messages
-    // noncomputable definitions not tagged as noncomputable.
-    bool                   m_ignore_noncomputable;
+    noncomputable_policy    m_noncomputable_policy;
 
     // error recovery
     bool                   m_error_recovery = true;
@@ -142,8 +140,8 @@ public:
     virtual optional<pos_info> get_pos_info(expr const & e) const = 0;
     virtual message_builder mk_message(pos_info const &p, message_severity severity) const = 0;
     virtual message_builder mk_message(message_severity severity) const = 0;
-    bool ignore_noncomputable() const { return m_ignore_noncomputable; }
-    void set_ignore_noncomputable() { m_ignore_noncomputable = true; }
+    noncomputable_policy get_noncomputable_policy() const { return m_noncomputable_policy; }
+    void set_noncomputable_policy(noncomputable_policy p) { m_noncomputable_policy = p; }
     virtual char const * get_file_name() const = 0;
     virtual pos_info cmd_pos() const = 0;
     virtual optional<pos_info> const & get_break_at_pos() const = 0;
@@ -653,7 +651,6 @@ bool parse_commands(environment & env, io_state & ios, char const * fname);
 
 class dummy_def_parser : public parser_info {
 public:
-  bool            m_ignore_noncomputable;
   pos_info        m_pos;
   std::string     m_file_name;
   name            m_name;
@@ -668,7 +665,6 @@ public:
     parser_info(env, io_state(io_state(), opts))
       { m_error_recovery = false; }
   char const * get_file_name() const override { return m_file_name.c_str(); }
-  bool ignore_noncomputable() const { return m_ignore_noncomputable; }
   options get_options() const { return m_ios.get_options(); }
   message_builder mk_message(pos_info const &p, message_severity severity) const override {
     std::shared_ptr<abstract_type_context> tc = std::make_shared<type_context_old>(m_env, get_options());

--- a/src/frontends/lean/parser_state.h
+++ b/src/frontends/lean/parser_state.h
@@ -96,16 +96,17 @@ struct snapshot {
     name_set           m_include_vars; // subset of m_eds that must be included
     options            m_options;
     bool               m_imports_parsed;
-    bool               m_noncomputable_theory;
+    noncomputable_policy m_noncomputable_policy;
     parser_scope_stack m_parser_scope_stack;
     unsigned           m_next_inst_idx;
     pos_info           m_pos;
     snapshot(environment const & env, name_generator const & ngen, local_level_decls const & lds,
              local_expr_decls const & eds, name_set const & lvars, name_set const & vars,
-             name_set const & includes, options const & opts, bool imports_parsed, bool noncomputable_theory, parser_scope_stack const & pss,
+             name_set const & includes, options const & opts, bool imports_parsed,
+             noncomputable_policy noncomputable_policy, parser_scope_stack const & pss,
              unsigned next_inst_idx, pos_info const & pos):
         m_env(env), m_ngen(ngen), m_lds(lds), m_eds(eds), m_lvars(lvars), m_vars(vars), m_include_vars(includes),
-        m_options(opts), m_imports_parsed(imports_parsed), m_noncomputable_theory(noncomputable_theory),
+        m_options(opts), m_imports_parsed(imports_parsed), m_noncomputable_policy(noncomputable_policy),
         m_parser_scope_stack(pss), m_next_inst_idx(next_inst_idx), m_pos(pos)
         {}
 };

--- a/src/frontends/lean/tokens.cpp
+++ b/src/frontends/lean/tokens.cpp
@@ -123,6 +123,7 @@ static name const * g_inductive_tk = nullptr;
 static name const * g_instance_tk = nullptr;
 static name const * g_this_tk = nullptr;
 static name const * g_noncomputable_tk = nullptr;
+static name const * g_exclam_tk = nullptr;
 static name const * g_theory_tk = nullptr;
 static name const * g_key_equivalences_tk = nullptr;
 static name const * g_using_tk = nullptr;
@@ -248,6 +249,7 @@ void initialize_tokens() {
     g_instance_tk = new name{"instance"};
     g_this_tk = new name{"this"};
     g_noncomputable_tk = new name{"noncomputable"};
+    g_exclam_tk = new name{"!"};
     g_theory_tk = new name{"theory"};
     g_key_equivalences_tk = new name{"key_equivalences"};
     g_using_tk = new name{"using"};
@@ -374,6 +376,7 @@ void finalize_tokens() {
     delete g_instance_tk;
     delete g_this_tk;
     delete g_noncomputable_tk;
+    delete g_exclam_tk;
     delete g_theory_tk;
     delete g_key_equivalences_tk;
     delete g_using_tk;
@@ -499,6 +502,7 @@ name const & get_inductive_tk() { return *g_inductive_tk; }
 name const & get_instance_tk() { return *g_instance_tk; }
 name const & get_this_tk() { return *g_this_tk; }
 name const & get_noncomputable_tk() { return *g_noncomputable_tk; }
+name const & get_exclam_tk() { return *g_exclam_tk; }
 name const & get_theory_tk() { return *g_theory_tk; }
 name const & get_key_equivalences_tk() { return *g_key_equivalences_tk; }
 name const & get_using_tk() { return *g_using_tk; }

--- a/src/frontends/lean/tokens.h
+++ b/src/frontends/lean/tokens.h
@@ -125,6 +125,7 @@ name const & get_inductive_tk();
 name const & get_instance_tk();
 name const & get_this_tk();
 name const & get_noncomputable_tk();
+name const & get_exclam_tk();
 name const & get_theory_tk();
 name const & get_key_equivalences_tk();
 name const & get_using_tk();

--- a/src/library/module.cpp
+++ b/src/library/module.cpp
@@ -525,10 +525,10 @@ static task<bool> error_already_reported() {
     return any(children, [] (bool already_reported) { return already_reported; });
 }
 
-environment add(environment const & env, certified_declaration const & d) {
+environment add(environment const & env, certified_declaration const & d, bool force_noncomputable) {
     environment new_env = env.add(d);
     declaration _d = d.get_declaration();
-    if (!check_computable(new_env, _d.get_name()))
+    if (force_noncomputable || !check_computable(new_env, _d.get_name()))
         new_env = mark_noncomputable(new_env, _d.get_name());
     if (!is_private(new_env, _d.get_name()))
         new_env = add_parent_namespaces(new_env, strip_internal_suffixes(_d.get_name()));

--- a/src/library/module.h
+++ b/src/library/module.h
@@ -153,7 +153,7 @@ environment add(environment const & env, std::shared_ptr<modification const> con
 environment add_and_perform(environment const & env, std::shared_ptr<modification const> const & modif);
 
 /** \brief Add the given declaration to the environment, and mark it to be exported. */
-environment add(environment const & env, certified_declaration const & d);
+environment add(environment const & env, certified_declaration const & d, bool force_noncomputable = false);
 
 /** \brief Adds a module-level doc to the current module. */
 environment add_doc_string(environment const & env, std::string const & doc, pos_info pos);

--- a/src/library/vm/vm_parser.cpp
+++ b/src/library/vm/vm_parser.cpp
@@ -110,7 +110,7 @@ static vm_obj to_obj(decl_modifiers const & mods) {
             mk_vm_bool(mods.m_is_protected),
             mk_vm_bool(mods.m_is_meta),
             mk_vm_bool(mods.m_is_mutual),
-            mk_vm_bool(mods.m_is_noncomputable),
+            mk_vm_simple(static_cast<unsigned>(mods.m_noncomputable)),
     });
 }
 
@@ -137,9 +137,7 @@ decl_modifiers to_decl_modifiers(vm_obj const & o) {
     if (to_bool(cfield(o, 3))) {
         mods.m_is_mutual = true;
     }
-    if (to_bool(cfield(o, 4))) {
-        mods.m_is_noncomputable = true;
-    }
+    mods.m_noncomputable = static_cast<noncomputable_modifier>(cidx(cfield(o, 4)));
     return mods;
 }
 

--- a/tests/lean/noncomputable_modifier.lean
+++ b/tests/lean/noncomputable_modifier.lean
@@ -1,0 +1,35 @@
+import init.meta.interactive
+
+open tactic lean lean.parser interactive
+
+meta def describe_it : noncomputable_modifier → string
+| noncomputable_modifier.computable := "computable"
+| noncomputable_modifier.noncomputable := "noncomputable"
+| noncomputable_modifier.force_noncomputable := "force_noncomputable"
+
+@[user_command] meta def my_command (mi : interactive.decl_meta_info)
+  (_ : parse (tk "my_command")) : parser unit := do
+trace $ describe_it mi.modifiers.is_noncomputable
+.
+
+my_command
+
+noncomputable
+my_command
+
+noncomputable!
+my_command
+
+def n1 : ℕ := 37
+#eval n1
+noncomputable def n2 : ℕ := 37
+#eval n2
+noncomputable! def n3 : ℕ := 37
+#eval n3
+
+noncomputable theory
+noncomputable def n4 : ℕ := 37
+#eval n4
+noncomputable! def n5 : ℕ := 37
+#eval n5
+noncomputable! theory

--- a/tests/lean/noncomputable_modifier.lean.expected.out
+++ b/tests/lean/noncomputable_modifier.lean.expected.out
@@ -1,0 +1,10 @@
+computable
+noncomputable
+force_noncomputable
+37
+noncomputable_modifier.lean:25:18: warning: definition 'n2' was incorrectly marked as noncomputable
+37
+noncomputable_modifier.lean:28:0: error: code generation failed, VM does not have code for 'n3'
+37
+noncomputable_modifier.lean:34:0: error: code generation failed, VM does not have code for 'n5'
+noncomputable_modifier.lean:35:15: error: invalid 'noncomputable! theory', unsupported noncomputability policy


### PR DESCRIPTION
This adds a user-visible feature: the `noncomputable!` modifier. Definitions with this will not have their computability checked, will be marked noncomputable when added to the environment, and will not be VM compiled. Noncomputability modifiers interact with the `noncomputable theory` command in the following way:

1. Without `noncomputable theory`
   1. No modifier: check is computable, run VM compiler
   2. `noncomputable`: check is noncomputable, do not VM compile, mark declaration as noncomputable
   3. `noncomputable!`: do not test computability, do not VM compile, and mark declaration as noncomputable
2. With `noncomputable theory`
   1. No modifier or `noncomputable`: if computable, run VM compiler; if noncomputable, mark declaration as noncomputable and do not VM compile
   2. `noncomputable!`: do not test computability, do not VM compile, and mark declaration as noncomputable

A `noncomputable! theory` command is explicitly not supported to avoid the possibility of making the Lean 4 porting effort any more difficult.

Behind the scenes, there is a little bit of cleanup, refactoring, and additional internal documentation.