### PR TITLE
[Merged by Bors] - feat(frontends/lean/notation_cmd): allow duplicate notations with the same name

### DIFF
--- a/src/frontends/lean/parser_config.h
+++ b/src/frontends/lean/parser_config.h
@@ -80,7 +80,7 @@ parse_table const & get_led_table(environment const & env);
 parse_table const & get_reserved_nud_table(environment const & env);
 parse_table const & get_reserved_led_table(environment const & env);
 cmd_table const & get_cmd_table(environment const & env);
-bool has_notation(environment const & env, name const & n);
+notation_entry const * get_notation_entry(environment const & env, name const & n);
 environment add_command(environment const & env, name const & n, cmd_info const & info);
 
 /** \brief Add \c n as notation for \c e */


### PR DESCRIPTION
Addendum to #754. This makes it legal to write:
```lean
local notation `foo`:20 := nat
local notation `foo`:20 := nat
```
It only works if the notations are exactly the same - if they resolve to different expressions, or use different syntax, then the names must be different.

This is required to support `localized` declarations in mathlib, because `open_locale foo` may introduce a local notation that is already in scope due to a previous `open_locale foo`, or because we are in the scope of a `localized ... in foo` and are doing `open_locale foo` to get other things in the `foo` locale. These all end up putting the same local notation in scope twice, and even if you name the notation inside the `localized` string it will still be a conflict.