### PR TITLE
[Merged by Bors] - fix(frontends/lean/pp): correct binder links

### DIFF
--- a/src/frontends/lean/pp.cpp
+++ b/src/frontends/lean/pp.cpp
@@ -1623,11 +1623,11 @@ static T mk_tk_fmt(name const & tkn) {
     }
 }
 template<class T>
-auto pretty_fn<T>::pp_notation(notation_entry const & entry, buffer<optional<subexpr>> & args) -> optional<result> {
+auto pretty_fn<T>::pp_notation(notation_entry const & entry, expr const & src, buffer<optional<subexpr>> & args) -> optional<result> {
     if (entry.is_numeral()) {
         return some(result(T(entry.get_num().to_string())));
     } else if (is_atomic_notation(entry)) {
-        T fmt   = mk_link(entry.get_expr(), T(head(entry.get_transitions()).get_token().to_string_unescaped()));
+        T fmt   = mk_link(src, T(head(entry.get_transitions()).get_token().to_string_unescaped()));
         return some(result(fmt));
     } else {
         using notation::transition;
@@ -1646,7 +1646,7 @@ auto pretty_fn<T>::pp_notation(notation_entry const & entry, buffer<optional<sub
             T curr;
             notation::action const & a = ts[i].get_action();
             name const & tk = ts[i].get_token();
-            T tk_fmt = mk_link(entry.get_expr(), mk_tk_fmt<T>(ts[i].get_pp_token().to_string_unescaped()));
+            T tk_fmt = mk_link(src, mk_tk_fmt<T>(ts[i].get_pp_token().to_string_unescaped()));
             switch (a.kind()) {
             case notation::action_kind::Skip:
                 curr = tk_fmt;
@@ -1828,7 +1828,7 @@ auto pretty_fn<T>::pp_notation(subexpr const & ep) -> optional<result> {
         buffer<optional<subexpr>> args;
         args.resize(num_params);
         if (match(entry.get_expr(), ep, args)) {
-            if (auto r = pp_notation(entry, args))
+            if (auto r = pp_notation(entry, ep.first, args))
                 return r;
         }
     }

--- a/src/frontends/lean/pp.h
+++ b/src/frontends/lean/pp.h
@@ -136,7 +136,7 @@ private:
     bool match(expr const & p, subexpr const & e, buffer<optional<subexpr>> & args);
     /** \brief pretty-print e parsed with rbp, terminated by a token with lbp */
     result pp_notation_child(expr const & e, unsigned rbp, unsigned lbp, bool below_implicit = false);
-    optional<result> pp_notation(notation_entry const & entry, buffer<optional<subexpr>> & args);
+    optional<result> pp_notation(notation_entry const & entry, expr const & e, buffer<optional<subexpr>> & args);
     optional<result> pp_notation(subexpr const & e);
 
     result add_paren_if_needed(result const & r, unsigned bp);

--- a/tests/lean/pp_links.lean
+++ b/tests/lean/pp_links.lean
@@ -6,3 +6,7 @@ structure point (α : Type*) :=
 example : ∀ i : ℤ, (i, i).snd = i + 0 + (point.mk 0 i).x := by do
 os ← get_options,
 set_options (os.set_bool `pp.links tt)
+
+example : ∃ i j : ℤ, true := by do
+os ← get_options,
+set_options (os.set_bool `pp.links tt)

--- a/tests/lean/pp_links.lean.expected.out
+++ b/tests/lean/pp_links.lean.expected.out
@@ -1,9 +1,9 @@
-pp_links.lean:10:32: error: tactic failed, there are unsolved goals
-state:
-⊢ Exists∃ (i j : intℤ)Exists, truetrue
 pp_links.lean:6:63: error: tactic failed, there are unsolved goals
 state:
 ⊢ forall∀ (i : intℤ),
     (i, i).prod.sndsndeq =
       ihas_add.add + 0has_add.add +
         point.mk{point.xx := 0, point.yy := i}.point.xx
+pp_links.lean:10:32: error: tactic failed, there are unsolved goals
+state:
+⊢ Exists∃ (i j : intℤ)Exists, truetrue

--- a/tests/lean/pp_links.lean.expected.out
+++ b/tests/lean/pp_links.lean.expected.out
@@ -1,3 +1,6 @@
+pp_links.lean:10:32: error: tactic failed, there are unsolved goals
+state:
+⊢ Exists∃ (i j : intℤ)Exists, truetrue
 pp_links.lean:6:63: error: tactic failed, there are unsolved goals
 state:
 ⊢ forall∀ (i : intℤ),


### PR DESCRIPTION
Previously these used the notation definition (the RHS of the `:=`) rather than the matched expression. This usually doesn't work at all, since often the RHS is just `#0` and all the notation happens within the `scoped` block.

This affected a lot of mathlib notation; `Exists`/`infi`/`supr`/`filter.eventually`/`filter.frequently`/...

I don't know if this used to work and then we broke it, or if it's always been broken.