### PR TITLE
[Merged by Bors] - chore(init/data/nat/lemmas): Turn implicit arguments to `↔`

### DIFF
--- a/library/init/data/nat/bitwise.lean
+++ b/library/init/data/nat/bitwise.lean
@@ -119,7 +119,7 @@ def binary_rec {C : nat → Sort u} (z : C 0) (f : ∀ b n, C n → C (bit b n))
 | n := if n0 : n = 0 then by rw n0; exact z else let n' := div2 n in
     have n' < n, begin
       change div2 n < n, rw div2_val,
-      apply (div_lt_iff_lt_mul _ _ (succ_pos 1)).2,
+      apply (div_lt_iff_lt_mul $ succ_pos 1).2,
       have := nat.mul_lt_mul_of_pos_left (lt_succ_self 1)
         (lt_of_le_of_ne n.zero_le (ne.symm n0)),
       rwa nat.mul_one at this


### PR DESCRIPTION
Make arguments to equivalences implicit and rename the corresponding lemmas according to the corresponding mathlib names:
* `add_le_add_iff_le_right` → `add_le_add_iff_le_right`
* `sub_le_sub_right_iff` → `sub_le_sub_iff_right`
* `add_le_to_le_sub` → `le_sub_iff_right`