### PR TITLE
[Merged by Bors] - fix(noncomputable,definition_cmds): require non-Prop theorems to be noncomputable

### DIFF
--- a/library/init/classical.lean
+++ b/library/init/classical.lean
@@ -33,12 +33,9 @@ private def V (x : Prop) : Prop := x = false ∨ p
 private lemma exU : ∃ x, U x := ⟨true, or.inl rfl⟩
 private lemma exV : ∃ x, V x := ⟨false, or.inl rfl⟩
 
-/- TODO(Leo): check why the code generator is not ignoring (some exU)
-   when we mark u as def. -/
-private lemma u : Prop := some exU
-private lemma v : Prop := some exV
+private def u : Prop := some exU
+private def v : Prop := some exV
 
-set_option type_context.unfold_lemmas true
 private lemma u_def : U u := some_spec exU
 private lemma v_def : V v := some_spec exV
 

--- a/library/init/core.lean
+++ b/library/init/core.lean
@@ -189,7 +189,7 @@ lemma prod.mk.inj {α : Type u} {β : Type v} {x₁ : α} {y₁ : β} {x₂ : α
   : (x₁, y₁) = (x₂, y₂) → and (x₁ = x₂) (y₁ = y₂) :=
 λ h, prod.no_confusion h (λ h₁ h₂, ⟨h₁, h₂⟩)
 
-lemma prod.mk.inj_arrow {α : Type u} {β : Type v} {x₁ : α} {y₁ : β} {x₂ : α} {y₂ : β}
+def prod.mk.inj_arrow {α : Type u} {β : Type v} {x₁ : α} {y₁ : β} {x₂ : α} {y₂ : β}
   : (x₁, y₁) = (x₂, y₂) → Π ⦃P : Sort w⦄, (x₁ = x₂ → y₁ = y₂ → P) → P :=
 λ h₁ _ h₂, prod.no_confusion h₁ h₂
 
@@ -197,7 +197,7 @@ lemma pprod.mk.inj {α : Sort u} {β : Sort v} {x₁ : α} {y₁ : β} {x₂ : �
   : pprod.mk x₁ y₁ = pprod.mk x₂ y₂ → and (x₁ = x₂) (y₁ = y₂) :=
 λ h, pprod.no_confusion h (λ h₁ h₂, ⟨h₁, h₂⟩)
 
-lemma pprod.mk.inj_arrow {α : Type u} {β : Type v} {x₁ : α} {y₁ : β} {x₂ : α} {y₂ : β}
+def pprod.mk.inj_arrow {α : Type u} {β : Type v} {x₁ : α} {y₁ : β} {x₂ : α} {y₂ : β}
   : (x₁, y₁) = (x₂, y₂) → Π ⦃P : Sort w⦄, (x₁ = x₂ → y₁ = y₂ → P) → P :=
 λ h₁ _ h₂, prod.no_confusion h₁ h₂
 

--- a/src/frontends/lean/definition_cmds.cpp
+++ b/src/frontends/lean/definition_cmds.cpp
@@ -220,14 +220,19 @@ static void validate_noncomputable(noncomputable_policy policy, environment cons
         && is_marked_noncomputable(env, c_real_name)) {
         auto reason = get_noncomputable_reason(env, c_real_name);
         lean_assert(reason);
-        report_message(message(file_name, pos, ERROR,
-                               (sstream() << "definition '" << c_name << "' is noncomputable, it depends on '" << *reason << "'").str()));
+        if (*reason == c_real_name) {
+            report_message(message(file_name, pos, ERROR,
+                (sstream() << "missing 'noncomputable' modifier, definition '" << c_real_name << "' is not compiled").str()));
+        } else {
+            report_message(message(file_name, pos, ERROR,
+                (sstream() << "missing 'noncomputable' modifier, definition '" << c_name << "' depends on '" << *reason << "'").str()));
+        }
         return;
     }
     if (noncomputable_mod != noncomputable_modifier::Computable
         && !is_marked_noncomputable(env, c_real_name)) {
         report_message(message(file_name, pos, WARNING,
-                               (sstream() << "definition '" << c_name << "' was incorrectly marked as noncomputable").str()));
+            (sstream() << "unexpected 'noncomputable' modifier, definition '" << c_name << "' is computable").str()));
         return;
     }
 }

--- a/src/library/noncomputable.cpp
+++ b/src/library/noncomputable.cpp
@@ -227,6 +227,10 @@ optional<name> get_noncomputable_reason(environment const & env, name const & n)
     type_checker tc(env);
     if (tc.is_prop(d.get_type()))
         return optional<name>(); // definition is a proposition, then do nothing
+    if (d.is_theorem()) {
+        // definition is a non-Prop theorem
+        return optional<name>(n);
+    }
     expr const & v = d.get_value();
     auto ext = get_extension(env);
     bool ok  = true;

--- a/src/library/noncomputable.h
+++ b/src/library/noncomputable.h
@@ -15,6 +15,9 @@ bool is_noncomputable(environment const & env, name const & n);
 environment mark_noncomputable(environment const & env, name const & n);
 /** \brief In standard mode, check if definitions that are not propositions can compute */
 bool check_computable(environment const & env, name const & n);
+/** \brief If noncomputable, returns a name of a declaration that is the reason for this.
+ * Returns \c n itself if the reason it's noncomputable is that it is computationally
+ * relevant but will not be VM compiled (e.g. non-Prop theorems). */
 optional<name> get_noncomputable_reason(environment const & env, name const & n);
 void initialize_noncomputable();
 void finalize_noncomputable();

--- a/tests/lean/def2.lean.expected.out
+++ b/tests/lean/def2.lean.expected.out
@@ -1,1 +1,1 @@
-def2.lean:3:11: error: definition 'foo' is noncomputable, it depends on 'val'
+def2.lean:3:11: error: missing 'noncomputable' modifier, definition 'foo' depends on 'val'

--- a/tests/lean/empty.lean
+++ b/tests/lean/empty.lean
@@ -1,6 +1,6 @@
 --
 open inhabited nonempty classical
 
-lemma v1 : Prop := epsilon (λ x : Prop, true)
+noncomputable lemma v1 : Prop := epsilon (λ x : Prop, true)
 inductive Empty : Type
 noncomputable definition v2 : Empty := epsilon (λ x, true)

--- a/tests/lean/noncomp.lean.expected.out
+++ b/tests/lean/noncomp.lean.expected.out
@@ -1,1 +1,1 @@
-noncomp.lean:5:11: error: definition 'f' is noncomputable, it depends on 'n'
+noncomp.lean:5:11: error: missing 'noncomputable' modifier, definition 'f' depends on 'n'

--- a/tests/lean/noncomp_error.lean.expected.out
+++ b/tests/lean/noncomp_error.lean.expected.out
@@ -1,1 +1,1 @@
-noncomp_error.lean:1:25: warning: definition 'a' was incorrectly marked as noncomputable
+noncomp_error.lean:1:25: warning: unexpected 'noncomputable' modifier, definition 'a' is computable

--- a/tests/lean/noncomp_thm.lean.expected.out
+++ b/tests/lean/noncomp_thm.lean.expected.out
@@ -1,1 +1,1 @@
-noncomp_thm.lean:1:22: warning: definition 'foo' was incorrectly marked as noncomputable
+noncomp_thm.lean:1:22: warning: unexpected 'noncomputable' modifier, definition 'foo' is computable

--- a/tests/lean/noncomputable_lemma.lean
+++ b/tests/lean/noncomputable_lemma.lean
@@ -1,0 +1,2 @@
+noncomputable lemma a : ℕ := 37
+lemma b : ℕ := 37

--- a/tests/lean/noncomputable_lemma.lean.expected.out
+++ b/tests/lean/noncomputable_lemma.lean.expected.out
@@ -1,0 +1,1 @@
+noncomputable_lemma.lean:2:6: error: missing 'noncomputable' modifier, definition 'b' is not compiled

--- a/tests/lean/noncomputable_modifier.lean.expected.out
+++ b/tests/lean/noncomputable_modifier.lean.expected.out
@@ -2,7 +2,7 @@ computable
 noncomputable
 force_noncomputable
 37
-noncomputable_modifier.lean:25:18: warning: definition 'n2' was incorrectly marked as noncomputable
+noncomputable_modifier.lean:25:18: warning: unexpected 'noncomputable' modifier, definition 'n2' is computable
 37
 noncomputable_modifier.lean:28:0: error: code generation failed, VM does not have code for 'n3'
 37

--- a/tests/lean/noncomputable_reason.lean
+++ b/tests/lean/noncomputable_reason.lean
@@ -2,6 +2,8 @@ constant foo : ℕ
 
 noncomputable def bar : ℕ := foo
 
+noncomputable lemma bar' : ℕ := 37
+
 def baz : ℕ := 0
 
 open tactic
@@ -9,4 +11,5 @@ run_cmd do
   e ← get_env,
   trace $ e.decl_noncomputable_reason `foo,
   trace $ e.decl_noncomputable_reason `bar,
+  trace $ e.decl_noncomputable_reason `bar',
   trace $ e.decl_noncomputable_reason `baz

--- a/tests/lean/noncomputable_reason.lean.expected.out
+++ b/tests/lean/noncomputable_reason.lean.expected.out
@@ -1,3 +1,4 @@
 none
 (some foo)
+(some bar')
 none

--- a/tests/lean/run/1728.lean
+++ b/tests/lean/run/1728.lean
@@ -8,7 +8,7 @@ class Finite ( α : Type ) :=
   ( cardinality : nat )
   ( bijection : Bijection α (fin cardinality) )
 
-lemma empty_exfalso (x : false) : empty := begin exfalso, trivial end
+def empty_exfalso (x : false) : empty := begin exfalso, trivial end
 
 instance empty_is_Finite : Finite empty := {
   cardinality := 0,

--- a/tests/lean/run/372c.lean
+++ b/tests/lean/run/372c.lean
@@ -1,5 +1,5 @@
 def foo (n : ℕ) := Type
 def beta (n : ℕ) : foo n :=
 by unfold foo; exact ℕ → ℕ
-lemma baz (n : ℕ) : beta n := id
+noncomputable lemma baz (n : ℕ) : beta n := id
 example : ℕ := by apply baz <|> exact 0

--- a/tests/lean/run/abstract_zeta.lean
+++ b/tests/lean/run/abstract_zeta.lean
@@ -2,6 +2,7 @@
 -- subterm proving `n < 5`, we need to zeta-expand n not just in the subterm,
 -- but also in the local context.
 
+noncomputable
 lemma bug₁ : fin 5 :=
 let n : ℕ := 3 in
 have h : n < 5, from dec_trivial,

--- a/tests/lean/run/class2.lean
+++ b/tests/lean/run/class2.lean
@@ -1,5 +1,5 @@
 open tactic
-theorem H {A B : Type} (H1 : inhabited A) : inhabited (Prop × A × (B → nat))
+def H {A B : Type} (H1 : inhabited A) : inhabited (Prop × A × (B → nat))
 := by apply_instance
 
 #print H

--- a/tests/lean/run/class3.lean
+++ b/tests/lean/run/class3.lean
@@ -6,7 +6,7 @@ section
   variable Ha : inhabited A
   variable Hb : inhabited B
   include Ha Hb
-  theorem tst : inhabited (Prop × A × B) := by apply_instance
+  def tst : inhabited (Prop × A × B) := by apply_instance
 
 end
 

--- a/tests/lean/run/class6.lean
+++ b/tests/lean/run/class6.lean
@@ -6,14 +6,14 @@ inductive t1 : Type
 inductive t2 : Type
 | mk2 : t2
 
-theorem inhabited_t1 : inhabited t1
+def inhabited_t1 : inhabited t1
 := inhabited.mk t1.mk1
 
-theorem inhabited_t2 : inhabited t2
+def inhabited_t2 : inhabited t2
 := inhabited.mk t2.mk2
 
 attribute [instance] inhabited_t1
 attribute [instance] inhabited_t2
 
-theorem T : inhabited (t1 × t2)
+def T : inhabited (t1 × t2)
 := by apply_instance

--- a/tests/lean/run/e3.lean
+++ b/tests/lean/run/e3.lean
@@ -4,6 +4,7 @@ definition Prop := Type.{0}
 definition false := ∀x : Prop, x
 #check false
 
+noncomputable
 theorem false.elim (C : Prop) (H : false) : C
 := H C
 
@@ -14,8 +15,10 @@ definition Eq {A : Type} (a b : A)
 
 infix `=`:50 := Eq
 
+noncomputable
 theorem refl {A : Type} (a : A) : a = a
 := λ P H, H
 
+noncomputable
 theorem subst {A : Type} {P : A -> Prop} {a b : A} (H1 : a = b) (H2 : P a) : P b
 := @H1 P H2

--- a/tests/lean/run/has_sizeof_indices.lean
+++ b/tests/lean/run/has_sizeof_indices.lean
@@ -3,7 +3,7 @@ universes u
 inductive foo : nat → Type
 | baz (n : nat) : foo n → foo (nat.succ n)
 
-lemma foo.size (α β : Type u) (n a : ℕ) : has_sizeof (foo a) :=
+def foo.size (α β : Type u) (n a : ℕ) : has_sizeof (foo a) :=
 by tactic.mk_has_sizeof_instance
 
 inductive bla : nat → bool → Type
@@ -11,5 +11,5 @@ inductive bla : nat → bool → Type
 | baz (n : nat) : bla n ff → bla (nat.succ n) tt
 | boo (n : nat) : bla n tt → bla (nat.succ n) ff
 
-lemma bla.size (α β : Type u) (a : ℕ) (t : bool)  : has_sizeof (bla a t) :=
+def bla.size (α β : Type u) (a : ℕ) (t : bool)  : has_sizeof (bla a t) :=
 by tactic.mk_has_sizeof_instance

--- a/tests/lean/run/match3.lean
+++ b/tests/lean/run/match3.lean
@@ -10,7 +10,7 @@ example : foo 3 = 2 := rfl
 
 open decidable
 
-protected theorem dec_eq : ∀ x y : nat, decidable (x = y)
+protected def dec_eq : ∀ x y : nat, decidable (x = y)
 | 0        0        := is_true rfl
 | (succ x) 0        := is_false (λ h, nat.no_confusion h)
 | 0       (succ y) := is_false (λ h, nat.no_confusion h)

--- a/tests/lean/run/partial_explicit1.lean
+++ b/tests/lean/run/partial_explicit1.lean
@@ -1,2 +1,2 @@
-lemma eq_rect (A : Type) (x : A) (P : A → Type) (f : P x) (y : A) (e : x = y) : P y :=
+def eq_rect (A : Type) (x : A) (P : A → Type) (f : P x) (y : A) (e : x = y) : P y :=
   @eq.rec_on _ _ (λ (y : A), P y) _ e f

--- a/tests/lean/run/soundness.lean
+++ b/tests/lean/run/soundness.lean
@@ -84,7 +84,7 @@ namespace PropF
 
   open Nc
 
-  lemma weakening2 : ∀ {Γ A Δ}, Γ ⊢ A → Γ ⊆ Δ → Δ ⊢ A
+  def weakening2 : ∀ {Γ A Δ}, Γ ⊢ A → Γ ⊆ Δ → Δ ⊢ A
   | ._ ._       Δ (Nax Γ A Hin)          Hs := Nax _ _ (Hs Hin)
   | ._ .(A ⇒ B) Δ (ImpI Γ A B H)         Hs := ImpI _ _ _ (weakening2 H (cons_subset_cons A Hs))
   | ._ ._       Δ (ImpE Γ A B H₁ H₂)     Hs := ImpE _ _ _ (weakening2 H₁ Hs) (weakening2 H₂ Hs)
@@ -97,13 +97,13 @@ namespace PropF
   | ._ ._       Δ (OrE Γ A B C H₁ H₂ H₃) Hs :=
        OrE _ _ _ _ (weakening2 H₁ Hs) (weakening2 H₂ (cons_subset_cons A Hs)) (weakening2 H₃ (cons_subset_cons B Hs))
 
-  lemma weakening : ∀ Γ Δ A, Γ ⊢ A → Γ++Δ ⊢ A :=
+  def weakening : ∀ Γ Δ A, Γ ⊢ A → Γ++Δ ⊢ A :=
   λ Γ Δ A H, weakening2 H (subset_append_left Γ Δ)
 
-  lemma deduction : ∀ Γ A B, Γ ⊢ A ⇒ B → A::Γ ⊢ B :=
+  def deduction : ∀ Γ A B, Γ ⊢ A ⇒ B → A::Γ ⊢ B :=
   λ Γ A B H, ImpE _ _ _ (weakening2 H (subset_cons A Γ)) (Nax _ _ (mem_cons_self A Γ))
 
-  lemma prov_impl : ∀ A B, Provable (A ⇒ B) → ∀ Γ, Γ ⊢ A → Γ ⊢ B :=
+  def prov_impl : ∀ A B, Provable (A ⇒ B) → ∀ Γ, Γ ⊢ A → Γ ⊢ B :=
   λ A B Hp Γ Ha,
     have wHp : Γ ⊢ (A ⇒ B), from weakening _ _ _ Hp,
     ImpE _ _ _ wHp Ha

--- a/tests/lean/run/specialize.lean
+++ b/tests/lean/run/specialize.lean
@@ -20,7 +20,7 @@ begin
   specialize (@f _ x), exact f,
 end
 
-lemma test5 (X : Type) [has_add X] (f : forall {A : Type} [has_add A], A → A → A) (x : X) : X :=
+def test5 (X : Type) [has_add X] (f : forall {A : Type} [has_add A], A → A → A) (x : X) : X :=
 begin
   specialize (f x x), assumption
 end

--- a/tests/lean/run/whnfinst.lean
+++ b/tests/lean/run/whnfinst.lean
@@ -7,9 +7,9 @@ section
   variable {A : Type}
   variable (R : A → A → Prop)
 
-  theorem tst1 (H : Πx y, decidable (R x y)) (a b c : A) : decidable (R a b ∧ R b a) :=
+  def tst1 (H : Πx y, decidable (R x y)) (a b c : A) : decidable (R a b ∧ R b a) :=
   by tactic.apply_instance
 
-  theorem tst2 (H : decidable_bin_rel R) (a b c : A) : decidable (R a b ∧ R b a ∨ R b b) :=
+  def tst2 (H : decidable_bin_rel R) (a b c : A) : decidable (R a b ∧ R b a ∨ R b b) :=
   by tactic.apply_instance
 end


### PR DESCRIPTION
The noncomputability checker is meant to determine what can and cannot be VM compiled, and since theorems do not get VM compiled, non-Prop theorems should be noncomputable. This is more restrictive than necessary, but at least for mathlib every theorem must be Prop-valued to pass the linter anyway.

The noncomputability error messages are also somewhat improved.