### PR TITLE
[Merged by Bors] - fix(noncomputable, definition_cmds): better error message for non-Prop theorems

### DIFF
--- a/src/frontends/lean/cmd_table.h
+++ b/src/frontends/lean/cmd_table.h
@@ -25,7 +25,7 @@ struct cmd_meta {
              optional<std::string> const & doc = optional<std::string>()):
         m_attrs(attrs), m_modifiers(mods), m_doc_string(doc) {}
 
-    void throw_exception_if_nonempty() const & {
+    void throw_exception_if_nonempty() const {
         if (m_modifiers)
             throw exception("command does not accept modifiers");
         if (m_attrs)

--- a/tests/lean/noncomputable_lemma.lean
+++ b/tests/lean/noncomputable_lemma.lean
@@ -1,2 +1,6 @@
 noncomputable lemma a : ℕ := 37
 lemma b : ℕ := 37
+-- do not report missing noncomputable:
+lemma sorry_type : sorry := sorry
+-- do not report missing noncomputable:
+lemma incomplete :

--- a/tests/lean/noncomputable_lemma.lean.expected.out
+++ b/tests/lean/noncomputable_lemma.lean.expected.out
@@ -1,1 +1,4 @@
-noncomputable_lemma.lean:2:6: error: missing 'noncomputable' modifier, definition 'b' is not compiled
+noncomputable_lemma.lean:2:6: error: theorems do not get VM compiled, use 'def' or add 'noncomputable' modifier to 'b'
+noncomputable_lemma.lean:4:0: warning: declaration 'sorry_type' uses sorry
+noncomputable_lemma.lean:6:18: error: invalid expression, unexpected token
+noncomputable_lemma.lean:6:0: warning: declaration 'incomplete' uses sorry


### PR DESCRIPTION
The error message for non-Prop theorems gives misleading advice -- you likely want to switch to using a `def` rather than adding `noncomputable`. This change also prevents the error from appearing if the type of the theorem contains `sorry`, since a user is likely in the process of editing the theorem and the `def`/`noncomputable` advice is unhelpful.