### PR TITLE
fix(lean/elaborator.cpp): reject `Sort` and suggest `Prop`

### DIFF
--- a/src/frontends/lean/elaborator.cpp
+++ b/src/frontends/lean/elaborator.cpp
@@ -3513,7 +3513,11 @@ expr elaborator::visit(expr const & e, optional<expr> const & expected_type) {
         } else if (is_emptyc_or_emptys(e)) {
             return visit_emptyc_or_emptys(e, expected_type);
         } else if (is_sort_wo_universe(e)) {
-            return visit(get_annotation_arg(e), expected_type);
+            auto& arg = get_annotation_arg(e);
+            if (sort_level(arg) == mk_level_zero())
+                report_or_throw(elaborator_exception(arg,
+                    "invalid universe `Sort`, use `Sort 0` or `Prop` instead"));
+            return visit(arg, expected_type);
         } else {
             switch (e.kind()) {
                 case expr_kind::Var: lean_unreachable();  // LCOV_EXCL_LINE

--- a/tests/lean/sort.lean
+++ b/tests/lean/sort.lean
@@ -1,0 +1,1 @@
+#check Sort

--- a/tests/lean/sort.lean.expected.out
+++ b/tests/lean/sort.lean.expected.out
@@ -1,0 +1,2 @@
+sort.lean:1:7: error: invalid universe `Sort`, use `Sort 0` or `Prop` instead
+Prop : Type


### PR DESCRIPTION
As [reported on Zulip](https://leanprover.zulipchat.com/#narrow/stream/113488-general/topic/Sort.20is.20Prop).