### PR TITLE
[Merged by Bors] - feat: extend `pp.links` to support Pi, Prop, Type, and Sort

### DIFF
--- a/src/frontends/lean/pp.cpp
+++ b/src/frontends/lean/pp.cpp
@@ -700,13 +700,13 @@ template<class T>
 auto pretty_fn<T>::pp_sort(expr const & e) -> result {
     level u = sort_level(e);
     if (u == mk_level_zero()) {
-        return result(mk_builtin_link("Prop", "Prop"));
+        return result(mk_builtin_link("Prop", T("Prop")));
     } else if (u == mk_level_one()) {
-        return result(mk_builtin_link("Type", "Type"));
+        return result(mk_builtin_link("Type", T("Type")));
     } else if (optional<level> u1 = dec_level(u)) {
-        return result(max_bp()-1, group(mk_builtin_link("Type", "Type") + space() + nest(5, pp_child(*u1))));
+        return result(max_bp()-1, group(mk_builtin_link("Type", T("Type")) + space() + nest(5, pp_child(*u1))));
     } else {
-        return result(max_bp()-1, group(mk_builtin_link("Sort", "Sort") + space() + nest(5, pp_child(u))));
+        return result(max_bp()-1, group(mk_builtin_link("Sort", T("Sort")) + space() + nest(5, pp_child(u))));
     }
 }
 template<class T>
@@ -759,7 +759,7 @@ T pretty_fn<T>::mk_link(expr const & dest, T const & body) {
 template<class T>
 T pretty_fn<T>::mk_builtin_link(std::string const & dest, T const & body) {
     if (m_links) {
-        return T((sstream() << "\xee\x80\x80\xee\x80\x84" << dest << "\xee\x80\x81").str()) +
+        return T((sstream() << "\xee\x80\x80\xee\x80\x83" << dest << "\xee\x80\x81").str()) +
             body + T("\xee\x80\x82");
     } else {
         return body;
@@ -778,7 +778,7 @@ auto pretty_fn<T>::pp_const(expr const & e, optional<unsigned> const & num_ref_u
         return T("⊥");
     name n = const_name(e);
     if (m_notation && n == get_unit_star_name())
-        return mk_link(n, "()");
+        return mk_link(n, T("()"));
     if (!num_ref_univ_params) {
         if (auto r = pp_local_ref(e))
             return *r;

--- a/src/frontends/lean/pp.h
+++ b/src/frontends/lean/pp.h
@@ -119,6 +119,9 @@ private:
     result mk_link(name const & dest, result const & body);
     T mk_link(expr const & dest, T const & body);
 
+    T mk_builtin_link(std::string const & dest, T const & body);
+    result mk_builtin_link(std::string const & dest, result const & body);
+
     format pp_child(level const & l);
     format pp_max(level l);
     format pp_meta(level const & l);

--- a/tests/lean/pp_links.lean.expected.out
+++ b/tests/lean/pp_links.lean.expected.out
@@ -1,6 +1,6 @@
 pp_links.lean:6:63: error: tactic failed, there are unsolved goals
 state:
-⊢ ∀ (i : intℤ),
+⊢ forall∀ (i : intℤ),
     (i, i).prod.sndsndeq =
       ihas_add.add + 0has_add.add +
         point.mk{point.xx := 0, point.yy := i}.point.xx


### PR DESCRIPTION
This uses `U+E003` (the next available private use character after the ones claimed in #89) to prefix the names:

* `pi`
* `forall`
* `function`
* `implies`
* `Sort`
* `Prop`
* `Type`

The motivation is to be able to link these ideas in doc-gen.