### PR TITLE
[Merged by Bors] - chore(library/init/logic): remove an unnecessary case split from `or.by_cases`

### DIFF
--- a/library/init/logic.lean
+++ b/library/init/logic.lean
@@ -681,9 +681,7 @@ section
 
   protected def or.by_cases [decidable p] [decidable q] {α : Sort u}
                                    (h : p ∨ q) (h₁ : p → α) (h₂ : q → α) : α :=
-  if hp : p then h₁ hp else
-    if hq : q then h₂ hq else
-      false.rec _ (or.elim h hp hq)
+  if hp : p then h₁ hp else h₂ (h.resolve_left hp)
 end
 
 section

--- a/library/init/logic.lean
+++ b/library/init/logic.lean
@@ -679,7 +679,8 @@ section
   def  decidable_of_decidable_of_eq (hp : decidable p) (h : p = q) : decidable q :=
   decidable_of_decidable_of_iff hp h.to_iff
 
-  protected def or.by_cases [decidable p] [decidable q] {α : Sort u}
+  /-- A version of `or.elim` in `Type`. If both `p` and `q` are true, `h₁` is used. -/
+  protected def or.by_cases [decidable p] {α : Sort u}
                                    (h : p ∨ q) (h₁ : p → α) (h₂ : q → α) : α :=
   if hp : p then h₁ hp else h₂ (h.resolve_left hp)
 end


### PR DESCRIPTION
`if h : x then f else false.elim _` is the same as `f`.
This means we can drop the `decidable q` argument.

A docstring is also added, but the behavior it describes has not changed.