### PR TITLE
[Merged by Bors] - refactor(algebra/classes): remove redundant assumption from `is_strict_total_order`

### DIFF
--- a/library/init/algebra/classes.lean
+++ b/library/init/algebra/classes.lean
@@ -160,7 +160,7 @@ instance is_total_preorder_is_preorder (α : Type u) (r : α → α → Prop) [s
 (trichotomous : ∀ a b, lt a b ∨ a = b ∨ lt b a)
 
 @[algebra] class is_strict_total_order (α : Type u) (lt : α → α → Prop)
-  extends is_trichotomous α lt, is_strict_weak_order α lt : Prop.
+  extends is_trichotomous α lt, is_strict_order α lt : Prop.
 
 instance eq_is_equiv (α : Type u) : is_equiv α (=) :=
 {symm := @eq.symm _, trans := @eq.trans _, refl := eq.refl}


### PR DESCRIPTION
Currently in mathlib, we have the [`is_strict_total_order'`](https://leanprover-community.github.io/mathlib_docs/order/rel_classes.html#is_strict_total_order') class. This is mathematically the same as [`is_strict_total_order`](https://leanprover-community.github.io/mathlib_docs/init/algebra/classes.html#is_strict_total_order), as proven by [`is_strict_total_order_of_is_strict_total_order'`](https://leanprover-community.github.io/mathlib_docs/order/rel_classes.html#is_strict_total_order_of_is_strict_total_order'), but has one assumption less. We remove the redundant assumption from `is_strict_total_order` so that it now exactly matches `is_strict_total_order'`.

If this PR is merged, once mathlib is bumped, we'll be left with two identical classes for a short while. There shouldn't be significant breakage, as the unprimed class sees almost no use in `mathlib`. After that, I'll do a separate refactor to remove the redundant typeclass.