### PR TITLE
[Merged by Bors] - chore: remove unused theorems, to match port to mathlib4

### DIFF
--- a/library/init/propext.lean
+++ b/library/init/propext.lean
@@ -34,10 +34,3 @@ propext (iff.intro
   (assume h, iff.to_eq h)
   (assume h, h.to_iff))
 
-lemma eq_false {a : Prop} : (a = false) = (¬ a) :=
-have (a ↔ false) = (¬ a), from propext (iff_false a),
-eq.subst (@iff_eq_eq a false) this
-
-lemma eq_true {a : Prop} : (a = true) = a :=
-have (a ↔ true) = a, from propext (iff_true a),
-eq.subst (@iff_eq_eq a true) this


### PR DESCRIPTION
When porting `init/propext.lean` to mathlib4, I deleted two theorems that seem to not be used, and which collided with theorems with the same names in Lean 4. To prevent accident future use, I'm deleting these here too. (Subject to CI...)