### PR TITLE
feat(specialize): additional goals come after the main goal

### DIFF
--- a/library/init/meta/interactive.lean
+++ b/library/init/meta/interactive.lean
@@ -1692,7 +1692,7 @@ focus1 $
 do e ← i_to_expr p,
    let h := expr.get_app_fn e,
    if h.is_local_constant
-   then tactic.note h.local_pp_name none e >> try (tactic.clear h) >> rotate 1
+   then tactic.note h.local_pp_name none e >> try (tactic.clear h)
    else tactic.fail "specialize requires a term of the form `h x_1 .. x_n` where `h` appears in the local context"
 
 meta def congr := tactic.congr


### PR DESCRIPTION
This reverts #530.

Lean 4's `specialize` puts the additional goals after the main goal. Rather than writing an additional mini-tactic to preserve Lean 3 behaviour, I propose we just backport to achieve this behaviour. It's a relatively minor change to mathlib to adapot.

I couldn't find an account of why #530 wanted to change the order in the first place.