### PR TITLE
[Merged by Bors] - feat: io.unsafe_perform_io

### DIFF
--- a/library/system/io.lean
+++ b/library/system/io.lean
@@ -266,17 +266,7 @@ This primitive is used to invoke external tools (e.g., SAT and SMT solvers) from
 IMPORTANT: this primitive can be used to implement `unsafe_perform_io {α : Type} : io α → option α`
 or `unsafe_perform_io {α : Type} [inhabited α] : io α → α`. This can be accomplished by executing
 the resulting tactic using an empty `tactic_state` (we have `tactic_state.mk_empty`).
-If `unsafe_perform_io` is defined, and used to perform side-effects, users need to take the following
-precautions:
 
-- Use `@[noinline]` attribute in any function to invokes `tactic.unsafe_perform_io`.
-  Reason: if the call is inlined, the IO may be performed more than once.
-
-- Set `set_option compiler.cse false` before any function that invokes `tactic.unsafe_perform_io`.
-  This option disables common subexpression elimination. Common subexpression elimination
-  might combine two side effects that were meant to be separate.
-
-TODO[Leo]: add `[noinline]` attribute and option `compiler.cse`.
 -/
 meta constant tactic.unsafe_run_io {α : Type} : io α → tactic α
 
@@ -289,3 +279,19 @@ meta constant tactic.unsafe_run_io {α : Type} : io α → tactic α
    This action is mainly useful for writing tactics that inspect
    the environment. -/
 meta constant io.run_tactic {α : Type} (a : tactic α) : io α
+
+/-- Similarly to `tactic.unsafe_run_io`, this gives an unsafe backdoor to run io inside a pure function.
+
+If `unsafe_perform_io` is used to perform side-effects, users need to take the following
+precautions:
+
+- Use `@[noinline]` attribute in any function to invokes `tactic.unsafe_perform_io`.
+  Reason: if the call is inlined, the IO may be performed more than once.
+
+- Set `set_option compiler.cse false` before any function that invokes `tactic.unsafe_perform_io`.
+  This option disables common subexpression elimination. Common subexpression elimination
+  might combine two side effects that were meant to be separate.
+
+TODO[Leo]: add `[noinline]` attribute and option `compiler.cse`.
+-/
+meta constant io.unsafe_perform_io {α : Type} (a : io α) : except io.error α

--- a/library/system/io.lean
+++ b/library/system/io.lean
@@ -263,10 +263,6 @@ This is the "back door" into the `io` monad, allowing IO computation to be perfo
 For this to be safe, the IO computation should be ideally free of side effects and independent of its environment.
 This primitive is used to invoke external tools (e.g., SAT and SMT solvers) from a tactic.
 
-IMPORTANT: this primitive can be used to implement `unsafe_perform_io {α : Type} : io α → option α`
-or `unsafe_perform_io {α : Type} [inhabited α] : io α → α`. This can be accomplished by executing
-the resulting tactic using an empty `tactic_state` (we have `tactic_state.mk_empty`).
-
 -/
 meta constant tactic.unsafe_run_io {α : Type} : io α → tactic α
 

--- a/src/library/tactic/tactic_state.cpp
+++ b/src/library/tactic/tactic_state.cpp
@@ -876,6 +876,18 @@ vm_obj io_run_tactic(vm_obj const &, vm_obj const & tac, vm_obj const &) {
     }
 }
 
+// io.unsafe_run {α} : io α → except io.error α
+vm_obj io_unsafe_perform_io(vm_obj const &, vm_obj const & a) {
+    vm_obj r = invoke(a, mk_vm_unit());
+    if (optional<vm_obj> a = is_io_result(r)) {
+        return mk_vm_constructor(1, *a); // except.ok
+    } else {
+        optional<vm_obj> e = is_io_error(r);
+        lean_assert(e);
+        return mk_vm_constructor(0, *e); // except.error
+    }
+}
+
 unsigned tactic_user_state::alloc(vm_obj const & v) {
     unsigned r;
     if (m_free_refs) {
@@ -1171,6 +1183,7 @@ void initialize_tactic_state() {
     DECLARE_VM_BUILTIN(name({"tactic", "frozen_local_instances"}),   tactic_frozen_local_instances);
     DECLARE_VM_BUILTIN(name({"tactic", "with_ast"}),             tactic_with_ast);
     DECLARE_VM_BUILTIN(name({"io", "run_tactic"}),               io_run_tactic);
+    DECLARE_VM_BUILTIN(name({"io", "unsafe_perform_io"}),               io_unsafe_perform_io);
 }
 
 void finalize_tactic_state() {

--- a/tests/lean/run/io_unsafe_perform_io.lean
+++ b/tests/lean/run/io_unsafe_perform_io.lean
@@ -1,0 +1,12 @@
+
+import system.io
+open list io
+
+def getD {ε α : Type} (d : α): except ε α → α
+  | (except.ok a) := a
+  | (except.error e) := d
+
+meta def f (i : nat) : nat :=
+   getD 100 $ io.unsafe_perform_io (do put_str "value: ", print i, put_str "\n", pure i)
+
+#eval list.map f [0,1,2,3,4]


### PR DESCRIPTION
Introduces a function `io.unsafe_perform_io : io α → except io.error α`.
It is not possible to derive this from `tactic.unsafe_run_io` because
there is no `tactic_state.mk_empty`. The warnings about compiler
optimisations have been moved from the `tactic.unsafe_run_io` docstring
to `io.unsafe_perform_io`.