### PR TITLE
[Merged by Bors] - refactor(library/init/logic): remove tc

### DIFF
--- a/library/init/logic.lean
+++ b/library/init/logic.lean
@@ -1059,9 +1059,6 @@ lemma inv_image.trans (f : α → β) (h : transitive r) : transitive (inv_image
 lemma inv_image.irreflexive (f : α → β) (h : irreflexive r) : irreflexive (inv_image r f) :=
 λ (a : α) (h₁ : inv_image r f a a), h (f a) h₁
 
-inductive tc {α : Sort u} (r : α → α → Prop) : α → α → Prop
-| base  : ∀ a b, r a b → tc a b
-| trans : ∀ a b c, tc a b → tc b c → tc a c
 end relation
 
 section binary

--- a/library/init/wf.lean
+++ b/library/init/wf.lean
@@ -106,25 +106,6 @@ section
 end
 end inv_image
 
--- The transitive closure of a well-founded relation is well-founded
-namespace tc
-section
-  parameters {α : Sort u} {r : α → α → Prop}
-  local notation `r⁺` := tc r
-
-  lemma accessible {z : α} (ac : acc r z) : acc (tc r) z :=
-  acc.rec_on ac (λ x acx ih,
-    acc.intro x (λ y rel,
-      tc.rec_on rel
-        (λ a b rab acx ih, ih a rab)
-        (λ a b c rab rbc ih₁ ih₂ acx ih, acc.inv (ih₂ acx ih) rab)
-        acx ih))
-
-  lemma wf (h : well_founded r) : well_founded r⁺ :=
-  ⟨λ a, accessible (apply h a)⟩
-end
-end tc
-
 /-- less-than is well-founded -/
 lemma nat.lt_wf : well_founded nat.lt :=
 ⟨nat.rec

--- a/tests/lean/run/type_equations.lean
+++ b/tests/lean/run/type_equations.lean
@@ -12,13 +12,34 @@ inductive direct_subterm : Expr → Expr → Prop
 | add_2 : ∀ e₁ e₂ : Expr, direct_subterm e₂ (add e₁ e₂)
 
 theorem direct_subterm_wf : well_founded direct_subterm :=
-sorry
-/-
 begin
   constructor, intro e, induction e,
-  repeat (constructor; intro y hlt; cases hlt; repeat assumption)
+  repeat { constructor, intros y hlt, cases hlt; assumption },
 end
--/
+
+inductive tc {α : Sort*} (r : α → α → Prop) : α → α → Prop
+| base  : ∀ a b, r a b → tc a b
+| trans : ∀ a b c, tc a b → tc b c → tc a c
+
+-- The transitive closure of a well-founded relation is well-founded
+-- (moved to mathlib)
+namespace tc
+section
+  parameters {α : Sort*} {r : α → α → Prop}
+  local notation `r⁺` := tc r
+
+  lemma accessible {z : α} (ac : acc r z) : acc (tc r) z :=
+  acc.rec_on ac (λ x acx ih,
+    acc.intro x (λ y rel,
+      tc.rec_on rel
+        (λ a b rab acx ih, ih a rab)
+        (λ a b c rab rbc ih₁ ih₂ acx ih, acc.inv (ih₂ acx ih) rab)
+        acx ih))
+
+  lemma wf (h : well_founded r) : well_founded r⁺ :=
+  ⟨λ a, accessible (h.apply a)⟩
+end
+end tc
 
 definition subterm := tc direct_subterm
 


### PR DESCRIPTION
Mathlib has its own version of transitive closure as `relation.trans_gen`, so this commit removes the relatively unused version from core. The transitive closure of a well-founded relation is already in mathlib as `relation.well_founded.trans_gen`.

Co-authored-by: Junyan Xu <junyanxu.math@gmail.com>