### PR TITLE
[Merged by Bors] - feat(frontend/lean/notation_cmds.cpp): `notation (name := ...)` syntax

### DIFF
--- a/library/init/algebra/classes.lean
+++ b/library/init/algebra/classes.lean
@@ -155,7 +155,7 @@ is, `is_preorder X r` and `is_symm X r`. -/
 is, `is_symm X r` and `is_trans X r`. -/
 @[algebra] class is_per (α : Type u) (r : α → α → Prop) extends is_symm α r, is_trans α r : Prop.
 
-/-- `is_strict_order X r` means that the binary relation `r` on `X` is a strict order, that is, 
+/-- `is_strict_order X r` means that the binary relation `r` on `X` is a strict order, that is,
 `is_irrefl X r` and `is_trans X r`. -/
 @[algebra] class is_strict_order (α : Type u) (r : α → α → Prop) extends
   is_irrefl α r, is_trans α r : Prop.
@@ -170,7 +170,7 @@ that is, `is_strict_order X lt` and `is_incomp_trans X lt`. -/
 @[algebra] class is_strict_weak_order (α : Type u) (lt : α → α → Prop) extends
   is_strict_order α lt, is_incomp_trans α lt : Prop.
 
-/-- `is_trichotomous X lt` means that the binary relation `lt` on `X` is trichotomous, that is, 
+/-- `is_trichotomous X lt` means that the binary relation `lt` on `X` is trichotomous, that is,
 either `lt a b` or `a = b` or `lt b a` for any `a` and `b`. -/
 @[algebra] class is_trichotomous (α : Type u) (lt : α → α → Prop) : Prop :=
 (trichotomous : ∀ a b, lt a b ∨ a = b ∨ lt b a)
@@ -258,7 +258,7 @@ def equiv (a b : α) : Prop :=
 
 parameter [is_strict_weak_order α r]
 
-local infix ` ≈ `:50 := equiv
+local infix (name := equiv) ` ≈ `:50 := equiv
 
 lemma erefl (a : α) : a ≈ a :=
 ⟨irrefl a, irrefl a⟩

--- a/library/init/logic.lean
+++ b/library/init/logic.lean
@@ -1066,10 +1066,10 @@ variables {α : Type u} {β : Type v}
 variable f : α → α → α
 variable inv : α → α
 variable one : α
-local notation a * b := f a b
-local notation a ⁻¹  := inv a
+local notation (name := f) a * b := f a b
+local notation (name := inv) a ⁻¹  := inv a
 variable g : α → α → α
-local notation a + b := g a b
+local notation (name := g) a + b := g a b
 
 def commutative        := ∀ a b, a * b = b * a
 def associative        := ∀ a b c, (a * b) * c = a * (b * c)

--- a/src/frontends/lean/notation_cmd.cpp
+++ b/src/frontends/lean/notation_cmd.cpp
@@ -112,8 +112,7 @@ static optional<unsigned> get_precedence(environment const & env, char const * t
 }
 
 void check_notation_name(environment const & env, notation_entry_group grp,
-    const pos_info & pos, name const & name, bool was_anon)
-{
+    const pos_info & pos, name const & name, bool was_anon) {
     if (grp == notation_entry_group::Reserve || !has_notation(env, name)) return;
     if (was_anon)
         throw parser_error(sstream() <<

--- a/src/frontends/lean/parser.h
+++ b/src/frontends/lean/parser.h
@@ -429,7 +429,7 @@ public:
     /** \brief Lookahead version of \c curr_is_token. See \c ahead(). */
     bool ahead_is_token(name const & tk, int n = 0);
 
-    /** \brief Check current token, and move to next characther, throw exception if current token is not \c tk.  Returns true if succesful. */
+    /** \brief Check current token, and move to next character, throw exception if current token is not \c tk.  Returns true if succesful. */
     bool check_token_next(name const & tk, char const * msg);
     void check_token_or_id_next(name const & tk, char const * msg);
     /** \brief Check if the current token is an identifier, if it is return it and move to next token,

--- a/src/frontends/lean/parser_config.h
+++ b/src/frontends/lean/parser_config.h
@@ -80,6 +80,7 @@ parse_table const & get_led_table(environment const & env);
 parse_table const & get_reserved_nud_table(environment const & env);
 parse_table const & get_reserved_led_table(environment const & env);
 cmd_table const & get_cmd_table(environment const & env);
+bool has_notation(environment const & env, name const & n);
 environment add_command(environment const & env, name const & n, cmd_info const & info);
 
 /** \brief Add \c n as notation for \c e */

--- a/src/frontends/lean/tokens.cpp
+++ b/src/frontends/lean/tokens.cpp
@@ -115,6 +115,7 @@ static name const * g_infixr_tk = nullptr;
 static name const * g_postfix_tk = nullptr;
 static name const * g_prefix_tk = nullptr;
 static name const * g_notation_tk = nullptr;
+static name const * g_name_tk = nullptr;
 static name const * g_calc_tk = nullptr;
 static name const * g_root_tk = nullptr;
 static name const * g_fields_tk = nullptr;
@@ -241,6 +242,7 @@ void initialize_tokens() {
     g_postfix_tk = new name{"postfix"};
     g_prefix_tk = new name{"prefix"};
     g_notation_tk = new name{"notation"};
+    g_name_tk = new name{"name"};
     g_calc_tk = new name{"calc"};
     g_root_tk = new name{"_root_"};
     g_fields_tk = new name{"fields"};
@@ -368,6 +370,7 @@ void finalize_tokens() {
     delete g_postfix_tk;
     delete g_prefix_tk;
     delete g_notation_tk;
+    delete g_name_tk;
     delete g_calc_tk;
     delete g_root_tk;
     delete g_fields_tk;
@@ -494,6 +497,7 @@ name const & get_infixr_tk() { return *g_infixr_tk; }
 name const & get_postfix_tk() { return *g_postfix_tk; }
 name const & get_prefix_tk() { return *g_prefix_tk; }
 name const & get_notation_tk() { return *g_notation_tk; }
+name const & get_name_tk() { return *g_name_tk; }
 name const & get_calc_tk() { return *g_calc_tk; }
 name const & get_root_tk() { return *g_root_tk; }
 name const & get_fields_tk() { return *g_fields_tk; }

--- a/src/frontends/lean/tokens.h
+++ b/src/frontends/lean/tokens.h
@@ -117,6 +117,7 @@ name const & get_infixr_tk();
 name const & get_postfix_tk();
 name const & get_prefix_tk();
 name const & get_notation_tk();
+name const & get_name_tk();
 name const & get_calc_tk();
 name const & get_root_tk();
 name const & get_fields_tk();

--- a/src/frontends/lean/tokens.txt
+++ b/src/frontends/lean/tokens.txt
@@ -110,6 +110,7 @@ infixr       infixr
 postfix      postfix
 prefix       prefix
 notation     notation
+name         name
 calc         calc
 root         _root_
 fields       fields
@@ -118,6 +119,7 @@ inductive    inductive
 instance     instance
 this         this
 noncomputable noncomputable
+exclam       !
 theory       theory
 key_equivalences key_equivalences
 using        using

--- a/src/library/tactic/backward/backward_lemmas.cpp
+++ b/src/library/tactic/backward/backward_lemmas.cpp
@@ -20,6 +20,7 @@ Author: Leonardo de Moura
 #include "library/tactic/tactic_state.h"
 #include "library/tactic/backward/backward_lemmas.h"
 #include "frontends/lean/parser.h"
+#include "frontends/lean/tokens.h"
 
 namespace lean {
 static optional<head_index> get_backward_target(type_context_old & ctx, expr type) {
@@ -54,10 +55,10 @@ struct intro_attr_data : public attr_data {
 
     ast_id parse(abstract_parser & p) override {
         ast_id r = 0;
-        if (p.curr_is_token("!")) {
+        if (p.curr_is_token(get_exclam_tk())) {
             lean_assert(dynamic_cast<parser *>(&p));
             auto& p2 = *static_cast<parser *>(&p);
-            r = p2.new_ast("!", p2.pos()).m_id;
+            r = p2.new_ast(get_exclam_tk(), p2.pos()).m_id;
             p2.next();
             m_eager = true;
         }

--- a/tests/lean/712.lean
+++ b/tests/lean/712.lean
@@ -6,11 +6,11 @@ local infix `~~~` := eq
 
 #print notation ~~~
 
-local infix `~~~`:50 := eq
+local infix (name := eq2) `~~~`:50 := eq
 
 #print notation ~~~
 
-local infix `~~~`:100 := eq
+local infix (name := eq3) `~~~`:100 := eq
 
 infix `~~~`:100 := eq  -- FAIL
 

--- a/tests/lean/assertion1.lean
+++ b/tests/lean/assertion1.lean
@@ -17,7 +17,7 @@ structure Functor (C : Category.{ u1 v1 }) (D : Category.{ u2 v2 }) :=
   }
 
 namespace ProductCategory
-  notation C `×` D := ProductCategory C D
+  notation (name := prod) C `×` D := ProductCategory C D
 end ProductCategory
 
 @[reducible] definition TensorProduct ( C: Category ) := Functor ( C × C ) C

--- a/tests/lean/bad_quoted_symbol.lean
+++ b/tests/lean/bad_quoted_symbol.lean
@@ -1,4 +1,4 @@
-notation a ` \/ ` b := a ∨ b
+notation (name := or2) a ` \/ ` b := a ∨ b
 notation a `1\/` b := a ∨ b
 notation a ` 1\/` b := a ∨ b
 notation a ` \ / ` b := a ∨ b

--- a/tests/lean/calc1.lean
+++ b/tests/lean/calc1.lean
@@ -41,7 +41,7 @@ attribute [trans] le_lt_trans
           ... < d : H5
 
 constant le2 : A → A → bool
-infixl ` ≤ `:50 := le2
+infixl (name := le2) ` ≤ `:50 := le2
 constant le2_trans (a b c : A) (H1 : le2 a b) (H2 : le2 b c) : le2 a c
 attribute [trans] le2_trans
 -- print raw calc b   ≤ c : H2

--- a/tests/lean/hole_issue2.lean
+++ b/tests/lean/hole_issue2.lean
@@ -13,7 +13,7 @@ noncomputable definition count {A} (a : A) (b : bag A) : nat :=
 quotient.lift_on b (λ l, list.count a l)
   (λ l₁ l₂ h, sorry)
 definition subbag {A} (b₁ b₂ : bag A) := ∀ a, count a b₁ ≤ count a b₂
-infix ` ⊆ ` := subbag
+infix (name := subbag) ` ⊆ ` := subbag
 
 noncomputable definition decidable_subbag_1 {A} (b₁ b₂ : bag A) : decidable (b₁ ⊆ b₂) :=
 quotient.rec_on_subsingleton₂ b₁ b₂ (λ l₁ l₂,

--- a/tests/lean/local_notation_meta_bug.lean
+++ b/tests/lean/local_notation_meta_bug.lean
@@ -1,5 +1,5 @@
-local infix ` + ` := nat.add
-@[class] local infix ` + ` := nat.add
-noncomputable local infix ` + ` := nat.add
-@[class] noncomputable local infix ` + ` := nat.add
-/-- foo -/ local infix ` + ` := nat.add
+local infix (name := plus1) ` + ` := nat.add
+@[class] local infix (name := plus2) ` + ` := nat.add
+noncomputable local infix (name := plus3) ` + ` := nat.add
+@[class] noncomputable local infix (name := plus4) ` + ` := nat.add
+/-- foo -/ local infix (name := plus5) ` + ` := nat.add

--- a/tests/lean/nary_overload.lean
+++ b/tests/lean/nary_overload.lean
@@ -7,8 +7,8 @@ constant lst.nil {A : Type} : lst A
 constant vec.cons {A : Type} : A → vec A → vec A
 constant lst.cons {A : Type} : A → lst A → lst A
 
-notation `[` l:(foldr `, ` (h t, vec.cons h t) vec.nil `]`) := l
-notation `[` l:(foldr `, ` (h t, lst.cons h t) lst.nil `]`) := l
+notation (name := list1) `[` l:(foldr `, ` (h t, vec.cons h t) vec.nil `]`) := l
+notation (name := list2) `[` l:(foldr `, ` (h t, lst.cons h t) lst.nil `]`) := l
 
 constant A : Type
 variables a b c : A

--- a/tests/lean/notation2.lean
+++ b/tests/lean/notation2.lean
@@ -1,6 +1,11 @@
 --
-inductive List (T : Type) : Type | nil {} : List | cons   : T → List → List open List notation h :: t  := cons h t notation `[` l:(foldr `,` (h t, cons h t) nil) `]` := l
-infixr `::` := cons
+inductive List (T : Type) : Type
+| nil {} : List
+| cons   : T → List → List
+open List
+notation (name := cons2) h :: t  := cons h t
+notation (name := list2) `[` l:(foldr `,` (h t, cons h t) nil) `]` := l
+infixr (name := cons) `::` := cons
 #check (1:nat) :: 2 :: nil
 #check (1:nat) :: 2 :: 3 :: 4 :: 5 :: nil
 #print ]

--- a/tests/lean/notation3.lean
+++ b/tests/lean/notation3.lean
@@ -1,5 +1,10 @@
 --
-inductive List (T : Type) : Type | nil {} : List | cons   : T → List → List open List notation h :: t  := cons h t notation `[` l:(foldr `, ` (h t, cons h t) nil) `]` := l
+inductive List (T : Type) : Type
+| nil {} : List
+| cons   : T → List → List
+open List
+notation (name := cons2) h :: t  := cons h t
+notation (name := list2) `[` l:(foldr `, ` (h t, cons h t) nil) `]` := l
 constants a b : nat
 #check [a, b, b]
 #check (a, true, a = b, b)

--- a/tests/lean/notation4.lean
+++ b/tests/lean/notation4.lean
@@ -1,6 +1,11 @@
 --
 open sigma
-inductive List (T : Type) : Type | nil {} : List | cons   : T → List → List open List notation h :: t  := cons h t notation `[` l:(foldr `,` (h t, cons h t) nil) `]` := l
+inductive List (T : Type) : Type
+| nil {} : List
+| cons   : T → List → List
+open List
+notation (name := cons2) h :: t  := cons h t
+notation (name := list2) `[` l:(foldr `,` (h t, cons h t) nil) `]` := l
 #check ∃ (A : Type) (x y : A), x = y
 #check ∃ (x : nat), x = 0
 #check Σ' (x : nat), x = 10

--- a/tests/lean/over_notation.lean
+++ b/tests/lean/over_notation.lean
@@ -1,8 +1,8 @@
 constant f : nat → nat → nat
 constant g : string → string → string
 
-infix ` & `:60 := f
-infix ` & `:60 := g
+infix (name := f) ` & `:60 := f
+infix (name := g) ` & `:60 := g
 
 set_option pp.notation false
 
@@ -10,8 +10,8 @@ set_option pp.notation false
 #check "a" & "b"
 #check tt & ff
 
-notation `[[`:max l:(foldr `, ` (h t, f h t) 0 `]]`:0) := l
-notation `[[`:max l:(foldr `, ` (h t, g h t) "" `]]`:0) := l
+notation (name := list1) `[[`:max l:(foldr `, ` (h t, f h t) 0 `]]`:0) := l
+notation (name := list2) `[[`:max l:(foldr `, ` (h t, g h t) "" `]]`:0) := l
 
 #check [[ (1:nat), 2, 3 ]]
 #check [[ "a", "b", "c" ]]

--- a/tests/lean/reserve_bugs.lean
+++ b/tests/lean/reserve_bugs.lean
@@ -10,10 +10,10 @@ reserve infixl `-`:65
 reserve prefix `-`:100
 
 
-local infixl `+` := g
-local infixl `-` := h
-local prefix `-` := f
-local infixr `&` := h
+local infixl (name := «+») `+` := g
+local infixl (name := « - ») `-` := h
+local prefix (name := «- ») `-` := f
+local infixr (name := «&») `&` := h
 
 set_option pp.notation false
 

--- a/tests/lean/run/1705.lean
+++ b/tests/lean/run/1705.lean
@@ -1,6 +1,6 @@
 def {u} stream (α : Type u) := nat → α
 constant stream.cons {α} (a : α) (s : stream α) : stream α
-notation h :: t := stream.cons h t
+notation (name := cons) h :: t := stream.cons h t
 
 inductive T : Type
 | mk : nat → T
@@ -10,7 +10,7 @@ notation `&-` := T.mk
 example : T → T
 | (&- x) := &- x --works
 
-notation `&-` := list.head
+notation (name := head) `&-` := list.head
 
 example : T → T
 | (&- x) := &- x

--- a/tests/lean/run/assoc_flat.lean
+++ b/tests/lean/run/assoc_flat.lean
@@ -46,7 +46,7 @@ meta definition flat : expr → expr → expr → tactic (expr × expr)
        return (e, pr)
   end
 
-local infix `+` := nat.add
+local infix (name := and) `+` := nat.add
 set_option trace.app_builder true
 set_option pp.all true
 

--- a/tests/lean/run/choice_anon_ctor.lean
+++ b/tests/lean/run/choice_anon_ctor.lean
@@ -3,7 +3,7 @@ import data.vector
 -- constant vector.cons {α n} : α → vector α n → vector α (nat.succ n)
 
 -- notation a :: b := vector.cons a b
-notation `[` l:(foldr `, ` (h t, vector.cons h t) vector.nil `]`) := l
+notation (name := veclist) `[` l:(foldr `, ` (h t, vector.cons h t) vector.nil `]`) := l
 
 structure author :=
 (name : string)

--- a/tests/lean/run/coe_to_fn.lean
+++ b/tests/lean/run/coe_to_fn.lean
@@ -12,7 +12,7 @@ instance: has_coe_to_fun (α ≃ β) (λ _, α → β) := ⟨equiv.f⟩
 @[symm] def equiv.inv : α ≃ β → β ≃ α
 | ⟨f,g⟩ := ⟨g,f⟩
 
-local postfix `⁻¹` := equiv.inv
+local postfix (name := inv) `⁻¹` := equiv.inv
 
 -- coe_fn should be applied at function arguments
 def equiv.trans (f : α ≃ β) (g : β ≃ γ) : α ≃ γ :=

--- a/tests/lean/run/e1.lean
+++ b/tests/lean/run/e1.lean
@@ -9,8 +9,8 @@ infix `=`:50 := eq
 constant f : Prop → N → N
 constant g : N → N → N
 precedence `+`:50
-infixl + := f
-infixl + := g
+infixl (name := f) + := f
+infixl (name := g) + := g
 #check a + b + c
 constant p : Prop
 #check p + a + b + c

--- a/tests/lean/run/match_convoy.lean
+++ b/tests/lean/run/match_convoy.lean
@@ -38,7 +38,7 @@ noncomputable definition count {A} (a : A) (b : bag A) : nat :=
 quotient.lift_on b (λ l, list.count a l)
   (λ l₁ l₂ h, sorry)
 noncomputable definition subbag {A} (b₁ b₂ : bag A) := ∀ a, count a b₁ ≤ count a b₂
-infix ⊆ := subbag
+infix (name := subbag) ⊆ := subbag
 
 attribute [instance]
 noncomputable definition decidable_subbag {A} (b₁ b₂ : bag A) : decidable (b₁ ⊆ b₂) :=

--- a/tests/lean/run/match_convoy3.lean
+++ b/tests/lean/run/match_convoy3.lean
@@ -12,7 +12,7 @@ noncomputable definition count {A} (a : A) (b : bag A) : nat :=
 quotient.lift_on b (λ l, list.count a l)
   (λ l₁ l₂ h, sorry)
 noncomputable definition subbag {A} (b₁ b₂ : bag A) := ∀ a, count a b₁ ≤ count a b₂
-infix ⊆ := subbag
+infix (name := subbag) ⊆ := subbag
 
 attribute [instance]
 noncomputable definition decidable_subbag {A} (b₁ b₂ : bag A) : decidable (b₁ ⊆ b₂) :=

--- a/tests/lean/run/monad_univ_lift.lean
+++ b/tests/lean/run/monad_univ_lift.lean
@@ -19,8 +19,8 @@ sorry
 def {t s} down {A : Type s} (a : M (ulift.{t} A)) : M A :=
 sorry
 
-prefix `↑`:10 := up.{1}
-prefix `↓`:10 := down.{1}
+prefix (name := up) `↑`:10 := up.{1}
+prefix (name := down) `↓`:10 := down.{1}
 
 def ex : M unit :=
 ↓do

--- a/tests/lean/run/nat_bug4.lean
+++ b/tests/lean/run/nat_bug4.lean
@@ -5,9 +5,9 @@ inductive nat : Type
 | succ : nat → nat
 namespace nat
 definition add (x y : nat) : nat := nat.rec x (λn r, succ r) y
-infixl `+` := add
+infixl (name := add) `+` := add
 definition mul (n m : nat) : nat := nat.rec zero (fun m x, x + n) m
-infixl `*` := mul
+infixl (name := mul) `*` := mul
 
 axiom mul_succ_right (n m : nat) : n * succ m = n * m + n
 open eq

--- a/tests/lean/run/nat_bug7.lean
+++ b/tests/lean/run/nat_bug7.lean
@@ -5,7 +5,7 @@ inductive nat : Type
 
 namespace nat
 definition add (x y : nat) : nat := nat.rec x (λn r, succ r) y
-infixl `+` := add
+infixl (name := add) `+` := add
 
 axiom add_right_comm (n m k : nat) : n + m + k = n + k + m
 open eq

--- a/tests/lean/run/not_bug1.lean
+++ b/tests/lean/run/not_bug1.lean
@@ -4,8 +4,8 @@ constant List : Type.{1}
 constant nil  : List
 constant cons : bool → List → List
 
-infixr `::` := cons
-notation `[` l:(foldr `,` (h t, cons h t) nil `]`) := l
+infixr (name := cons) `::` := cons
+notation (name := list) `[` l:(foldr `,` (h t, cons h t) nil `]`) := l
 
 #check []
 #check [tt]

--- a/tests/lean/run/over_subst.lean
+++ b/tests/lean/run/over_subst.lean
@@ -4,8 +4,8 @@ constant nat : Type.{1}
 constant add : nat → nat → nat
 constant le : nat → nat → Prop
 constant one : nat
-infixl `+` := add
-infix `≤` := le
+infixl (name := nat.add) `+` := add
+infix (name := nat.le) `≤` := le
 axiom add_assoc (a b c : nat) : (a + b) + c = a + (b + c)
 axiom add_le_left {a b : nat} (H : a ≤ b) (c : nat) : c + a ≤ c + b
 end nat
@@ -15,11 +15,11 @@ constant int : Type.{1}
 constant add : int → int → int
 constant le : int → int → Prop
 constant one1 : int
-infixl `+` := add
-infix `≤`  := le
+infixl (name := int.add) `+` := add
+infix (name := int.le) `≤`  := le
 axiom add_assoc (a b c : int) : (a + b) + c = a + (b + c)
 axiom add_le_left {a b : int} (H : a ≤ b) (c : int) : c + a ≤ c + b
 noncomputable definition lt (a b : int) := a + one1 ≤ b
-infix `<`  := lt
+infix (name := int.lt) `<`  := lt
 end int
 end experiment

--- a/tests/lean/run/overload2.lean
+++ b/tests/lean/run/overload2.lean
@@ -10,7 +10,7 @@ definition add : F2 → F2 → F2
 | I O := I
 | I I := O
 
-infix + := F2.add
+infix (name := add) + := F2.add
 
 end F2
 

--- a/tests/lean/run/prec_max.lean
+++ b/tests/lean/run/prec_max.lean
@@ -2,7 +2,7 @@ open nat
 
 reserve postfix ⁻¹:(max + 1)
 
-postfix ⁻¹ := eq.symm
+postfix (name := symm) ⁻¹ := eq.symm
 
 constant foo (a b : nat) : a + b = 0
 

--- a/tests/lean/run/reserve.lean
+++ b/tests/lean/run/reserve.lean
@@ -1,7 +1,7 @@
 reserve infix `=?=`:50
 reserve infixr `&&&`:25
 
-notation a `=?=` b := eq a b
+notation (name := eq) a `=?=` b := eq a b
 notation a `&&&` b := and a b
 
 set_option pp.notation false

--- a/tests/lean/run/rvec.lean
+++ b/tests/lean/run/rvec.lean
@@ -7,7 +7,7 @@ inductive rvec (α : Type u) : nat → Type u
 
 namespace rvec
 
-local infix :: := cons
+local infix (name := cons) :: := cons
 variables {α β δ : Type u}
 
 def map (f : α → β) : Π {n : nat}, rvec α n → rvec β n

--- a/tests/lean/run/secnot.lean
+++ b/tests/lean/run/secnot.lean
@@ -13,7 +13,7 @@ inductive List (T : Type) : Type
 namespace List
 section
 variable {T : Type}
-notation `[` l:(foldr `,` (h t, cons h t) nil) `]` := l
+notation (name := list) `[` l:(foldr `,` (h t, cons h t) nil) `]` := l
 #check [(10:nat), 20, 30]
 end
 end List

--- a/tests/lean/run/simp_univ_poly.lean
+++ b/tests/lean/run/simp_univ_poly.lean
@@ -4,7 +4,7 @@ universes u v
 def equinumerous (α : Type u) (β : Type v) :=
 ∃ f : α → β, function.bijective f
 
-local infix ` ≈ `:50 := equinumerous
+local infix (name := equiv) ` ≈ `:50 := equinumerous
 
 @[refl] lemma refl {α} : α ≈ α := sorry
 @[trans] lemma trans {α β γ} :

--- a/tests/lean/run/soundness.lean
+++ b/tests/lean/run/soundness.lean
@@ -25,8 +25,8 @@ inductive PropF
 
 namespace PropF
   notation `#`:max P:max := Var P
-  local notation A ∨ B   := Disj A B
-  local notation A ∧ B   := Conj A B
+  local notation (name := Disj) A ∨ B   := Disj A B
+  local notation (name := Conj) A ∧ B   := Conj A B
   local infixr `⇒`:27    := Impl
   notation `⊥`           := Bot
 

--- a/tests/lean/run/tc_inout1.lean
+++ b/tests/lean/run/tc_inout1.lean
@@ -50,7 +50,7 @@ run_cmd do
 
 
 section
-local infix + := nat.add
+local infix (name := add) + := nat.add
 
 example (a b c : nat) : (a + b) + c = a + (b + c) :=
 assoc a b c
@@ -63,7 +63,7 @@ class has_mem2 (α : out_param $ Type u) (γ : Type v) :=
 def mem2 {α : Type u} {γ : Type v} [has_mem2 α γ] : α → γ → Prop :=
 has_mem2.mem
 
-local infix ∈ := mem2
+local infix (name := mem) ∈ := mem2
 
 instance (α : Type u) : has_mem2 α (list α) :=
 ⟨list.mem⟩

--- a/tests/lean/run/type_equations.lean
+++ b/tests/lean/run/type_equations.lean
@@ -46,7 +46,7 @@ definition subterm := tc direct_subterm
 theorem subterm_wf : well_founded subterm :=
 tc.wf direct_subterm_wf
 
-local infix `+` := Expr.add
+local infix (name := add) `+` := Expr.add
 
 set_option pp.notation false
 

--- a/tests/lean/run/u_eq_max_u_v.lean
+++ b/tests/lean/run/u_eq_max_u_v.lean
@@ -71,7 +71,7 @@ structure Functor (C : Category.{ u1 v1 }) (D : Category.{ u2 v2 }) :=
   }
 
 namespace ProductCategory
-  notation C `×` D := ProductCategory C D
+  notation (name := prod) C `×` D := ProductCategory C D
 end ProductCategory
 
 structure PreMonoidalCategory

--- a/tests/lean/t13.lean
+++ b/tests/lean/t13.lean
@@ -2,8 +2,8 @@ prelude constant A : Type.{1}
 constant f : A → A → A
 constant g : A → A → A
 precedence `+` : 65
-infixl + := f
-infixl + := g
+infixl (name := f) + := f
+infixl (name := g) + := g
 constant a : A
 constant b : A
 #print raw a+b -- + is overloaded


### PR DESCRIPTION
This is an attempt to solve the issues in leanprover-community/mathport#158 once and for all. The main new user-facing behavior is that notations have names, and if you have an overlapping name the definition is rejected. That means that the following is now rejected:
```lean
notation `foo` := nat
notation `foo` := nat
```
To fix the issue, name one or the other using the new `(name := ...)` syntax:
```lean
notation `foo` := nat
notation (name := bar) `foo` := nat
```
Unlike declaration names, notation names are only required to be distinct within a scope. So the following is legal:
```lean
section
local notation (name := foo) `foo` := nat
end
local notation (name := foo) `foo` := nat
```

Reserved notations do not have names / do not cause name conflicts with regular notations, although you are syntactically allowed to name them.