### PR TITLE
[Merged by Bors] - fix(tactic/simp_lemmas): do not treat `iff` refl lemmas as if they were `eq` refl lemmas

### DIFF
--- a/src/library/tactic/dsimplify.h
+++ b/src/library/tactic/dsimplify.h
@@ -71,14 +71,14 @@ public:
 };
 
 class dsimplify_fn : public dsimplify_core_fn {
-    simp_lemmas_for   m_simp_lemmas;
+    simp_lemmas       m_simp_lemmas;
     name_set          m_to_unfold;
     expr reduce(expr const & e);
     virtual optional<pair<expr, bool>> pre(expr const & e) override;
     virtual optional<pair<expr, bool>> post(expr const & e) override;
 public:
     dsimplify_fn(type_context_old & ctx, defeq_canonizer::state & s,
-                 simp_lemmas_for const & lemmas, list<name> const & to_unfold, dsimp_config const & cfg);
+                 simp_lemmas const & lemmas, list<name> const & to_unfold, dsimp_config const & cfg);
 };
 
 expr reduce_beta_eta_proj_iota(type_context_old & ctx, expr e, bool beta, bool eta, bool proj, bool iota);

--- a/src/library/tactic/smt/hinst_lemmas.cpp
+++ b/src/library/tactic/smt/hinst_lemmas.cpp
@@ -256,7 +256,7 @@ static expr dsimp(type_context_old & ctx, transparency_mode md, expr const & e) 
     cfg.m_canonize_instances = false;
     cfg.m_max_steps          = 1000000; /* TODO(Leo): add parameter? */
     cfg.m_eta                = true;
-    return dsimplify_fn(ctx, dcs, simp_lemmas_for(), list<name>(), cfg)(e);
+    return dsimplify_fn(ctx, dcs, simp_lemmas(), list<name>(), cfg)(e);
 }
 
 struct mk_hinst_lemma_fn {

--- a/src/library/tactic/smt/smt_state.cpp
+++ b/src/library/tactic/smt/smt_state.cpp
@@ -219,10 +219,7 @@ static dsimplify_fn mk_dsimp(type_context_old & ctx, defeq_can_state & dcs, smt_
        This is not an issue in this module since it assumes goals do not contain metavariables.
     */
     dcfg.m_eta               = true;
-    simp_lemmas_for eq_lemmas;
-    if (auto r = cfg.m_simp_lemmas.find(get_eq_name()))
-        eq_lemmas = *r;
-    return dsimplify_fn(ctx, dcs, eq_lemmas, list<name>(), dcfg);
+    return dsimplify_fn(ctx, dcs, cfg.m_simp_lemmas, list<name>(), dcfg);
 }
 
 static simplify_fn mk_simp(type_context_old & ctx, defeq_can_state & dcs, smt_pre_config const & cfg) {


### PR DESCRIPTION
This fixes a mistake in #723, where `iff` lemmas were invisibly translated to `eq` lemmas.
This meant that they were treated by simp as having higher priority, since it seems `eq` lemmas are always visited before `iff` lemmas, irrespective of priority.

This restores the old behavior by instead teaching `dsimp` how to handle `iff` lemmas.
This should make bumping mathlib easier.