### PR TITLE
refactor(library/init/meta/expr): make the type argument to `reflected` explicit

### DIFF
--- a/library/init/meta/attribute.lean
+++ b/library/init/meta/attribute.lean
@@ -73,14 +73,14 @@ meta def user_attribute.parse_reflect {α β : Type} (attr : user_attribute α �
 
 meta constant user_attribute.get_param_untyped {α β : Type} (attr : user_attribute α β) (decl : name)
   : tactic expr
-meta constant user_attribute.set_untyped {α β : Type} [reflected β] (attr : user_attribute α β) (decl : name)
+meta constant user_attribute.set_untyped {α β : Type} [reflected _ β] (attr : user_attribute α β) (decl : name)
   (val : expr) (persistent : bool) (prio : option nat := none) : tactic unit
 
 /-- Get the value of the parameter for the attribute on a given declatation. Will fail if the attribute does not exist.-/
-meta def user_attribute.get_param {α β : Type} [reflected β] (attr : user_attribute α β) (n : name) : tactic β :=
+meta def user_attribute.get_param {α β : Type} [reflected _ β] (attr : user_attribute α β) (n : name) : tactic β :=
 attr.get_param_untyped n >>= tactic.eval_expr β
 
-meta def user_attribute.set {α β : Type} [reflected β] (attr : user_attribute α β) (n : name)
+meta def user_attribute.set {α β : Type} [reflected _ β] (attr : user_attribute α β) (n : name)
   (val : β) (persistent : bool) (prio : option nat := none) : tactic unit :=
 attr.set_untyped n (attr.reflect_param val) persistent prio
 
@@ -89,7 +89,7 @@ open tactic
 /-- Alias for attribute.register -/
 meta def register_attribute := attribute.register
 
-meta def get_attribute_cache_dyn {α : Type} [reflected α] (attr_decl_name : name) : tactic α :=
+meta def get_attribute_cache_dyn {α : Type} [reflected _ α] (attr_decl_name : name) : tactic α :=
 let attr : pexpr := expr.const attr_decl_name [] in
 do e ← to_expr ``(user_attribute.get_cache %%attr),
    t ← eval_expr (tactic α) e,

--- a/library/init/meta/derive.lean
+++ b/library/init/meta/derive.lean
@@ -84,7 +84,7 @@ else pure false
 instance_derive_handler ``has_reflect mk_has_reflect_instance ff (λ n params tgt,
   -- add additional `reflected` assumption for each parameter
   params.mfoldr (λ param tgt,
-  do param_cls ← mk_app `reflected [param],
+  do param_cls ← mk_mapp `reflected [none, some param],
     pure $ expr.pi `a binder_info.inst_implicit param_cls tgt
   ) tgt)
 

--- a/library/init/meta/expr.lean
+++ b/library/init/meta/expr.lean
@@ -258,31 +258,34 @@ meta constant expr.get_delayed_abstraction_locals : expr → option (list name)
     by nested inference of `reflected` instances.
 
     The quotation expression `` `(a) `` (outside of patterns) is equivalent to `reflect a`
-    and thus can be used as an explicit way of inferring an instance of `reflected a`. -/
-@[class] meta def reflected {α : Sort u} : α → Type :=
+    and thus can be used as an explicit way of inferring an instance of `reflected a`.
+    
+    Note that the `α` argument is explicit to prevent it being treated as reducible by typeclass
+    inference, as this breaks `reflected` instances on type synonyms. -/
+@[class] meta def reflected (α : Sort u) : α → Type :=
 λ _, expr
 
-@[inline] meta def reflected.to_expr {α : Sort u} {a : α} : reflected a → expr :=
+@[inline] meta def reflected.to_expr {α : Sort u} {a : α} : reflected _ a → expr :=
 id
 
 /-- This is a more strongly-typed version of `expr.subst` that keeps track of the value being
 reflected. To obtain a term of type `reflected _`, use `` (`(λ x y, foo x y).subst ex).subst ey`` instead of
 using `` `(foo %%ex %%ey) `` (which returns an `expr`). -/
 @[inline] meta def reflected.subst {α : Sort v} {β : α → Sort u} {f : Π a : α, β a} {a : α} :
-  reflected f → reflected a → reflected (f a) :=
+  reflected _ f → reflected _ a → reflected _ (f a) :=
 expr.subst
 
 attribute [irreducible] reflected reflected.subst reflected.to_expr
 
-@[instance] protected meta constant expr.reflect (e : expr elab) : reflected e
-@[instance] protected meta constant string.reflect (s : string) : reflected s
+@[instance] protected meta constant expr.reflect (e : expr elab) : reflected _ e
+@[instance] protected meta constant string.reflect (s : string) : reflected _ s
 
-@[inline] meta instance {α : Sort u} (a : α) : has_coe (reflected a) expr :=
+@[inline] meta instance {α : Sort u} (a : α) : has_coe (reflected _ a) expr :=
 ⟨reflected.to_expr⟩
 
-protected meta def reflect {α : Sort u} (a : α) [h : reflected a] : reflected a := h
+protected meta def reflect {α : Sort u} (a : α) [h : reflected _ a] : reflected _ a := h
 
-meta instance {α} (a : α) : has_to_format (reflected a) :=
+meta instance {α} (a : α) : has_to_format (reflected _ a) :=
 ⟨λ h, to_fmt h.to_expr⟩
 
 namespace expr

--- a/library/init/meta/has_reflect.lean
+++ b/library/init/meta/has_reflect.lean
@@ -9,17 +9,17 @@ import init.meta.expr init.util
 universes u v
 
 /-- `has_reflect α` lets you produce an `expr` from an instance of α. That is, it is a function from α to expr such that the expr has type α. -/
-@[reducible] meta def has_reflect (α : Sort u) := Π a : α, reflected a
+@[reducible] meta def has_reflect (α : Sort u) := Π a : α, reflected _ a
 
 meta structure reflected_value (α : Type u) :=
 (val : α)
-[reflect : reflected val]
+[reflect : reflected _ val]
 
 namespace reflected_value
 
 meta def expr {α : Type u} (v : reflected_value α) : expr := v.reflect
 
-meta def subst {α : Type u} {β : Type v} (f : α → β) [rf : reflected f]
+meta def subst {α : Type u} {β : Type v} (f : α → β) [rf : reflected _ f]
   (a : reflected_value α) : reflected_value β :=
 @mk _ (f a.val) (rf.subst a.reflect)
 
@@ -47,7 +47,7 @@ meta instance name.reflect : has_reflect name
 | (name.mk_string  s n) := `(λ n, name.mk_string  s n).subst (name.reflect n)
 | (name.mk_numeral i n) := `(λ n, name.mk_numeral i n).subst (name.reflect n)
 
-meta instance list.reflect {α : Type} [has_reflect α] [reflected α] : has_reflect (list α)
+meta instance list.reflect {α : Type} [has_reflect α] [reflected _ α] : has_reflect (list α)
 | []     := `([])
 | (h::t) := `(λ t, h :: t).subst (list.reflect t)
 

--- a/library/init/meta/lean/parser.lean
+++ b/library/init/meta/lean/parser.lean
@@ -141,7 +141,7 @@ meta instance cast (p : lean.parser (reflected_value α)) : reflectable (val p) 
 meta instance has_reflect [r : has_reflect α] (p : lean.parser α) : reflectable p :=
 {full := do rp ← p, return ⟨rp⟩}
 
-meta instance optional {α : Type} [reflected α] (p : parser α)
+meta instance optional {α : Type} [reflected _ α] (p : parser α)
   [r : reflectable p] : reflectable (optional p) :=
 {full := reflected_value.subst some <$> r.full <|> return ⟨none⟩}
 

--- a/library/init/meta/mk_has_reflect_instance.lean
+++ b/library/init/meta/mk_has_reflect_instance.lean
@@ -25,7 +25,7 @@ fail "mk_has_reflect_instance tactic failed, target type is expected to be of th
 private meta def mk_has_reflect_instance_for (a : expr) : tactic expr :=
 do t    ← infer_type a,
    do {
-     m    ← mk_app `reflected [a],
+     m    ← mk_mapp `reflected [none, some a],
      inst ← mk_instance m
      <|> do {
        f ← pp t,
@@ -49,10 +49,10 @@ do field_quotes ← mk_reflect I_name F_name field_names 0,
    -- fn should be of the form `F_name ps fs`, where ps are the inductive parameter arguments,
    -- and `fs.length = field_names.length`
    `(reflected %%fn) ← target,
-   -- `reflected (F_name ps)` should be synthesizable directly, using instances from the context
+   -- `reflected _ (F_name ps)` should be synthesizable directly, using instances from the context
    let fn := field_names.foldl (λ fn _, expr.app_fn fn) fn,
-   quote ← mk_app `reflected [fn] >>= mk_instance,
-   -- now extend to an instance of `reflected (F_name ps fs)`
+   quote ← mk_mapp `reflected [none, some fn] >>= mk_instance,
+   -- now extend to an instance of `reflected _ (F_name ps fs)`
    quote ← field_quotes.mfoldl (λ quote fquote, to_expr ``(reflected.subst %%quote %%fquote)) quote,
    exact quote
 

--- a/library/init/meta/pexpr.lean
+++ b/library/init/meta/pexpr.lean
@@ -42,5 +42,5 @@ meta instance : has_to_pexpr pexpr :=
 meta instance : has_to_pexpr expr :=
 ⟨pexpr.of_expr⟩
 
-meta instance (α : Sort u) (a : α) : has_to_pexpr (reflected a) :=
+meta instance (α : Sort u) (a : α) : has_to_pexpr (reflected _ a) :=
 ⟨pexpr.of_expr ∘ reflected.to_expr⟩

--- a/library/init/meta/tactic.lean
+++ b/library/init/meta/tactic.lean
@@ -363,7 +363,7 @@ meta def option_to_tactic_format {α : Type u} [has_to_tactic_format α] : optio
 meta instance {α : Type u} [has_to_tactic_format α] : has_to_tactic_format (option α) :=
 ⟨option_to_tactic_format⟩
 
-meta instance {α} (a : α) : has_to_tactic_format (reflected a) :=
+meta instance {α} (a : α) : has_to_tactic_format (reflected _ a) :=
 ⟨λ h, pp h.to_expr⟩
 
 @[priority 10] meta instance has_to_format_to_has_to_tactic_format (α : Type) [has_to_format α] : has_to_tactic_format α :=
@@ -412,7 +412,7 @@ inductive transparency
 export transparency (reducible semireducible)
 
 /-- (eval_expr α e) evaluates 'e' IF 'e' has type 'α'. -/
-meta constant eval_expr (α : Type u) [reflected α] : expr → tactic α
+meta constant eval_expr (α : Type u) [reflected _ α] : expr → tactic α
 
 /-- Return the partial term/proof constructed so far. Note that the resultant expression
    may contain variables that are not declarate in the current main goal. -/
@@ -1896,7 +1896,7 @@ do t ← target,
    let locked_pr := mk_tagged_proof pr_type pr tag,
    mk_eq_mpr locked_pr ht >>= exact
 
-meta def eval_pexpr (α) [reflected α] (e : pexpr) : tactic α :=
+meta def eval_pexpr (α) [reflected _ α] (e : pexpr) : tactic α :=
 to_expr ``(%%e : %%(reflect α)) ff ff >>= eval_expr α
 
 meta def run_simple {α} : tactic_state → tactic α → option α

--- a/tests/lean/reflect_type_defeq.lean
+++ b/tests/lean/reflect_type_defeq.lean
@@ -1,2 +1,2 @@
-meta def foo (x : reflected (3 : ℕ)) : reflected ([10] : list ℕ) :=
+meta def foo (x : reflected ℕ 3) : reflected (list ℕ) [10] :=
 x -- ERROR

--- a/tests/lean/run/1590.lean
+++ b/tests/lean/run/1590.lean
@@ -1,5 +1,5 @@
 #check `(true.intro)
 #check (`(true.intro) : expr)
 
-variables (h : true) [reflected h]
+variables (h : true) [reflected _ h]
 #check `(id h)

--- a/tests/lean/run/exhaustive_vm_impl_test.lean
+++ b/tests/lean/run/exhaustive_vm_impl_test.lean
@@ -72,7 +72,7 @@ meta def mk_checker_core : list expr → expr → tactic expr
 
 meta def mk_checker := mk_checker_core []
 
-meta def verify (p : Prop) [rp : reflected p] : tactic unit := do
+meta def verify (p : Prop) [rp : reflected _ p] : tactic unit := do
 prove_goal_async $ do
 checker ← mk_checker rp,
 program ← to_expr ``(%%checker : bool),

--- a/tests/lean/run/reflected.lean
+++ b/tests/lean/run/reflected.lean
@@ -1,4 +1,14 @@
-meta def eval_list (α : Type) [reflected α] (e : expr) : tactic (list α) :=
+meta def eval_list (α : Type) [reflected _ α] (e : expr) : tactic (list α) :=
 tactic.eval_expr (list α) e
 
 run_cmd eval_list ℕ ↑`([1, 2]) >>= tactic.trace
+
+def synonym (α : Type) : Type := α
+
+def synonym.of {α : Type} (a : α) : synonym α := a
+
+meta instance synonym.reflect {α : Type} [has_reflect α] [reflected α] :
+  has_reflect (synonym α) :=
+λ x, show reflected (synonym.of x), from `(synonym.of).subst `(x)
+
+#eval let x := synonym.of 1 in tactic.trace `(x)


### PR DESCRIPTION
This prevents typeclass inference treating the type as reducible and unfolding type synonyms.