### PR TITLE
chore(*): Swap `append` and `concat`

### DIFF
--- a/library/data/buffer.lean
+++ b/library/data/buffer.lean
@@ -85,7 +85,7 @@ def append_array {α : Type u} {n : nat} (nz : 0 < n) :
   let i : fin n := ⟨n - 2 - j, lt_aux_3 h⟩ in
   append_array ⟨m+1, b.push_back (a.read i)⟩ a j (lt_aux_1 h)
 
-protected def append {α : Type u} : buffer α → buffer α → buffer α
+protected def concat {α : Type u} : buffer α → buffer α → buffer α
 | b ⟨0, a⟩   := b
 | b ⟨n+1, a⟩ := append_array (nat.zero_lt_succ _) b a n (nat.lt_succ_self _)
 
@@ -127,8 +127,7 @@ protected def mem (v : α) (a : buffer α) : Prop := ∃i, read a i = v
 
 instance : has_mem α (buffer α) := ⟨buffer.mem⟩
 
-instance : has_append (buffer α) :=
-⟨buffer.append⟩
+instance : has_concat (buffer α) := ⟨buffer.concat⟩
 
 instance [has_repr α] : has_repr (buffer α) :=
 ⟨repr ∘ to_list⟩

--- a/library/data/dlist.lean
+++ b/library/data/dlist.lean
@@ -22,8 +22,7 @@ variables {α : Type u}
 local notation `♯`:max := by abstract { intros, simp }
 
 /-- Convert a list to a dlist -/
-def of_list (l : list α) : dlist α :=
-⟨append l, ♯⟩
+def of_list (l : list α) : dlist α := ⟨concat l, ♯⟩
 
 /-- Convert a lazily-evaluated list to a dlist -/
 def lazy_of_list (l : thunk (list α)) : dlist α :=
@@ -50,17 +49,16 @@ def cons (x : α) : dlist α →  dlist α
 | ⟨xs, h⟩ := ⟨x::_ ∘ xs, by abstract { intros, simp, rw [←h] }⟩
 
 /-- `O(1)` Append a single element to a dlist -/
-def concat (x : α) : dlist α → dlist α
+def append (x : α) : dlist α → dlist α
 | ⟨xs, h⟩ := ⟨xs ∘ x::_, by abstract { intros, simp, rw [h, h [x]], simp }⟩
 
-/-- `O(1)` Append dlists -/
-protected def append : dlist α → dlist α → dlist α
+/-- `O(1)` Concatenate dlists -/
+protected def concat : dlist α → dlist α → dlist α
 | ⟨xs, h₁⟩ ⟨ys, h₂⟩ := ⟨xs ∘ ys, by { intros, simp, rw [h₂, h₁, h₁ (ys list.nil)], simp } ⟩
 
-instance : has_append (dlist α) :=
-⟨dlist.append⟩
+instance : has_concat (dlist α) := ⟨dlist.concat⟩
 
-local attribute [simp] of_list to_list empty singleton cons concat dlist.append
+local attribute [simp] of_list to_list empty singleton cons concat dlist.concat
 
 lemma to_list_of_list (l : list α) : to_list (of_list l) = l :=
 by cases l; simp
@@ -68,7 +66,7 @@ by cases l; simp
 lemma of_list_to_list (l : dlist α) : of_list (to_list l) = l :=
 begin
    cases l with xs,
-   have h : append (xs []) = xs,
+   have h : concat (xs []) = xs,
    { intros, funext x, simp [l_invariant x] },
    simp [h]
 end
@@ -79,14 +77,14 @@ by simp
 lemma to_list_singleton (x : α) : to_list (singleton x) = [x] :=
 by simp
 
-lemma to_list_append (l₁ l₂ : dlist α) : to_list (l₁ ++ l₂) = to_list l₁ ++ to_list l₂ :=
-show to_list (dlist.append l₁ l₂) = to_list l₁ ++ to_list l₂, from
+lemma to_list_concat (l₁ l₂ : dlist α) : to_list (l₁ ++ l₂) = to_list l₁ ++ to_list l₂ :=
+show to_list (dlist.concat l₁ l₂) = to_list l₁ ++ to_list l₂, from
 by cases l₁; cases l₂; simp; rw l₁_invariant
 
 lemma to_list_cons (x : α) (l : dlist α) : to_list (cons x l) = x :: to_list l :=
 by cases l; simp
 
-lemma to_list_concat (x : α) (l : dlist α) : to_list (concat x l) = to_list l ++ [x] :=
+lemma to_list_append (x : α) (l : dlist α) : to_list (append x l) = to_list l ++ [x] :=
 by cases l; simp; rw [l_invariant]
 
 end dlist

--- a/library/data/vector.lean
+++ b/library/data/vector.lean
@@ -51,7 +51,7 @@ def to_list (v : vector α n) : list α := v.1
 
 def nth : Π (v : vector α n), fin n → α | ⟨ l, h ⟩ i := l.nth_le i.1 (by rw h; exact i.2)
 
-def append {n m : nat} : vector α n → vector α m → vector α (n + m)
+def concat {n m : nat} : vector α n → vector α m → vector α (n + m)
 | ⟨ l₁, h₁ ⟩ ⟨ l₂, h₂ ⟩ := ⟨ l₁ ++ l₂, by simp * ⟩
 
 @[elab_as_eliminator] def elim {α} {C : Π {n}, vector α n → Sort u} (H : ∀l : list α, C ⟨l, rfl⟩)
@@ -121,7 +121,7 @@ rfl
 @[simp] theorem to_list_cons (a : α) (v : vector α n) : to_list (cons a v) = a :: to_list v :=
 begin cases v, reflexivity end
 
-@[simp] theorem to_list_append {n m : nat} (v : vector α n) (w : vector α m) : to_list (append v w) = to_list v ++ to_list w :=
+@[simp] theorem to_list_concat {n m : nat} (v : vector α n) (w : vector α m) : to_list (concat v w) = to_list v ++ to_list w :=
 begin cases v, cases w, reflexivity end
 
 @[simp] theorem to_list_drop {n m : ℕ} (v : vector α m) : to_list (drop n v) = list.drop n (to_list v) :=

--- a/library/init/core.lean
+++ b/library/init/core.lean
@@ -307,7 +307,7 @@ class has_dvd      (α : Type u) := (dvd : α → α → Prop)
 class has_mod      (α : Type u) := (mod : α → α → α)
 class has_le       (α : Type u) := (le : α → α → Prop)
 class has_lt       (α : Type u) := (lt : α → α → Prop)
-class has_append   (α : Type u) := (append : α → α → α)
+class has_concat   (α : Type u) := (concat : α → α → α)
 class has_andthen  (α : Type u) (β : Type v) (σ : out_param $ Type w) := (andthen : α → β → σ)
 class has_union    (α : Type u) := (union : α → α → α)
 class has_inter    (α : Type u) := (inter : α → α → α)
@@ -347,7 +347,7 @@ prefix `-`:75    := has_neg.neg
 infix ` <= `:50  := has_le.le
 infix ` ≤ `:50   := has_le.le
 infix ` < `:50   := has_lt.lt
-infixl ` ++ `:65 := has_append.append
+infixl ` ++ `:65 := has_concat.concat
 infixl `; `:1    := andthen
 notation `∅`     := has_emptyc.emptyc
 infixl ` ∪ `:65  := has_union.union
@@ -358,7 +358,7 @@ infix ` \ `:70   := has_sdiff.sdiff
 infix ` ≈ `:50   := has_equiv.equiv
 infixr ` ^ `:80  := has_pow.pow
 
-export has_append (append)
+export has_concat (concat)
 
 @[reducible] def ge {α : Type u} [has_le α] (a b : α) : Prop := has_le.le b a
 @[reducible] def gt {α : Type u} [has_lt α] (a b : α) : Prop := has_lt.lt b a

--- a/library/init/data/list/basic.lean
+++ b/library/init/data/list/basic.lean
@@ -33,12 +33,11 @@ protected def has_dec_eq [s : decidable_eq α] : decidable_eq (list α)
 instance [decidable_eq α] : decidable_eq (list α) :=
 list.has_dec_eq
 
-@[simp] protected def append : list α → list α → list α
+@[simp] protected def concat : list α → list α → list α
 | []       l := l
-| (h :: s) t := h :: (append s t)
+| (h :: s) t := h :: concat s t
 
-instance : has_append (list α) :=
-⟨list.append⟩
+instance : has_concat (list α) := ⟨list.concat⟩
 
 protected def mem : α → list α → Prop
 | a []       := false

--- a/library/init/data/list/instances.lean
+++ b/library/init/data/list/instances.lean
@@ -24,7 +24,7 @@ instance : is_lawful_monad list :=
 
 instance : alternative list :=
 { failure := @list.nil,
-  orelse  := @list.append,
+  orelse  := @list.concat,
   ..list.monad }
 
 namespace list

--- a/library/init/data/list/lemmas.lean
+++ b/library/init/data/list/lemmas.lean
@@ -13,18 +13,18 @@ variables {α : Type u} {β : Type v} {γ : Type w}
 namespace list
 open nat
 
-/- append -/
+/- concat -/
 
-@[simp] lemma nil_append (s : list α) : [] ++ s = s :=
+@[simp] lemma nil_concat (s : list α) : [] ++ s = s :=
 rfl
 
-@[simp] lemma cons_append (x : α) (s t : list α) : (x::s) ++ t = x::(s ++ t) :=
+@[simp] lemma cons_concat (x : α) (s t : list α) : (x::s) ++ t = x::(s ++ t) :=
 rfl
 
-@[simp] lemma append_nil (t : list α) : t ++ [] = t :=
+@[simp] lemma concat_nil (t : list α) : t ++ [] = t :=
 by induction t; simp [*]
 
-@[simp] lemma append_assoc (s t u : list α) : s ++ t ++ u = s ++ (t ++ u) :=
+@[simp] lemma concat_assoc (s t u : list α) : s ++ t ++ u = s ++ (t ++ u) :=
 by induction s; simp [*]
 
 /- length -/
@@ -32,7 +32,7 @@ by induction s; simp [*]
 lemma length_cons (a : α) (l : list α) : length (a :: l) = length l + 1 :=
 rfl
 
-@[simp] lemma length_append (s t : list α) : length (s ++ t) = length s + length t :=
+@[simp] lemma length_concat (s t : list α) : length (s ++ t) = length s + length t :=
 begin
   induction s,
   { show length t = 0 + length t, by rw nat.zero_add },
@@ -59,7 +59,7 @@ by cases l; refl
 lemma map_cons (f : α → β) (a l) : map f (a::l) = f a :: map f l :=
 rfl
 
-@[simp] lemma map_append (f : α → β) : ∀ l₁ l₂, map f (l₁ ++ l₂) = (map f l₁) ++ (map f l₂) :=
+@[simp] lemma map_concat (f : α → β) : ∀ l₁ l₂, map f (l₁ ++ l₂) = map f l₁ ++ map f l₂ :=
 by intro l₁; induction l₁; intros; simp [*]
 
 lemma map_singleton (f : α → β) (a : α) : map f [a] = [f a] :=
@@ -82,7 +82,7 @@ by simp [join, list.bind]
 @[simp] lemma cons_bind (x xs) (f : α → list β) : list.bind (x :: xs) f = f x ++ list.bind xs f :=
 by simp [join, list.bind]
 
-@[simp] lemma append_bind (xs ys) (f : α → list β) :
+@[simp] lemma concat_bind (xs ys) (f : α → list β) :
   list.bind (xs ++ ys) f = list.bind xs f ++ list.bind ys f :=
 by induction xs; [refl, simp [*, cons_bind]]
 
@@ -109,17 +109,17 @@ assume H, or.inr H
 lemma eq_or_mem_of_mem_cons {a y : α} {l : list α} : a ∈ y::l → a = y ∨ a ∈ l :=
 assume h, h
 
-@[simp] lemma mem_append {a : α} {s t : list α} : a ∈ s ++ t ↔ a ∈ s ∨ a ∈ t :=
+@[simp] lemma mem_concat {a : α} {s t : list α} : a ∈ s ++ t ↔ a ∈ s ∨ a ∈ t :=
 by induction s; simp [*, or_assoc]
 
-@[rsimp] lemma mem_append_eq (a : α) (s t : list α) : (a ∈ s ++ t) = (a ∈ s ∨ a ∈ t) :=
-propext mem_append
+@[rsimp] lemma mem_concat_eq (a : α) (s t : list α) : (a ∈ s ++ t) = (a ∈ s ∨ a ∈ t) :=
+propext mem_concat
 
-lemma mem_append_left {a : α} {l₁ : list α} (l₂ : list α) (h : a ∈ l₁) : a ∈ l₁ ++ l₂ :=
-mem_append.2 (or.inl h)
+lemma mem_concat_left {a : α} {l₁ : list α} (l₂ : list α) (h : a ∈ l₁) : a ∈ l₁ ++ l₂ :=
+mem_concat.2 (or.inl h)
 
-lemma mem_append_right {a : α} (l₁ : list α) {l₂ : list α} (h : a ∈ l₂) : a ∈ l₁ ++ l₂ :=
-mem_append.2 (or.inr h)
+lemma mem_concat_right {a : α} (l₁ : list α) {l₂ : list α} (h : a ∈ l₂) : a ∈ l₁ ++ l₂ :=
+mem_concat.2 (or.inr h)
 
 lemma not_bex_nil (p : α → Prop) : ¬ (∃ x ∈ @nil α, p x) :=
 λ⟨x, hx, px⟩, hx
@@ -165,11 +165,11 @@ lemma cons_subset_cons {l₁ l₂ : list α} (a : α) (s : l₁ ⊆ l₂) : (a::
   (λ e : b = a,  or.inl e)
   (λ i : b ∈ l₁, or.inr (s i))
 
-@[simp] lemma subset_append_left (l₁ l₂ : list α) : l₁ ⊆ l₁++l₂ :=
-λ b, mem_append_left _
+@[simp] lemma subset_concat_left (l₁ l₂ : list α) : l₁ ⊆ l₁ ++ l₂ :=
+λ b, mem_concat_left _
 
-@[simp] lemma subset_append_right (l₁ l₂ : list α) : l₂ ⊆ l₁++l₂ :=
-λ b, mem_append_right _
+@[simp] lemma subset_concat_right (l₁ l₂ : list α) : l₂ ⊆ l₁ ++ l₂ :=
+λ b, mem_concat_right _
 
 lemma subset_cons_of_subset (a : α) {l₁ l₂ : list α} : l₁ ⊆ l₂ → l₁ ⊆ (a::l₂) :=
 λ (s : l₁ ⊆ l₂) (a : α) (i : a ∈ l₁), or.inr (s i)
@@ -226,10 +226,10 @@ lemma length_le_of_sublist : ∀ {l₁ l₂ : list α}, l₁ <+ l₂ → length 
   ∀ l, ¬ p a → filter p (a::l) = filter p l :=
 λ l pa, if_neg pa
 
-@[simp] theorem filter_append {p : α → Prop} [h : decidable_pred p] :
-  ∀ (l₁ l₂ : list α), filter p (l₁++l₂) = filter p l₁ ++ filter p l₂
+@[simp] theorem filter_concat {p : α → Prop} [h : decidable_pred p] :
+  ∀ (l₁ l₂ : list α), filter p (l₁ ++ l₂) = filter p l₁ ++ filter p l₂
 | []      l₂ := rfl
-| (a::l₁) l₂ := by by_cases pa : p a; simp [pa, filter_append]
+| (a::l₁) l₂ := by by_cases pa : p a; simp [pa, filter_concat]
 
 @[simp] theorem filter_sublist {p : α → Prop} [h : decidable_pred p] : Π (l : list α), filter p l <+ l
 | []     := sublist.slnil

--- a/library/init/data/string/basic.lean
+++ b/library/init/data/string/basic.lean
@@ -48,7 +48,7 @@ def push : string → char → string
 
 /- The internal implementation uses dynamic arrays and will perform destructive updates
    if the string is not shared. -/
-def append : string → string → string
+def concat : string → string → string
 | ⟨a⟩ ⟨b⟩ := ⟨a ++ b⟩
 
 /- O(n) in the VM, where n is the length of the string -/
@@ -146,8 +146,7 @@ instance : inhabited string :=
 instance : has_sizeof string :=
 ⟨string.length⟩
 
-instance : has_append string :=
-⟨string.append⟩
+instance : has_concat string := ⟨string.concat⟩
 
 namespace string
 def str : string → char → string := push
@@ -206,14 +205,14 @@ to_nat_core s.mk_iterator s.length 0
 
 namespace string
 
-private lemma nil_ne_append_singleton : ∀ (c : char) (l : list char), [] ≠ l ++ [c]
+private lemma nil_ne_concat_singleton : ∀ (c : char) (l : list char), [] ≠ l ++ [c]
 | c []     := λ h, list.no_confusion h
 | c (d::l) := λ h, list.no_confusion h
 
 lemma empty_ne_str : ∀ (c : char) (s : string), empty ≠ str s c
 | c ⟨l⟩ :=
   λ h : string_imp.mk [] = string_imp.mk (l ++ [c]),
-    string_imp.no_confusion h $ λ h, nil_ne_append_singleton _ _ h
+    string_imp.no_confusion h $ λ h, nil_ne_concat_singleton _ _ h
 
 lemma str_ne_empty (c : char) (s : string) : str s c ≠ empty :=
 (empty_ne_str c s).symm
@@ -223,11 +222,11 @@ private lemma str_ne_str_left_aux : ∀ {c₁ c₂ : char} (l₁ l₂ : list cha
 | c₁ c₂ (d₁::l₁) [] h₁ h₂ :=
   have d₁ :: (l₁ ++ [c₁]) = [c₂], from h₂,
   have l₁ ++ [c₁] = [], from list.no_confusion this (λ _ h, h),
-  absurd this.symm (nil_ne_append_singleton _ _)
+  absurd this.symm (nil_ne_concat_singleton _ _)
 | c₁ c₂ [] (d₂::l₂) h₁ h₂ :=
   have [c₁] = d₂ :: (l₂ ++ [c₂]), from h₂,
   have []   = l₂ ++ [c₂], from list.no_confusion this (λ _ h, h),
-  absurd this (nil_ne_append_singleton _ _)
+  absurd this (nil_ne_concat_singleton _ _)
 | c₁ c₂ (d₁::l₁) (d₂::l₂) h₁ h₂ :=
   have d₁ :: (l₁ ++ [c₁]) = d₂ :: (l₂ ++ [c₂]), from h₂,
   have l₁ ++ [c₁] = l₂ ++ [c₂], from list.no_confusion this (λ _ h, h),
@@ -243,11 +242,11 @@ private lemma str_ne_str_right_aux : ∀ (c₁ c₂ : char) {l₁ l₂ : list ch
 | c₁ c₂ (d₁::l₁) [] h₁ h₂ :=
   have d₁ :: (l₁ ++ [c₁]) = [c₂], from h₂,
   have l₁ ++ [c₁] = [], from list.no_confusion this (λ _ h, h),
-  absurd this.symm (nil_ne_append_singleton _ _)
+  absurd this.symm (nil_ne_concat_singleton _ _)
 | c₁ c₂ [] (d₂::l₂) h₁ h₂ :=
   have [c₁] = d₂ :: (l₂ ++ [c₂]), from h₂,
   have []   = l₂ ++ [c₂], from list.no_confusion this (λ _ h, h),
-  absurd this (nil_ne_append_singleton _ _)
+  absurd this (nil_ne_concat_singleton _ _)
 | c₁ c₂ (d₁::l₁) (d₂::l₂) h₁ h₂ :=
   have aux₁ : d₁ :: (l₁ ++ [c₁]) = d₂ :: (l₂ ++ [c₂]), from h₂,
   have d₁ = d₂, from list.no_confusion aux₁ (λ h _, h),

--- a/library/init/meta/expr_address.lean
+++ b/library/init/meta/expr_address.lean
@@ -77,7 +77,7 @@ instance has_repr : has_repr address := ⟨address.to_string⟩
 instance has_to_string : has_to_string address := ⟨address.to_string⟩
 meta instance has_to_format : has_to_format address := ⟨list.to_format⟩
 
-instance : has_append address := ⟨list.append⟩
+instance : has_concat address := ⟨list.concat⟩
 
 /-- `as_below x y` is some z when it finds `∃ z, x = y ++ z` -/
 meta def as_below : address → address → option address

--- a/library/init/meta/format.lean
+++ b/library/init/meta/format.lean
@@ -58,8 +58,7 @@ meta constant trace_fmt {α : Type u} : format → (unit → α) → α
 meta instance : inhabited format :=
 ⟨format.space⟩
 
-meta instance : has_append format :=
-⟨format.compose⟩
+meta instance : has_concat format := ⟨format.compose⟩
 
 meta instance : has_to_string format :=
 ⟨λ f, f.to_string options.mk⟩

--- a/library/init/meta/name.lean
+++ b/library/init/meta/name.lean
@@ -86,7 +86,7 @@ meta constant name.has_decidable_eq : decidable_eq name
 /- Both cmp and lex_cmp are total orders, but lex_cmp implements a lexicographical order. -/
 meta constant name.cmp : name → name → ordering
 meta constant name.lex_cmp : name → name → ordering
-meta constant name.append : name → name → name
+meta constant name.concat : name → name → name
 meta constant name.is_internal : name → bool
 
 protected meta def name.lt (a b : name) : Prop :=
@@ -100,8 +100,8 @@ meta instance : has_lt name :=
 
 attribute [instance] name.has_decidable_eq
 
-meta instance : has_append name :=
-⟨name.append⟩
+meta instance : has_concat name :=
+⟨name.concat⟩
 
 /-- `name.append_after n i` return a name of the form n_i -/
 meta constant name.append_after : name → nat → name

--- a/library/init/meta/smt/smt_tactic.lean
+++ b/library/init/meta/smt/smt_tactic.lean
@@ -56,8 +56,7 @@ meta constant smt_state.classical       : smt_state → bool
 meta def smt_tactic :=
 state_t smt_state tactic
 
-meta instance : has_append smt_state :=
-list.has_append
+meta instance : has_concat smt_state := list.has_concat
 
 section
 local attribute [reducible] smt_tactic

--- a/tests/lean/bad_unification_hint.lean
+++ b/tests/lean/bad_unification_hint.lean
@@ -1,14 +1,14 @@
 -- Good hint
-@[unify] def {u} cons_append_hint (α : Type u) (a b : α) (l₁ l₂ l₃: list α) : unification_hint :=
+@[unify] def {u} cons_concat_hint (α : Type u) (a b : α) (l₁ l₂ l₃: list α) : unification_hint :=
 { pattern     := (a :: l₁) ++ l₂ =?= b :: l₃,
   constraints := [l₃ =?= l₁ ++ l₂, a =?= b] }
 
 -- Bad hint: pattern is incorrect
-@[unify] def {u} append_cons_hint (α : Type u) (a b : α) (l₁ l₂ l₃: list α) : unification_hint :=
+@[unify] def {u} concat_cons_hint (α : Type u) (a b : α) (l₁ l₂ l₃: list α) : unification_hint :=
 { pattern     := l₁ ++ (a :: l₂) =?= b :: l₃,
   constraints := [l₃ =?= l₁ ++ l₂, a =?= b] }
 
 -- Bad hint: constraint #1 is incorrect
-@[unify] def {u} cons_append_hint' (α : Type u) (a b : α) (l₁ l₂ l₃: list α) : unification_hint :=
+@[unify] def {u} cons_concat_hint' (α : Type u) (a b : α) (l₁ l₂ l₃: list α) : unification_hint :=
 { pattern     := (a :: l₁) ++ l₂ =?= b :: l₃,
   constraints := [l₃ =?= l₁ ++ l₃, a =?= b] }

--- a/tests/lean/interactive/info.lean.expected.out
+++ b/tests/lean/interactive/info.lean.expected.out
@@ -5,5 +5,5 @@
 {"record":{"full-id":"bool.tt","source":,"state":"⊢ bool","type":"bool"},"response":"ok","seq_num":7}
 {"record":{"doc":"(trace) enable/disable tracing for the given module and submodules"},"response":"ok","seq_num":10}
 {"record":{"full-id":"list.cons","source":,"state":"⊢ list bool","type":"Π {T : Type}, T → list T → list T"},"response":"ok","seq_num":13}
-{"record":{"full-id":"has_append.append","source":,"state":"⊢ list bool","type":"Π {α : Type} [self : has_append α], α → α → α"},"response":"ok","seq_num":16}
+{"record":{"full-id":"has_concat.concat","source":,"state":"⊢ list bool","type":"Π {α : Type} [self : has_concat α], α → α → α"},"response":"ok","seq_num":16}
 {"record":{"full-id":"id","source":,"type":"Π {α : Sort u}, α → α"},"response":"ok","seq_num":19}

--- a/tests/lean/run/back1.lean
+++ b/tests/lean/run/back1.lean
@@ -16,12 +16,12 @@ lemma in_head  {α : Type u} {a : α}   {l : list α}              : a ∈ a::l 
 mem_cons_self _ _
 
 lemma in_left  {α : Type u} {a : α}   {l : list α} (r : list α) : a ∈ l → a ∈ l ++ r :=
-mem_append_left _
+mem_concat_left _
 
 lemma in_right {α : Type u} {a : α}   (l : list α) {r : list α} : a ∈ r → a ∈ l ++ r :=
-mem_append_right _
+mem_concat_right _
 
-/- Now, we define two helper tactics for matching cons/append-applications.
+/- Now, we define two helper tactics for matching cons/concat-applications.
    For example, (match_cons e) succeeds and return a pair (h, t) iff
    it is of the form (h::t).
 -/
@@ -41,8 +41,8 @@ meta def match_cons (e : expr) : tactic (expr × expr) :=
 -/
 do [_, h, t] ← match_app_of e `list.cons | failed, return (h, t)
 
-meta def match_append (e : expr) : tactic (expr × expr) :=
-do [_, _, l, r] ← match_app_of e `has_append.append | failed, return (l, r)
+meta def match_concat (e : expr) : tactic (expr × expr) :=
+do [_, _, l, r] ← match_app_of e `has_concat.concat | failed, return (l, r)
 
 /- The tactic (search_mem_list a e) tries to build a proof-term for (a ∈ e). -/
 meta def search_mem_list : expr → expr → tactic expr
@@ -63,9 +63,9 @@ meta def search_mem_list : expr → expr → tactic expr
 <|>
 /- If e is of the form l++r, then we try to build a proof for (a ∈ l),
    if we succeed, we built a proof for (a ∈ l++r) using the lemma in_left. -/
-(do (l, r) ← match_append e, h ← search_mem_list a l, mk_app `in_left [l, r, h])
+(do (l, r) ← match_concat e, h ← search_mem_list a l, mk_app `in_left [l, r, h])
 <|>
-(do (l, r) ← match_append e, h ← search_mem_list a r, mk_app `in_right [l, r, h])
+(do (l, r) ← match_concat e, h ← search_mem_list a r, mk_app `in_right [l, r, h])
 <|>
 (do (b, t) ← match_cons e, is_def_eq a b, mk_app `in_head [b, t])
 <|>

--- a/tests/lean/run/back1b.lean
+++ b/tests/lean/run/back1b.lean
@@ -15,16 +15,16 @@ lemma in_head  {α : Type u} (a : α) (l : list α)              : a ∈ a::l :=
 mem_cons_self _ _
 
 lemma in_left  {α : Type u} {a : α}   {l : list α} (r : list α) : a ∈ l → a ∈ l ++ r :=
-mem_append_left _
+mem_concat_left _
 
 lemma in_right {α : Type u} {a : α}   (l : list α) {r : list α} : a ∈ r → a ∈ l ++ r :=
-mem_append_right _
+mem_concat_right _
 
 meta def match_cons (e : expr) : tactic (expr × expr) :=
 do [_, h, t] ← match_app_of e `list.cons | failed, return (h, t)
 
-meta def match_append (e : expr) : tactic (expr × expr) :=
-do [_, _, l, r] ← match_app_of e `has_append.append | failed, return (l, r)
+meta def match_concat (e : expr) : tactic (expr × expr) :=
+do [_, _, l, r] ← match_app_of e `has_concat.concat | failed, return (l, r)
 
 /- The command `declare_trace` add a new trace.search_mem_list to Lean -/
 declare_trace search_mem_list
@@ -49,9 +49,9 @@ when_tracing `search_mem_list (do
   A quoted term `(t) is a pre-term. The tactic to_expr elaborates a pre-term
   with respect to the current main goal. The notation %%t is an anti-quotation.
 -/
-(do (l, r) ← match_append e, h ← search_mem_list a l, to_expr ``(in_left %%r %%h))
+(do (l, r) ← match_concat e, h ← search_mem_list a l, to_expr ``(in_left %%r %%h))
 <|>
-(do (l, r) ← match_append e, h ← search_mem_list a r, to_expr ``(in_right %%l %%h))
+(do (l, r) ← match_concat e, h ← search_mem_list a r, to_expr ``(in_right %%l %%h))
 <|>
 (do (b, t) ← match_cons e, is_def_eq a b, to_expr ``(in_head %%b %%t))
 <|>

--- a/tests/lean/run/back2.lean
+++ b/tests/lean/run/back2.lean
@@ -18,10 +18,10 @@ lemma in_head  {α : Type u} (a : α) (l : list α)              : a ∈ a::l :=
 mem_cons_self _ _
 
 lemma in_left  {α : Type u} {a : α}   {l : list α} (r : list α) : a ∈ l → a ∈ l ++ r :=
-mem_append_left _
+mem_concat_left _
 
 lemma in_right {α : Type u} {a : α}   (l : list α) {r : list α} : a ∈ r → a ∈ l ++ r :=
-mem_append_right _
+mem_concat_right _
 
 /- The command `declare_trace` add a new trace.search_mem_list to Lean -/
 declare_trace search_mem_list

--- a/tests/lean/run/back3.lean
+++ b/tests/lean/run/back3.lean
@@ -5,8 +5,8 @@ open list tactic
 universe variable u
 lemma in_tail  {α : Type u} {a : α} (b : α) {l : list α}        : a ∈ l → a ∈ b::l   := mem_cons_of_mem _
 lemma in_head  {α : Type u} (a : α) (l : list α)                : a ∈ a::l           := mem_cons_self _ _
-lemma in_left  {α : Type u} {a : α}   {l : list α} (r : list α) : a ∈ l → a ∈ l ++ r := mem_append_left _
-lemma in_right {α : Type u} {a : α}   (l : list α) {r : list α} : a ∈ r → a ∈ l ++ r := mem_append_right _
+lemma in_left  {α : Type u} {a : α}   {l : list α} (r : list α) : a ∈ l → a ∈ l ++ r := mem_concat_left _
+lemma in_right {α : Type u} {a : α}   (l : list α) {r : list α} : a ∈ r → a ∈ l ++ r := mem_concat_right _
 
 /- It is trivial to define mk_mem_list using backward chaining -/
 attribute [intro] in_tail in_head in_left in_right

--- a/tests/lean/run/back4.lean
+++ b/tests/lean/run/back4.lean
@@ -6,8 +6,8 @@ open list tactic
 universe variable u
 lemma in_tail  {α : Type u} {a : α} (b : α) {l : list α}        : a ∈ l → a ∈ b::l   := mem_cons_of_mem _
 lemma in_head  {α : Type u} (a : α) (l : list α)                : a ∈ a::l           := mem_cons_self _ _
-lemma in_left  {α : Type u} {a : α}   {l : list α} (r : list α) : a ∈ l → a ∈ l ++ r := mem_append_left _
-lemma in_right {α : Type u} {a : α}   (l : list α) {r : list α} : a ∈ r → a ∈ l ++ r := mem_append_right _
+lemma in_left  {α : Type u} {a : α}   {l : list α} (r : list α) : a ∈ l → a ∈ l ++ r := mem_concat_left _
+lemma in_right {α : Type u} {a : α}   (l : list α) {r : list α} : a ∈ r → a ∈ l ++ r := mem_concat_right _
 
 /- Using ematching -/
 example (a b c : nat) (l₁ l₂ : list nat) : a ∈ l₁ → a ∈ b::b::c::l₂ ++ b::c::l₁ ++ [c, c, b] :=

--- a/tests/lean/run/ind_issue.lean
+++ b/tests/lean/run/ind_issue.lean
@@ -1,9 +1,9 @@
 def stack := list nat
-instance : has_append stack :=
+instance : has_concat stack :=
 by unfold stack; apply_instance
 
 example (s : stack) : s ++ [] = s :=
 begin
   induction s,
-  refl, apply list.append_nil
+  refl, apply list.concat_nil
 end

--- a/tests/lean/run/lamexp.lean
+++ b/tests/lean/run/lamexp.lean
@@ -25,15 +25,15 @@ end lamexp_core
 
 namespace lamexp
 
-lemma nth_append {α} {ys : list α} : Π {n xs}, list.nth xs n ≠ none → list.nth (xs ++ ys) n = list.nth xs n
+lemma nth_concat {α} {ys : list α} : Π {n xs}, list.nth xs n ≠ none → list.nth (xs ++ ys) n = list.nth xs n
 | 0     []      h := by contradiction
 | (n+1) []      h := by contradiction
 | 0     (x::xs) h := rfl
-| (n+1) (x::xs) h := @nth_append n xs h
+| (n+1) (x::xs) h := @nth_concat n xs h
 
 def weaken_core : ∀ {Γ Δ t}, lamexp_core Γ t → lamexp_core (Γ ++ Δ) t
 | Γ Δ .(t) (@lamexp_core.var .(Γ) t n h) := lamexp_core.var n $
-    begin rw nth_append, assumption, rw h, intro, contradiction end
+    begin rw nth_concat, assumption, rw h, intro, contradiction end
 | Γ Δ .(t) (lamexp_core.fv n t) := lamexp_core.fv n t
 | Γ Δ .(t) (lamexp_core.con n t) := lamexp_core.con n t
 | Γ Δ .(s) (@lamexp_core.app .(Γ) t s a b) := lamexp_core.app (weaken_core a) (weaken_core b)

--- a/tests/lean/run/listex.lean
+++ b/tests/lean/run/listex.lean
@@ -11,9 +11,9 @@ meta def search_mem_list : expr → expr → tactic expr
 | a e :=
 (do m ← mk_app ``has_mem.mem [a, e], find_assumption m)
 <|>
-(do [_, _, l, r] ← match_app_of e ``has_append.append | failed, h ← search_mem_list a l, mk_app `in_left [l, r, h])
+(do [_, _, l, r] ← match_app_of e ``has_concat.concat | failed, h ← search_mem_list a l, mk_app `in_left [l, r, h])
 <|>
-(do [_, _, l, r] ← match_app_of e ``has_append.append | failed, h ← search_mem_list a r, mk_app `in_right [l, r, h])
+(do [_, _, l, r] ← match_app_of e ``has_concat.concat | failed, h ← search_mem_list a r, mk_app `in_right [l, r, h])
 <|>
 (do [_, b, t] ← match_app_of e ``list.cons | failed, is_def_eq a b, mk_app `in_head [b, t])
 <|>

--- a/tests/lean/run/listex2.lean
+++ b/tests/lean/run/listex2.lean
@@ -9,8 +9,8 @@ open expr tactic
 
 declare_trace search_mem_list
 
-meta def match_append (e : expr) : tactic (expr × expr) :=
-do [_, _, l, r] ← match_app_of e ``has_append.append | failed, return (l, r)
+meta def match_concat (e : expr) : tactic (expr × expr) :=
+do [_, _, l, r] ← match_app_of e ``has_concat.concat | failed, return (l, r)
 
 meta def match_cons (e : expr) : tactic (expr × expr) :=
 do [_, a, t] ← match_app_of e ``list.cons | failed, return (a, t)
@@ -22,9 +22,9 @@ meta def search_mem_list : expr → expr → tactic expr
 | a e := when_tracing `search_mem_list (do f₁ ← pp a, f₂ ← pp e, trace (to_fmt "search " ++ f₁ ++ to_fmt " in " ++ f₂)) >>
 (do m ← to_expr ``(%%a ∈ %%e), find_assumption m)
 <|>
-(do (l, r) ← match_append e, h ← search_mem_list a l, to_expr ``(in_left %%r %%h))
+(do (l, r) ← match_concat e, h ← search_mem_list a l, to_expr ``(in_left %%r %%h))
 <|>
-(do (l, r) ← match_append e, h ← search_mem_list a r, to_expr ``(in_right %%l %%h))
+(do (l, r) ← match_concat e, h ← search_mem_list a r, to_expr ``(in_right %%l %%h))
 <|>
 (do (b, t) ← match_cons e, is_def_eq a b,             to_expr ``(in_head %%b %%t))
 <|>

--- a/tests/lean/run/regset.lean
+++ b/tests/lean/run/regset.lean
@@ -7,7 +7,7 @@ parameter symbol : Type
 set (list symbol)
 
 def concat : lang → lang → lang :=
-λ a b : lang, { ll : list symbol | ∃xs ys : list symbol, ll = list.append xs ys ∧ xs ∈ a ∧ ys ∈ b }
+λ a b : lang, { ll : list symbol | ∃xs ys : list symbol, ll = list.concat xs ys ∧ xs ∈ a ∧ ys ∈ b }
 
 end
 end regset

--- a/tests/lean/run/simp_match_reducibility_issue.lean
+++ b/tests/lean/run/simp_match_reducibility_issue.lean
@@ -8,7 +8,7 @@ section
   variable  v : vector α m
   variable  w : vector α n
 
-  theorem append_nil : append v nil = v :=
-  by cases v; simp [vector.append, vector.nil]; reflexivity
+  theorem concat_nil : concat v nil = v :=
+  by cases v; simp [vector.concat, vector.nil]; reflexivity
 end
 end test

--- a/tests/lean/run/soundness.lean
+++ b/tests/lean/run/soundness.lean
@@ -98,7 +98,7 @@ namespace PropF
        OrE _ _ _ _ (weakening2 H₁ Hs) (weakening2 H₂ (cons_subset_cons A Hs)) (weakening2 H₃ (cons_subset_cons B Hs))
 
   def weakening : ∀ Γ Δ A, Γ ⊢ A → Γ++Δ ⊢ A :=
-  λ Γ Δ A H, weakening2 H (subset_append_left Γ Δ)
+  λ Γ Δ A H, weakening2 H (subset_concat_left Γ Δ)
 
   def deduction : ∀ Γ A B, Γ ⊢ A ⇒ B → A::Γ ⊢ B :=
   λ Γ A B H, ImpE _ _ _ (weakening2 H (subset_cons A Γ)) (Nax _ _ (mem_cons_self A Γ))

--- a/tests/lean/unfold1.lean
+++ b/tests/lean/unfold1.lean
@@ -5,14 +5,14 @@ do do h ← get_local Hname,
    rewrite_target h,
    try reflexivity
 
-example (l : list nat) : list.append l [] = l :=
+example (l : list nat) : list.concat l [] = l :=
 by do
   get_local `l >>= λ H, induction H [`h, `t, `iH],
   --
-  dunfold_target [`list.append],
+  dunfold_target [`list.concat],
   trace_state,
   trace "------",
   reflexivity,
-  dunfold_target [`list.append],
+  dunfold_target [`list.concat],
   trace_state,
   rewriteH `iH

--- a/tests/lean/unfold1.lean.expected.out
+++ b/tests/lean/unfold1.lean.expected.out
@@ -3,10 +3,10 @@
 
 h : ℕ,
 t : list ℕ,
-iH : t.append list.nil = t
-⊢ (h :: t).append list.nil = h :: t
+iH : t.concat list.nil = t
+⊢ (h :: t).concat list.nil = h :: t
 ------
 h : ℕ,
 t : list ℕ,
-iH : t.append list.nil = t
-⊢ h :: t.append list.nil = h :: t
+iH : t.concat list.nil = t
+⊢ h :: t.concat list.nil = h :: t

--- a/tests/lean/unification_hints2.lean
+++ b/tests/lean/unification_hints2.lean
@@ -11,7 +11,7 @@ begin
 end
 
 
-@[unify] def {u} cons_append_hint (α : Type u) (a b : α) (l₁ l₂ l₃: list α) : unification_hint :=
+@[unify] def {u} cons_concat_hint (α : Type u) (a b : α) (l₁ l₂ l₃: list α) : unification_hint :=
 { pattern     := (a :: l₁) ++ l₂ =?= b :: l₃,
   constraints := [l₃ =?= l₁ ++ l₂, a =?= b] }
 
@@ -23,6 +23,6 @@ universe u
 
 example (α : Type u) (a b : α) (l₁ l₂ : list α) (i : G α l₂) : G.raise α (a::l₁) l₂ i = G.cons α a _ (G.raise α _ _ i) :=
 begin
-  trace_state, -- the result should not contain recursor applications because we declared cons_append_hint above
+  trace_state, -- the result should not contain recursor applications because we declared cons_concat_hint above
   admit
 end


### PR DESCRIPTION
What's called `append` is concatenation in other languages and what's called `concat` is appending. This renames
* `has_append.append` → `has_concat.concat`
* `buffer.append` → `buffer.concat`
* `list.append` → `list.concat`
* `dlist.append` → `dlist.concat`
* `dlist.concat` → `dlist.append`
* `vector.append` → `vector.concat`
* `string.append` → `string.concat`
* `name.append` → `name.concat`