### PR TITLE
[Merged by Bors] - chore(library/init): convert `/-` comments to `/--` or `/-!` comments

### DIFF
--- a/library/init/cc_lemmas.lean
+++ b/library/init/cc_lemmas.lean
@@ -6,7 +6,7 @@ Authors: Leonardo de Moura
 prelude
 import init.propext init.classical
 
-/- Lemmas use by the congruence closure module -/
+/-! Lemmas use by the congruence closure module -/
 
 lemma iff_eq_of_eq_true_left {a b : Prop} (h : a = true) : (a ↔ b) = b :=
 h.symm ▸ propext (true_iff _)
@@ -58,7 +58,7 @@ h.symm ▸ propext (iff.intro (λ h, trivial) (λ h₁ h₂, false.elim h₂))
 lemma imp_eq_of_eq_false_right {a b : Prop} (h : b = false) : (a → b) = not a :=
 h.symm ▸ propext (iff.intro (λ h, h) (λ hna ha, hna ha))
 
-/- Remark: the congruence closure module will only use the following lemma is
+/-- Remark: the congruence closure module will only use this lemma if
    cc_config.em is tt. -/
 lemma not_imp_eq_of_eq_false_right {a b : Prop} (h : b = false) : (not a → b) = a :=
 h.symm ▸ propext (iff.intro (λ h', classical.by_contradiction (λ hna, h' hna)) (λ ha hna, hna ha))
@@ -105,7 +105,7 @@ eq_false_intro (λ hb, false.elim (eq.mp h (or.inr hb)))
 lemma eq_false_of_not_eq_true {a : Prop} (h : (not a) = true) : a = false :=
 eq_false_intro (λ ha, absurd ha (eq.mpr h trivial))
 
-/- Remark: the congruence closure module will only use the following lemma is
+/-- Remark: the congruence closure module will only use this lemma if
    cc_config.em is tt. -/
 lemma eq_true_of_not_eq_false {a : Prop} (h : (not a) = false) : a = true :=
 eq_true_intro (classical.by_contradiction (λ hna, eq.mp h hna))

--- a/library/init/classical.lean
+++ b/library/init/classical.lean
@@ -9,7 +9,7 @@ import init.data.subtype.basic init.funext
 namespace classical
 universes u v
 
-/- the axiom -/
+/-- The axiom -/
 axiom choice {α : Sort u} : nonempty α → α
 
 @[irreducible] noncomputable def indefinite_description {α : Sort u} (p : α → Prop)
@@ -79,7 +79,7 @@ noncomputable def inhabited_of_exists {α : Sort u} {p : α → Prop} (h : ∃ x
   inhabited α :=
 inhabited_of_nonempty (exists.elim h (λ w hw, ⟨w⟩))
 
-/- all propositions are decidable -/
+/-- All propositions are decidable -/
 noncomputable def prop_decidable (a : Prop) : decidable a :=
 choice $ or.elim (em a)
   (assume ha, ⟨is_true ha⟩)
@@ -106,8 +106,7 @@ if hp : ∃ x : α, p x then
   ⟨xp.val, λ h', xp.property⟩
 else ⟨choice h, λ h, absurd h hp⟩
 
-/- the Hilbert epsilon function -/
-
+/-- The Hilbert epsilon function -/
 noncomputable def epsilon {α : Sort u} [h : nonempty α] (p : α → Prop) : α :=
 (strong_indefinite_description p h).val
 
@@ -122,7 +121,7 @@ epsilon_spec_aux (nonempty_of_exists hex) p hex
 theorem epsilon_singleton {α : Sort u} (x : α) : @epsilon α ⟨x⟩ (λ y, y = x) = x :=
 @epsilon_spec α (λ y, y = x) ⟨x, rfl⟩
 
-/- the axiom of choice -/
+/-- The axiom of choice -/
 
 theorem axiom_of_choice {α : Sort u} {β : α → Sort v} {r : Π x, β x → Prop} (h : ∀ x, ∃ y, r x y) :
   ∃ (f : Π x, β x), ∀ x, r x (f x) :=

--- a/library/init/control/monad.lean
+++ b/library/init/control/monad.lean
@@ -27,6 +27,6 @@ class monad (m : Type u → Type v) extends applicative m, has_bind m : Type (ma
 @[reducible, inline] def return {m : Type u → Type v} [monad m] {α : Type u} : α → m α :=
 pure
 
-/- Identical to has_bind.and_then, but it is not inlined. -/
+/-- Identical to `has_bind.and_then`, but it is not inlined. -/
 def has_bind.seq {α β : Type u} {m : Type u → Type v} [has_bind m] (x : m α) (y : m β) : m β :=
 do x, y

--- a/library/init/core.lean
+++ b/library/init/core.lean
@@ -36,7 +36,7 @@ a
 /-- Gadget for marking output parameters in type classes. -/
 @[reducible] def out_param (α : Sort u) : Sort u := α
 
-/-
+/--
   id_rhs is an auxiliary declaration used in the equation compiler to address performance
   issues when proving equational lemmas. The equation compiler uses it as a marker.
 -/
@@ -88,9 +88,9 @@ prefix `¬`:40 := not
 inductive eq {α : Sort u} (a : α) : α → Prop
 | refl [] : eq a
 
-/-
+/-!
 Initialize the quotient module, which effectively adds the following definitions:
-
+```lean
 constant quot {α : Sort u} (r : α → α → Prop) : Sort u
 
 constant quot.mk {α : Sort u} (r : α → α → Prop) (a : α) : quot r
@@ -100,11 +100,11 @@ constant quot.lift {α : Sort u} {r : α → α → Prop} {β : Sort v} (f : α 
 
 constant quot.ind {α : Sort u} {r : α → α → Prop} {β : quot r → Prop} :
   (∀ a : α, β (quot.mk r a)) → ∀ q : quot r, β q
-
+```
 Also the reduction rule:
-
+```
 quot.lift f _ (quot.mk a) ~~> f a
-
+```
 -/
 init_quotient
 
@@ -243,7 +243,7 @@ inductive bool : Type
 | ff : bool
 | tt : bool
 
-/- Remark: subtype must take a Sort instead of Type because of the axiom strong_indefinite_description. -/
+/-- Remark: subtype must take a Sort instead of Type because of the axiom strong_indefinite_description. -/
 structure subtype {α : Sort u} (p : α → Prop) :=
 (val : α) (property : p val)
 
@@ -293,7 +293,7 @@ structure unification_hint :=
 (pattern : unification_constraint)
 (constraints : list unification_constraint)
 
-/- Declare builtin and reserved notation -/
+/-! Declare builtin and reserved notation -/
 
 class has_zero     (α : Type u) := (zero : α)
 class has_one      (α : Type u) := (one : α)
@@ -323,10 +323,10 @@ class has_ssubset  (α : Type u) := (ssubset : α → α → Prop)
 class has_emptyc   (α : Type u) := (emptyc : α)
 class has_insert   (α : out_param $ Type u) (γ : Type v) := (insert : α → γ → γ)
 class has_singleton (α : out_param $ Type u) (β : Type v) := (singleton : α → β)
-/- Type class used to implement the notation { a ∈ c | p a } -/
+/-- Type class used to implement the notation { a ∈ c | p a } -/
 class has_sep (α : out_param $ Type u) (γ : Type v) :=
 (sep : (α → Prop) → γ → γ)
-/- Type class for set-like membership -/
+/-- Type class for set-like membership -/
 class has_mem (α : out_param $ Type u) (γ : Type v) := (mem : α → γ → Prop)
 
 class has_pow (α : Type u) (β : Type v) :=
@@ -389,7 +389,7 @@ export is_lawful_singleton (insert_emptyc_eq)
 
 attribute [simp] insert_emptyc_eq
 
-/- nat basic instances -/
+/-! nat basic instances -/
 
 namespace nat
   protected def add : nat → nat → nat
@@ -425,11 +425,10 @@ end nat
 def std.prec.max   : nat := 1024 -- the strength of application, identifiers, (, [, etc.
 def std.prec.arrow : nat := 25
 
-/-
-The next def is "max + 10". It can be used e.g. for postfix operations that should
+/--
+This def is "max + 10". It can be used e.g. for postfix operations that should
 be stronger than application.
 -/
-
 def std.prec.max_plus : nat := std.prec.max + 10
 
 postfix `⁻¹`:std.prec.max_plus := has_inv.inv  -- input with \sy or \-1 or \inv
@@ -445,12 +444,12 @@ class has_sizeof (α : Sort u) :=
 def sizeof {α : Sort u} [s : has_sizeof α] : α → nat :=
 has_sizeof.sizeof
 
-/-
+/-!
 Declare sizeof instances and lemmas for types declared before has_sizeof.
 From now on, the inductive compiler will automatically generate sizeof instances and lemmas.
 -/
 
-/- Every type `α` has a default has_sizeof instance that just returns 0 for every element of `α` -/
+/-- Every type `α` has a default has_sizeof instance that just returns 0 for every element of `α` -/
 protected def default.sizeof (α : Sort u) : α → nat
 | a := 0
 

--- a/library/init/data/int/basic.lean
+++ b/library/init/data/int/basic.lean
@@ -2,14 +2,15 @@
 Copyright (c) 2016 Jeremy Avigad. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Jeremy Avigad
-
-The integers, with addition, multiplication, and subtraction.
 -/
 prelude
 import init.data.nat.lemmas init.data.nat.gcd
 open nat
 
-/- the type, coercions, and notation -/
+/-!
+# The integers, with addition, multiplication, and subtraction.
+
+the type, coercions, and notation -/
 
 @[derive decidable_eq]
 inductive int : Type
@@ -46,7 +47,7 @@ lemma of_nat_zero : of_nat (0 : nat) = (0 : int) := rfl
 
 lemma of_nat_one : of_nat (1 : nat) = (1 : int) := rfl
 
-/- definitions of basic functions -/
+/-! definitions of basic functions -/
 
 def neg_of_nat : ℕ → ℤ
 | 0        := 0
@@ -115,7 +116,7 @@ protected lemma coe_nat_add_out (m n : ℕ) : ↑m + ↑n = (m + n : ℤ) := rfl
 protected lemma coe_nat_mul_out (m n : ℕ) : ↑m * ↑n = (↑(m * n) : ℤ) := rfl
 protected lemma coe_nat_add_one_out (n : ℕ) : ↑n + (1 : ℤ) = ↑(succ n) := rfl
 
-/- these are only for internal use -/
+/-! these are only for internal use -/
 
 lemma of_nat_add_of_nat (m n : nat) : of_nat m + of_nat n = of_nat (m + n) := rfl
 lemma of_nat_add_neg_succ_of_nat (m n : nat) :
@@ -138,7 +139,7 @@ local attribute [simp] of_nat_add_of_nat of_nat_mul_of_nat neg_of_nat_zero neg_o
   neg_succ_of_nat_add_neg_succ_of_nat of_nat_mul_neg_succ_of_nat neg_succ_of_nat_of_nat
   mul_neg_succ_of_nat_neg_succ_of_nat
 
-/- some basic functions and properties -/
+/-!  some basic functions and properties -/
 
 protected lemma coe_nat_inj {m n : ℕ} (h : (↑m : ℤ) = ↑n) : m = n :=
 int.of_nat.inj h
@@ -154,7 +155,7 @@ lemma neg_succ_of_nat_inj_iff {m n : ℕ} : neg_succ_of_nat m = neg_succ_of_nat 
 
 lemma neg_succ_of_nat_eq (n : ℕ) : -[1+ n] = -(n + 1) := rfl
 
-/- neg -/
+/-! neg -/
 
 protected lemma neg_neg : ∀ a : ℤ, -(-a) = a
 | (of_nat 0)     := rfl
@@ -166,7 +167,7 @@ by rw [← int.neg_neg a, ← int.neg_neg b, h]
 
 protected lemma sub_eq_add_neg {a b : ℤ} : a - b = a + -b := rfl
 
-/- basic properties of sub_nat_nat -/
+/-! basic properties of sub_nat_nat -/
 
 lemma sub_nat_nat_elim (m n : ℕ) (P : ℕ → ℕ → ℤ → Prop)
   (hp : ∀i n, P (n + i) n (of_nat i))
@@ -220,7 +221,7 @@ lemma sub_nat_nat_of_lt {m n : ℕ} (h : m < n) : sub_nat_nat m n = -[1+ pred (n
 have n - m = succ (pred (n - m)), from eq.symm (succ_pred_eq_of_pos (nat.sub_pos_of_lt h)),
 by rewrite sub_nat_nat_of_sub_eq_succ this
 
-/- nat_abs -/
+/-! nat_abs -/
 
 @[simp] def nat_abs : ℤ → ℕ
 | (of_nat m) := m
@@ -252,7 +253,7 @@ lemma nat_abs_eq : Π (a : ℤ), a = nat_abs a ∨ a = -(nat_abs a)
 
 lemma eq_coe_or_neg (a : ℤ) : ∃n : ℕ, a = n ∨ a = -n := ⟨_, nat_abs_eq a⟩
 
-/- sign -/
+/-! sign -/
 
 def sign : ℤ → ℤ
 | (n+1:ℕ) := 1
@@ -263,7 +264,7 @@ def sign : ℤ → ℤ
 @[simp] theorem sign_one : sign 1 = 1 := rfl
 @[simp] theorem sign_neg_one : sign (-1) = -1 := rfl
 
-/- Quotient and remainder -/
+/-! Quotient and remainder -/
 
 -- There are three main conventions for integer division,
 -- referred here as the E, F, T rounding conventions.
@@ -314,7 +315,7 @@ def rem : ℤ → ℤ → ℤ
 instance : has_div ℤ := ⟨int.div⟩
 instance : has_mod ℤ := ⟨int.mod⟩
 
-/- gcd -/
+/-! gcd -/
 
 def gcd (m n : ℤ) : ℕ := gcd (nat_abs m) (nat_abs n)
 
@@ -322,7 +323,7 @@ def gcd (m n : ℤ) : ℕ := gcd (nat_abs m) (nat_abs n)
    int is a ring
 -/
 
-/- addition -/
+/-! addition -/
 
 protected lemma add_comm : ∀ a b : ℤ, a + b = b + a
 | (of_nat n) (of_nat m) := by simp [nat.add_comm]
@@ -394,7 +395,7 @@ protected lemma add_assoc : ∀ a b c : ℤ, a + b + c = a + (b + c)
                                          int.add_comm -[1+ k] ]
 | -[1+ m]    -[1+ n]    -[1+ k]    := by simp [add_succ, nat.add_comm, nat.add_left_comm, neg_of_nat_of_succ]
 
-/- negation -/
+/-! negation -/
 
 lemma sub_nat_self : ∀ n, sub_nat_nat n n = 0
 | 0        := rfl
@@ -410,7 +411,7 @@ protected lemma add_left_neg : ∀ a : ℤ, -a + a = 0
 protected lemma add_right_neg (a : ℤ) : a + -a = 0 :=
 by rw [int.add_comm, int.add_left_neg]
 
-/- multiplication -/
+/-! multiplication -/
 
 protected lemma mul_comm : ∀ a b : ℤ, a * b = b * a
 | (of_nat m) (of_nat n) := by simp [nat.mul_comm]

--- a/library/init/data/int/comp_lemmas.lean
+++ b/library/init/data/int/comp_lemmas.lean
@@ -2,16 +2,16 @@
 Copyright (c) 2016 Microsoft Corporation. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Leonardo de Moura
-
-Auxiliary lemmas used to compare int numerals.
 -/
 prelude
 import init.data.int.order
 
 namespace int
-/- Auxiliary lemmas for proving that to int numerals are different -/
+/-!
+# Auxiliary lemmas for proving that two int numerals are differen
+-/
 
-/- 1. Lemmas for reducing the problem to the case where the numerals are positive -/
+/-! 1. Lemmas for reducing the problem to the case where the numerals are positive -/
 
 protected lemma ne_neg_of_ne {a b : ℤ} : a ≠ b → -a ≠ -b :=
 λ h₁ h₂, absurd (int.neg_inj h₂) h₁
@@ -37,7 +37,7 @@ end
 protected lemma ne_neg_of_pos {a b : ℤ} : 0 < a → 0 < b → a ≠ -b :=
 λ h₁ h₂, ne.symm (int.neg_ne_of_pos h₂ h₁)
 
-/- 2. Lemmas for proving that positive int numerals are nonneg and positive -/
+/-! 2. Lemmas for proving that positive int numerals are nonneg and positive -/
 
 protected lemma one_pos : 0 < (1:int) :=
 int.zero_lt_one
@@ -63,7 +63,7 @@ protected lemma bit1_nonneg {a : ℤ} : 0 ≤ a → 0 ≤ bit1 a :=
 protected lemma nonneg_of_pos {a : ℤ} : 0 < a → 0 ≤ a :=
 le_of_lt
 
-/- 3. nat_abs auxiliary lemmas -/
+/-! 3. nat_abs auxiliary lemmas -/
 
 lemma neg_succ_of_nat_lt_zero (n : ℕ) : neg_succ_of_nat n < 0 :=
 @lt.intro _ _ n (by simp [neg_succ_of_nat_coe, int.coe_nat_succ, int.coe_nat_add, int.coe_nat_one,
@@ -88,7 +88,7 @@ protected lemma ne_of_nat_ne_nonneg_case {a b : ℤ} {n m : nat} (ha : 0 ≤ a) 
 have nat_abs a ≠ nat_abs b, by rwa [e1, e2],
 ne_of_nat_abs_ne_nat_abs_of_nonneg ha hb this
 
-/- 4. Aux lemmas for pushing nat_abs inside numerals
+/-! 4. Aux lemmas for pushing nat_abs inside numerals
    nat_abs_zero and nat_abs_one are defined at init/data/int/basic.lean -/
 
 lemma nat_abs_of_nat_core (n : ℕ) : nat_abs (of_nat n) = n :=

--- a/library/init/data/int/order.lean
+++ b/library/init/data/int/order.lean
@@ -107,7 +107,7 @@ lemma lt_of_coe_nat_lt_coe_nat {m n : ℕ} (h : (↑m : ℤ) < ↑n) : m < n :=
 lemma coe_nat_lt_coe_nat_of_lt {m n : ℕ} (h : m < n) : (↑m : ℤ) < ↑n :=
 (coe_nat_lt_coe_nat_iff _ _).mpr h
 
-/- show that the integers form an ordered additive group -/
+/-! show that the integers form an ordered additive group -/
 
 protected lemma le_refl (a : ℤ) : a ≤ a :=
 le.intro (int.add_zero a)
@@ -215,7 +215,7 @@ lemma eq_neg_succ_of_lt_zero : ∀ {a : ℤ}, a < 0 → ∃ n : ℕ, a = -[1+ n]
 | (n : ℕ) h := absurd h (not_lt_of_ge (coe_zero_le _))
 | -[1+ n] h := ⟨n, rfl⟩
 
-/- int is an ordered add comm group -/
+/-! int is an ordered add comm group -/
 
 protected lemma eq_neg_of_eq_neg {a b : ℤ} (h : a = -b) : b = -a :=
 by rw [h, int.neg_neg]
@@ -771,7 +771,7 @@ end
 
 end
 
-/- missing facts -/
+/-! missing facts -/
 
 protected lemma mul_lt_mul_of_pos_left {a b c : ℤ}
        (h₁ : a < b) (h₂ : 0 < c) : c * a < c * b :=
@@ -874,7 +874,7 @@ int.mul_le_mul h2 h2 h1 (le_trans h1 h2)
 protected lemma mul_self_lt_mul_self {a b : ℤ} (h1 : 0 ≤ a) (h2 : a < b) : a * a < b * b :=
 int.mul_lt_mul' (le_of_lt h2) h2 h1 (lt_of_le_of_lt h1 h2)
 
-/- more facts specific to int -/
+/-! more facts specific to int -/
 
 theorem of_nat_nonneg (n : ℕ) : 0 ≤ of_nat n := trivial
 

--- a/library/init/data/list/lemmas.lean
+++ b/library/init/data/list/lemmas.lean
@@ -13,7 +13,7 @@ variables {α : Type u} {β : Type v} {γ : Type w}
 namespace list
 open nat
 
-/- append -/
+/-! append -/
 
 @[simp] lemma nil_append (s : list α) : [] ++ s = s :=
 rfl
@@ -27,7 +27,7 @@ by induction t; simp [*]
 @[simp] lemma append_assoc (s t u : list α) : s ++ t ++ u = s ++ (t ++ u) :=
 by induction s; simp [*]
 
-/- length -/
+/-! length -/
 
 lemma length_cons (a : α) (l : list α) : length (a :: l) = length l + 1 :=
 rfl
@@ -54,7 +54,7 @@ by cases l; refl
           = length l - i             : length_drop i l
       ... = succ (length l) - succ i : (nat.succ_sub_succ_eq_sub (length l) i).symm
 
-/- map -/
+/-! map -/
 
 lemma map_cons (f : α → β) (a l) : map f (a::l) = f a :: map f l :=
 rfl
@@ -74,7 +74,7 @@ by induction l; simp [*]
 @[simp] lemma length_map (f : α → β) (l : list α) : length (map f l) = length l :=
 by induction l; simp [*]
 
-/- bind -/
+/-! bind -/
 
 @[simp] lemma nil_bind (f : α → list β) : list.bind [] f = [] :=
 by simp [join, list.bind]
@@ -86,7 +86,7 @@ by simp [join, list.bind]
   list.bind (xs ++ ys) f = list.bind xs f ++ list.bind ys f :=
 by induction xs; [refl, simp [*, cons_bind]]
 
-/- mem -/
+/-! mem -/
 
 lemma mem_nil_iff (a : α) : a ∈ ([] : list α) ↔ false :=
 iff.rfl
@@ -139,7 +139,7 @@ lemma ball_cons (p : α → Prop) (a : α) (l : list α) :
 ⟨λal, ⟨al a (mem_cons_self _ _), λx h, al x (mem_cons_of_mem _ h)⟩,
  λ⟨pa, al⟩ x o, o.elim (λe, e.symm ▸ pa) (al x)⟩
 
-/- list subset -/
+/-! list subset -/
 
 protected def subset (l₁ l₂ : list α) := ∀ ⦃a : α⦄, a ∈ l₁ → a ∈ l₂
 
@@ -201,7 +201,7 @@ theorem length_remove_nth : ∀ (l : list α) (i : ℕ), i < length l → length
 | []     := rfl
 | (a::l) := by { by_cases pa : p a; simp [partition, filter, pa, partition_eq_filter_filter l] }
 
-/- sublists -/
+/-! sublists -/
 
 inductive sublist : list α → list α → Prop
 | slnil : sublist [] []
@@ -215,7 +215,7 @@ lemma length_le_of_sublist : ∀ {l₁ l₂ : list α}, l₁ <+ l₂ → length 
 | _ _ (sublist.cons  l₁ l₂ a s) := le_succ_of_le (length_le_of_sublist s)
 | _ _ (sublist.cons2 l₁ l₂ a s) := succ_le_succ (length_le_of_sublist s)
 
-/- filter -/
+/-! filter -/
 @[simp] theorem filter_nil (p : α → Prop) [h : decidable_pred p] : filter p [] = [] := rfl
 
 @[simp] theorem filter_cons_of_pos {p : α → Prop} [h : decidable_pred p] {a : α} :
@@ -237,7 +237,7 @@ lemma length_le_of_sublist : ∀ {l₁ l₂ : list α}, l₁ <+ l₂ → length 
   then by simp [pa]; apply sublist.cons2; apply filter_sublist l
   else by simp [pa]; apply sublist.cons; apply filter_sublist l
 
-/- map_accumr -/
+/-! map_accumr -/
 section map_accumr
 variables {φ : Type w₁} {σ : Type w₂}
 

--- a/library/init/data/list/qsort.lean
+++ b/library/init/data/list/qsort.lean
@@ -24,7 +24,7 @@ def qsort.F {α} (lt : α → α → bool) : Π (x : list α),
     exact IH small this.left ++ h :: IH large this.right
   end
 
-/- This is based on the minimalist Haskell "quicksort".
+/-- This is based on the minimalist Haskell "quicksort".
 
    Remark: this is *not* really quicksort since it doesn't partition the elements in-place -/
 def qsort {α} (lt : α → α → bool) : list α → list α :=

--- a/library/init/data/nat/basic.lean
+++ b/library/init/data/nat/basic.lean
@@ -65,7 +65,7 @@ instance : inhabited ℕ :=
 @[simp] lemma nat_zero_eq_zero : nat.zero = 0 :=
 rfl
 
-/- properties of inequality -/
+/-! properties of inequality -/
 
 @[refl] protected lemma le_refl (a : ℕ) : a ≤ a :=
 less_than_or_equal.refl
@@ -152,7 +152,7 @@ protected lemma sub_lt : ∀ {a b : ℕ}, 0 < a → 0 < b → a - b < a
 protected lemma lt_of_lt_of_le {n m k : ℕ} : n < m → m ≤ k → n < k :=
 nat.le_trans
 
-/- Basic nat.add lemmas -/
+/-! Basic nat.add lemmas -/
 protected lemma zero_add : ∀ n : ℕ, 0 + n = n
 | 0     := rfl
 | (n+1) := congr_arg succ (zero_add n)
@@ -173,7 +173,7 @@ rfl
 lemma succ_eq_add_one (n : ℕ) : succ n = n + 1 :=
 rfl
 
-/- Basic lemmas for comparing numerals -/
+/-! Basic lemmas for comparing numerals -/
 
 protected lemma bit0_succ_eq (n : ℕ) : bit0 (succ n) = succ (succ (bit0 n)) :=
 show succ (succ n + n) = succ (succ (n + n)), from

--- a/library/init/data/nat/bitwise.lean
+++ b/library/init/data/nat/bitwise.lean
@@ -147,7 +147,7 @@ def lxor  : ℕ → ℕ → ℕ := bitwise bxor
     binary_rec z f 0 = z :=
 by {rw [binary_rec], refl}
 
-/- bitwise ops -/
+/-! bitwise ops -/
 
 lemma bodd_bit (b n) : bodd (bit b n) = b :=
 by rw bit_val; simp; cases b; cases bodd n; refl

--- a/library/init/data/nat/gcd.lean
+++ b/library/init/data/nat/gcd.lean
@@ -3,16 +3,19 @@ Copyright (c) 2014 Jeremy Avigad. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Jeremy Avigad, Leonardo de Moura, Mario Carneiro
 
-Definitions and properties of gcd, lcm, and coprime.
 -/
 prelude
 import init.data.nat.lemmas init.meta.well_founded_tactics
+
+/-!
+# Definitions and properties of gcd, lcm, and coprime
+-/
 
 open well_founded
 
 namespace nat
 
-/- gcd -/
+/-! gcd -/
 
 def gcd : nat → nat → nat
 | 0        y := y

--- a/library/init/data/string/basic.lean
+++ b/library/init/data/string/basic.lean
@@ -7,7 +7,7 @@ prelude
 import init.data.list.basic
 import init.data.char.basic
 
-/- In the VM, strings are implemented using a dynamic array and UTF-8 encoding.
+/-- In the VM, strings are implemented using a dynamic array and UTF-8 encoding.
 
    TODO: we currently cannot mark string_imp as private because
    we need to bind string_imp.mk and string_imp.cases_on in the VM.
@@ -25,7 +25,7 @@ namespace string
 instance : has_lt string :=
 ⟨λ s₁ s₂, s₁.data < s₂.data⟩
 
-/- Remark: this function has a VM builtin efficient implementation. -/
+/-- Remark: this function has a VM builtin efficient implementation. -/
 instance has_decidable_lt (s₁ s₂ : string) : decidable (s₁ < s₂) :=
 list.has_decidable_lt s₁.data s₂.data
 
@@ -41,24 +41,24 @@ def empty : string :=
 def length : string → nat
 | ⟨s⟩  := s.length
 
-/- The internal implementation uses dynamic arrays and will perform destructive updates
+/-- The internal implementation uses dynamic arrays and will perform destructive updates
    if the string is not shared. -/
 def push : string → char → string
 | ⟨s⟩ c := ⟨s ++ [c]⟩
 
-/- The internal implementation uses dynamic arrays and will perform destructive updates
+/-- The internal implementation uses dynamic arrays and will perform destructive updates
    if the string is not shared. -/
 def append : string → string → string
 | ⟨a⟩ ⟨b⟩ := ⟨a ++ b⟩
 
-/- O(n) in the VM, where n is the length of the string -/
+/-- O(n) in the VM, where n is the length of the string -/
 def to_list : string → list char
 | ⟨s⟩ := s
 
 def fold {α} (a : α) (f : α → char → α) (s : string) : α :=
 s.to_list.foldl f a
 
-/- In the VM, the string iterator is implemented as a pointer to the string being iterated + index.
+/-- In the VM, the string iterator is implemented as a pointer to the string being iterated + index.
 
    TODO: we currently cannot mark interator_imp as private because
    we need to bind string_imp.mk and string_imp.cases_on in the VM.
@@ -76,7 +76,7 @@ def curr : iterator → char
 | ⟨p, c::n⟩ := c
 | _         := default
 
-/- In the VM, `set_curr` is constant time if the string being iterated is not shared and linear time
+/-- In the VM, `set_curr` is constant time if the string being iterated is not shared and linear time
    if it is. -/
 def set_curr : iterator → char → iterator
 | ⟨p, c::n⟩ c' := ⟨p, c'::n⟩
@@ -104,7 +104,7 @@ def insert : iterator → string → iterator
 def remove : iterator → nat → iterator
 | ⟨p, n⟩ m := ⟨p, n.drop m⟩
 
-/- In the VM, `to_string` is a constant time operation. -/
+/-- In the VM, `to_string` is a constant time operation. -/
 def to_string : iterator → string
 | ⟨p, n⟩ := ⟨p.reverse ++ n⟩
 
@@ -138,7 +138,7 @@ def extract : iterator → iterator → option string
 end iterator
 end string
 
-/- The following definitions do not have builtin support in the VM -/
+/-! The following definitions do not have builtin support in the VM -/
 
 instance : inhabited string :=
 ⟨string.empty⟩

--- a/library/init/ite_simp.lean
+++ b/library/init/ite_simp.lean
@@ -6,8 +6,8 @@ Authors: Leonardo de Moura
 prelude
 import init.data.bool
 
-/-
-Simplification lemmas for ite.
+/-!
+# Simplification lemmas for ite.
 
 We don't prove them at logic.lean because it is easier to prove them using
 the tactic framework.

--- a/library/init/logic.lean
+++ b/library/init/logic.lean
@@ -16,8 +16,7 @@ rfl
 def flip {α : Sort u} {β : Sort v} {φ : Sort w} (f : α → β → φ) : β → α → φ :=
 λ b a, f a b
 
-/- implication -/
-
+/-- implication -/
 def implies (a b : Prop) := a → b
 
 /-- Implication `→` is transitive. If `P → Q` and `Q → R` then `P → R`. -/
@@ -36,7 +35,7 @@ h
 /-- Modus tollens. If an implication is true, then so is its contrapositive. -/
 lemma mt {a b : Prop} (h₁ : a → b) (h₂ : ¬b) : ¬a := assume ha : a, h₂ (h₁ ha)
 
-/- not -/
+/-! not -/
 
 lemma not_false : ¬false := id
 
@@ -45,12 +44,12 @@ def non_contradictory (a : Prop) : Prop := ¬¬a
 lemma non_contradictory_intro {a : Prop} (ha : a) : ¬¬a :=
 assume hna : ¬a, absurd ha hna
 
-/- false -/
+/-! false -/
 
 @[inline] def false.elim {C : Sort u} (h : false) : C :=
 false.rec C h
 
-/- eq -/
+/-! eq -/
 
 -- proof irrelevance is built in
 lemma proof_irrel {a : Prop} (h₁ h₂ : a) : h₁ = h₂ := rfl
@@ -95,7 +94,7 @@ lemma cast_proof_irrel {α β : Sort u} (h₁ h₂ : α = β) (a : α) : cast h�
 
 lemma cast_eq {α : Sort u} (h : α = α) (a : α) : cast h a = a := rfl
 
-/- ne -/
+/-! ne -/
 
 @[reducible] def ne {α : Sort u} (a b : α) := ¬(a = b)
 infix ` ≠ `:50 := ne
@@ -181,7 +180,7 @@ lemma eq_rec_compose : ∀ {α β φ : Sort u} (p₁ : β = φ) (p₂ : α = β)
 lemma cast_heq : ∀ {α β : Sort u} (h : α = β) (a : α), cast h a == a
 | α _ rfl a := heq.refl a
 
-/- and -/
+/-! and -/
 
 infixr ` /\ `:35 := and
 infixr ` ∧ `:35 := and
@@ -196,7 +195,7 @@ assume ⟨ha, hb⟩, ⟨hb, ha⟩
 
 lemma and.symm : a ∧ b → b ∧ a := and.swap
 
-/- or -/
+/-! or -/
 
 infixr ` \/ `:30 := or
 infixr ` ∨ `:30 := or
@@ -216,10 +215,10 @@ lemma or.swap : a ∨ b → b ∨ a := or.rec or.inr or.inl
 
 lemma or.symm : a ∨ b → b ∨ a := or.swap
 
-/- xor -/
+/-! xor -/
 def xor (a b : Prop) := (a ∧ ¬ b) ∨ (b ∧ ¬ a)
 
-/- iff -/
+/-! iff -/
 /-- `iff P Q`, with notation `P ↔ Q`, is the proposition asserting that `P` and `Q` are equivalent,
 that is, have the same truth value. -/
 structure iff (a b : Prop) : Prop :=
@@ -361,7 +360,7 @@ false.elim
 lemma eq_comm {α : Sort u} {a b : α} : a = b ↔ b = a :=
 ⟨eq.symm, eq.symm⟩
 
-/- and simp rules -/
+/-! and simp rules -/
 lemma and.imp (hac : a → c) (hbd : b → d) : a ∧ b → c ∧ d :=
 assume ⟨ha, hb⟩, ⟨hac ha, hbd hb⟩
 
@@ -417,7 +416,7 @@ iff_false_intro (assume ⟨h₁, h₂⟩, absurd h₁ h₂)
 @[simp] lemma and_self (a : Prop) : a ∧ a ↔ a :=
 iff.intro and.left (assume h, ⟨h, h⟩)
 
-/- or simp rules -/
+/-! or simp rules -/
 
 lemma or.imp (h₂ : a → c) (h₃ : b → d) : a ∨ b → c ∨ d :=
 or.rec (λ h, or.inl (h₂ h)) (λ h, or.inr (h₃ h))
@@ -471,7 +470,7 @@ lemma not_or {a b : Prop} : ¬ a → ¬ b → ¬ (a ∨ b)
 | hna hnb (or.inl ha) := absurd ha hna
 | hna hnb (or.inr hb) := absurd hb hnb
 
-/- or resolution rulse -/
+/-! or resolution rulse -/
 
 lemma or.resolve_left {a b : Prop} (h : a ∨ b) (na : ¬ a) : b :=
   or.elim h (λ ha, absurd ha na) id
@@ -485,7 +484,7 @@ lemma or.resolve_right {a b : Prop} (h : a ∨ b) (nb : ¬ b) : a :=
 lemma or.neg_resolve_right {a b : Prop} (h : a ∨ ¬ b) (hb : b) : a :=
   or.elim h id (λ nb, absurd hb nb)
 
-/- iff simp rules -/
+/-! iff simp rules -/
 
 @[simp] lemma iff_true (a : Prop) : (a ↔ true) ↔ a :=
 iff.intro (assume h, iff.mpr h trivial) iff_true_intro
@@ -507,7 +506,7 @@ iff_true_intro iff.rfl
   ((and_congr (imp_congr h₁ h₂) (imp_congr h₂ h₁)).trans
     (iff_iff_implies_and_implies c d).symm)
 
-/- implies simp rule -/
+/-! implies simp rule -/
 @[simp] lemma implies_true_iff (α : Sort u) : (α → true) ↔ true :=
 iff.intro (λ h, trivial) (λ ha h, trivial)
 
@@ -543,7 +542,7 @@ lemma exists.elim {α : Sort u} {p : α → Prop} {b : Prop}
   (h₁ : ∃ x, p x) (h₂ : ∀ (a : α), p a → b) : b :=
 Exists.rec h₂ h₁
 
-/- exists unique -/
+/-! exists unique -/
 
 def exists_unique {α : Sort u} (p : α → Prop) :=
 ∃ x, p x ∧ ∀ y, p y → y = x
@@ -574,7 +573,7 @@ exists_unique.elim h
     assume unique : ∀ y, p y → y = x,
     show y₁ = y₂, from eq.trans (unique _ py₁) (eq.symm (unique _ py₂)))
 
-/- exists, forall, exists unique congruences -/
+/-! exists, forall, exists unique congruences -/
 @[congr] lemma forall_congr {α : Sort u} {p q : α → Prop} (h : ∀ a, (p a ↔ q a)) : (∀ a, p a) ↔ ∀ a, q a :=
 iff.intro (λ p a, iff.mp (h a) (p a)) (λ q a, iff.mpr (h a) (q a))
 
@@ -592,7 +591,7 @@ exists_congr (λ x, and_congr (h x) (forall_congr (λ y, imp_congr (h y) iff.rfl
 lemma forall_not_of_not_exists {α : Sort u} {p : α → Prop} : ¬(∃ x, p x) → (∀ x, ¬p x) :=
 λ hne x hp, hne ⟨x, hp⟩
 
-/- decidable -/
+/-! decidable -/
 
 def decidable.to_bool (p : Prop) [h : decidable p] : bool :=
 decidable.cases_on h (λ h₁, bool.ff) (λ h₂, bool.tt)
@@ -616,8 +615,7 @@ is_false not_false
 @[inline] def dite {α : Sort u} (c : Prop) [h : decidable c] : (c → α) → (¬ c → α) → α :=
 λ t e, decidable.rec_on h e t
 
-/- if-then-else -/
-
+/-- if-then-else -/
 @[inline] def ite {α : Sort u} (c : Prop) [h : decidable c] (t e : α) : α :=
 decidable.rec_on h (λ hnc, e) (λ hc, t)
 
@@ -769,7 +767,7 @@ match (h a b) with
 | (is_false n₁) := proof_irrel n n₁ ▸ eq.refl (is_false n)
 end
 
-/- inhabited -/
+/-! inhabited -/
 
 class inhabited (α : Sort u) :=
 (default : α)
@@ -802,7 +800,7 @@ instance nonempty_of_inhabited {α : Sort u} [inhabited α] : nonempty α :=
 lemma nonempty_of_exists {α : Sort u} {p : α → Prop} : (∃ x, p x) → nonempty α
 | ⟨w, h⟩ := ⟨w⟩
 
-/- subsingleton -/
+/-! subsingleton -/
 
 class inductive subsingleton (α : Sort u) : Prop
 | intro (h : ∀ a b : α, a = b) : subsingleton
@@ -987,7 +985,7 @@ structure {r s} ulift (α : Type s) : Type (max s r) :=
 up :: (down : α)
 
 namespace ulift
-/- Bijection between α and ulift.{v} α -/
+/-- Bijection between α and ulift.{v} α -/
 lemma up_down {α : Type u} : ∀ (b : ulift.{v} α), up (down b) = b
 | (up a) := rfl
 
@@ -999,14 +997,14 @@ structure plift (α : Sort u) : Type u :=
 up :: (down : α)
 
 namespace plift
-/- Bijection between α and plift α -/
+/-- Bijection between α and plift α -/
 lemma up_down {α : Sort u} : ∀ (b : plift α), up (down b) = b
 | (up a) := rfl
 
 lemma down_up {α : Sort u} (a : α) : down (up a) = a := rfl
 end plift
 
-/- Equalities for rewriting let-expressions -/
+/-- Equalities for rewriting let-expressions -/
 lemma let_value_eq {α : Sort u} {β : Sort v} {a₁ a₂ : α} (b : α → β) :
                    a₁ = a₂ → (let x : α := a₁ in b x) = (let x : α := a₂ in b x) :=
 λ h, eq.rec_on h rfl

--- a/library/init/meta/backward.lean
+++ b/library/init/meta/backward.lean
@@ -9,15 +9,15 @@ import init.meta.tactic init.meta.set_get_option_tactics
 namespace tactic
 meta constant back_lemmas : Type
 
-/- Create a datastructure containing all lemmas tagged as [intro].
+/-- Create a datastructure containing all lemmas tagged as [intro].
    Lemmas are indexed using their head-symbol.
    The head-symbol is computed with respect to the given transparency setting. -/
 meta constant mk_back_lemmas_core     : transparency → tactic back_lemmas
-/- (back_lemmas_insert_core m lemmas lemma) adds the given lemma to the set back_lemmas.
+/-- (back_lemmas_insert_core m lemmas lemma) adds the given lemma to the set back_lemmas.
    It infers the type of the lemma, and uses its head-symbol as an index.
    The head-symbol is computed with respect to the given transparency setting. -/
 meta constant back_lemmas_insert_core : transparency → back_lemmas → expr → tactic back_lemmas
-/- Return the lemmas that have the same head symbol of the given expression -/
+/-- Return the lemmas that have the same head symbol of the given expression -/
 meta constant back_lemmas_find        : back_lemmas → expr → tactic (list expr)
 
 meta def mk_back_lemmas : tactic back_lemmas :=
@@ -27,7 +27,7 @@ meta def back_lemmas_insert : back_lemmas → expr → tactic back_lemmas :=
 back_lemmas_insert_core reducible
 
 
-/- (backward_chaining_core t insts max_depth pre_tactic leaf_tactic lemmas): perform backward chaining using
+/-- (backward_chaining_core t insts max_depth pre_tactic leaf_tactic lemmas): perform backward chaining using
    the lemmas marked as [intro] and extra_lemmas.
 
    The search maximum depth is \c max_depth.

--- a/library/init/meta/constructor_tactic.lean
+++ b/library/init/meta/constructor_tactic.lean
@@ -8,7 +8,7 @@ import init.meta.tactic init.function
 
 namespace tactic
 
-/- Return target after instantiating metavars and whnf -/
+/-- Return target after instantiating metavars and whnf -/
 private meta def target' : tactic expr :=
 target >>= instantiate_mvars >>= whnf
 

--- a/library/init/meta/exceptional.lean
+++ b/library/init/meta/exceptional.lean
@@ -5,11 +5,11 @@ Authors: Leonardo de Moura
 -/
 prelude
 import init.control.monad init.meta.format init.util
-/-
+
+/-- An exceptional is similar to `Result` in Haskell.
+
 Remark: we use a function that produces a format object as the exception information.
-Motivation: the formatting object may be big, and we may create it on demand.
--/
-/-- An exceptional is similar to `Result` in Haskell.-/
+Motivation: the formatting object may be big, and we may create it on demand.-/
 meta inductive exceptional (α : Type)
 | success   : α → exceptional
 | exception : (options → format) → exceptional

--- a/library/init/meta/has_reflect.lean
+++ b/library/init/meta/has_reflect.lean
@@ -39,7 +39,7 @@ meta instance unsigned.reflect : has_reflect unsigned
 
 end
 
-/- Instances that [derive] depends on. All other basic instances are defined at the end of
+/-! Instances that [derive] depends on. All other basic instances are defined at the end of
    derive.lean. -/
 
 meta instance name.reflect : has_reflect name

--- a/library/init/meta/injection_tactic.lean
+++ b/library/init/meta/injection_tactic.lean
@@ -10,7 +10,7 @@ namespace tactic
 
 open expr
 
-/- Given a local constant `H : C x₁ ... xₙ = D y₁ ... yₘ`, where `C` and `D` are
+/-- Given a local constant `H : C x₁ ... xₙ = D y₁ ... yₘ`, where `C` and `D` are
 fully applied constructors, `injection_with H ns base offset` does the
 following:
 

--- a/library/init/meta/interaction_monad.lean
+++ b/library/init/meta/interaction_monad.lean
@@ -82,7 +82,7 @@ meta def interaction_monad.silent_fail {α : Type u} : m α :=
 meta def interaction_monad.failed {α : Type u} : m α :=
 interaction_monad.fail "failed"
 
-/- Alternative orelse operator that allows to select which exception should be used.
+/-- Alternative orelse operator that allows to select which exception should be used.
    The default is to use the first exception since the standard `orelse` uses the second. -/
 meta def interaction_monad.orelse' {α : Type u} (t₁ t₂ : m α) (use_first_ex := tt) : m α :=
 λ s, interaction_monad.result.cases_on (t₁ s)

--- a/library/init/meta/interactive.lean
+++ b/library/init/meta/interactive.lean
@@ -18,19 +18,19 @@ local postfix `?`:9001 := optional
 local postfix *:9001 := many
 
 namespace tactic
-/- allows metavars -/
+/-- allows metavars -/
 meta def i_to_expr (q : pexpr) : tactic expr :=
 to_expr q tt
 
-/- allow metavars and no subgoals -/
+/-- allow metavars and no subgoals -/
 meta def i_to_expr_no_subgoals (q : pexpr) : tactic expr :=
 to_expr q tt ff
 
-/- doesn't allows metavars -/
+/-- doesn't allows metavars -/
 meta def i_to_expr_strict (q : pexpr) : tactic expr :=
 to_expr q ff
 
-/- Auxiliary version of i_to_expr for apply-like tactics.
+/-- Auxiliary version of i_to_expr for apply-like tactics.
    This is a workaround for comment
       https://github.com/leanprover/lean/issues/1342#issuecomment-307912291
    at issue #1342.
@@ -317,7 +317,7 @@ do {
   end
 }
 
-/- Version of to_expr that tries to bypass the elaborator if `p` is just a constant or local constant.
+/-- Version of to_expr that tries to bypass the elaborator if `p` is just a constant or local constant.
    This is not an optimization, by skipping the elaborator we make sure that no unwanted resolution is used.
    Example: the elaborator will force any unassigned ?A that must have be an instance of (has_one ?A) to nat.
    Remark: another benefit is that auxiliary temporary metavariables do not appear in error messages. -/
@@ -1788,7 +1788,7 @@ meta def mk_inj_eq : tactic unit :=
 ]
 end tactic
 
-/- Define inj_eq lemmas for inductive datatypes that were declared before `mk_inj_eq` -/
+/-! Define inj_eq lemmas for inductive datatypes that were declared before `mk_inj_eq` -/
 
 universes u v
 

--- a/library/init/meta/mk_dec_eq_instance.lean
+++ b/library/init/meta/mk_dec_eq_instance.lean
@@ -13,7 +13,7 @@ import init.meta.rec_util init.meta.interactive
 namespace tactic
 open expr environment list
 
-/- Retrieve the name of the type we are building a decidable equality proof for. -/
+/-- Retrieve the name of the type we are building a decidable equality proof for. -/
 private meta def get_dec_eq_type_name : tactic name :=
 do {
   (pi x1 i1 d1 (pi x2 i2 d2 b)) ← target >>= whnf,
@@ -24,7 +24,7 @@ do {
 <|>
 fail "mk_dec_eq_instance tactic failed, target type is expected to be of the form (decidable_eq ...)"
 
-/- Extract (lhs, rhs) from a goal (decidable (lhs = rhs)) -/
+/-- Extract (lhs, rhs) from a goal (decidable (lhs = rhs)) -/
 private meta def get_lhs_rhs : tactic (expr × expr) :=
 do
   (app dec lhs_eq_rhs) ← target | fail "mk_dec_eq_instance failed, unexpected case",
@@ -34,7 +34,7 @@ private meta def find_next_target : list expr → list expr → tactic (expr × 
 | (t::ts) (r::rs) := if t = r then find_next_target ts rs else return (t, r)
 | l1       l2     := failed
 
-/- Create an inhabitant of (decidable (lhs = rhs)) -/
+/-- Create an inhabitant of (decidable (lhs = rhs)) -/
 private meta def mk_dec_eq_for (lhs : expr) (rhs : expr) : tactic expr :=
 do lhs_type ← infer_type lhs,
    dec_type ← mk_app `decidable_eq [lhs_type] >>= whnf,
@@ -51,7 +51,7 @@ do pr ← mk_app `eq_of_heq [h],
    ty ← infer_type pr,
    assertv `h' ty pr >> skip
 
-/- Target is of the form (decidable (C ... = C ...)) where C is a constructor -/
+/-- Target is of the form (decidable (C ... = C ...)) where C is a constructor -/
 private meta def dec_eq_same_constructor : name → name → nat → tactic unit
 | I_name F_name num_rec :=
 do
@@ -84,11 +84,11 @@ do
       contradiction },
     return () }
 
-/- Easy case: target is of the form (decidable (C_1 ... = C_2 ...)) where C_1 and C_2 are distinct constructors -/
+/-- Easy case: target is of the form (decidable (C_1 ... = C_2 ...)) where C_1 and C_2 are distinct constructors -/
 private meta def dec_eq_diff_constructor : tactic unit :=
 left >> intron 1 >> contradiction
 
-/- This tactic is invoked for each case of decidable_eq. There n^2 cases, where n is the number
+/-- This tactic is invoked for each case of decidable_eq. There n^2 cases, where n is the number
    of constructors. -/
 private meta def dec_eq_case_2 (I_name : name) (F_name : name) : tactic unit :=
 do

--- a/library/init/meta/mk_has_reflect_instance.lean
+++ b/library/init/meta/mk_has_reflect_instance.lean
@@ -11,7 +11,7 @@ import init.meta.rec_util
 namespace tactic
 open expr environment list
 
-/- Retrieve the name of the type we are building a has_reflect instance for. -/
+/-- Retrieve the name of the type we are building a has_reflect instance for. -/
 private meta def get_has_reflect_type_name : tactic name :=
 do {
   (app (const n ls) t) ← target,
@@ -21,7 +21,7 @@ do {
 <|>
 fail "mk_has_reflect_instance tactic failed, target type is expected to be of the form (has_reflect ...)"
 
-/- Try to synthesize constructor argument using type class resolution -/
+/-- Try to synthesize constructor argument using type class resolution -/
 private meta def mk_has_reflect_instance_for (a : expr) : tactic expr :=
 do t    ← infer_type a,
    do {
@@ -33,7 +33,7 @@ do t    ← infer_type a,
      },
      mk_app `reflect [a, inst] }
 
-/- Synthesize (recursive) instances of `reflected` for all fields -/
+/-- Synthesize (recursive) instances of `reflected` for all fields -/
 private meta def mk_reflect : name → name → list name → nat → tactic (list expr)
 | I_name F_name []              num_rec := return []
 | I_name F_name (fname::fnames) num_rec := do
@@ -43,7 +43,7 @@ private meta def mk_reflect : name → name → list name → nat → tactic (li
   quotes   ← mk_reflect I_name F_name fnames (if rec then num_rec + 1 else num_rec),
   return (quote :: quotes)
 
-/- Solve the subgoal for constructor `F_name` -/
+/-- Solve the subgoal for constructor `F_name` -/
 private meta def has_reflect_case (I_name F_name : name) (field_names : list name) : tactic unit :=
 do field_quotes ← mk_reflect I_name F_name field_names 0,
    -- fn should be of the form `F_name ps fs`, where ps are the inductive parameter arguments,

--- a/library/init/meta/mk_has_sizeof_instance.lean
+++ b/library/init/meta/mk_has_sizeof_instance.lean
@@ -11,7 +11,7 @@ import init.meta.rec_util init.meta.constructor_tactic
 namespace tactic
 open expr environment list
 
-/- Retrieve the name of the type we are building a has_sizeof instance for. -/
+/-- Retrieve the name of the type we are building a has_sizeof instance for. -/
 private meta def get_has_sizeof_type_name : tactic name :=
 do {
   (app (const n ls) t) ← target >>= whnf,
@@ -21,7 +21,7 @@ do {
 <|>
 fail "mk_has_sizeof_instance tactic failed, target type is expected to be of the form (has_sizeof ...)"
 
-/- Try to synthesize constructor argument using type class resolution -/
+/-- Try to synthesize constructor argument using type class resolution -/
 private meta def mk_has_sizeof_instance_for (a : expr) (use_default : bool) : tactic expr :=
 do t    ← infer_type a,
    do {

--- a/library/init/meta/mk_inhabited_instance.lean
+++ b/library/init/meta/mk_inhabited_instance.lean
@@ -13,7 +13,7 @@ import init.meta.injection_tactic init.meta.relation_tactics
 namespace tactic
 open expr environment list
 
-/- Retrieve the name of the type we are building an inhabitant instance for. -/
+/-- Retrieve the name of the type we are building an inhabitant instance for. -/
 private meta def get_inhabited_type_name : tactic name :=
 do {
   (app (const n ls) t) ← target >>= whnf,
@@ -23,7 +23,7 @@ do {
 <|>
 fail "mk_inhabited_instance tactic failed, target type is expected to be of the form (inhabited ...)"
 
-/- Try to synthesize constructor argument using type class resolution -/
+/-- Try to synthesize constructor argument using type class resolution -/
 private meta def mk_inhabited_arg : tactic unit :=
 do tgt  ← target,
    inh  ← mk_app `inhabited [tgt],

--- a/library/init/meta/name.lean
+++ b/library/init/meta/name.lean
@@ -83,7 +83,7 @@ instance : has_repr name :=
 
 /- TODO(Leo): provide a definition in Lean. -/
 meta constant name.has_decidable_eq : decidable_eq name
-/- Both cmp and lex_cmp are total orders, but lex_cmp implements a lexicographical order. -/
+/-! Both cmp and lex_cmp are total orders, but lex_cmp implements a lexicographical order. -/
 meta constant name.cmp : name → name → ordering
 meta constant name.lex_cmp : name → name → ordering
 meta constant name.append : name → name → name

--- a/library/init/meta/simp_tactic.lean
+++ b/library/init/meta/simp_tactic.lean
@@ -148,7 +148,7 @@ end tactic
 meta constant simp_lemmas.dsimplify (s : simp_lemmas) (u : list name := []) (e : expr) (cfg : tactic.dsimp_config := {}) : tactic expr
 
 namespace tactic
-/- Remark: the configuration parameters `cfg.md` and `cfg.eta` are ignored by this tactic. -/
+/-- Remark: the configuration parameters `cfg.md` and `cfg.eta` are ignored by this tactic. -/
 meta constant dsimplify_core
   /- The user state type. -/
   {α : Type}
@@ -203,7 +203,7 @@ meta constant dunfold_head (e : expr) (md := transparency.instances) : tactic ex
 structure dunfold_config extends dsimp_config :=
 (md := transparency.instances)
 
-/- Remark: in principle, dunfold can be implemented on top of dsimp. We don't do it for
+/-! Remark: in principle, dunfold can be implemented on top of dsimp. We don't do it for
    performance reasons. -/
 
 meta constant dunfold (cs : list name) (e : expr) (cfg : dunfold_config := {}) : tactic expr
@@ -415,7 +415,7 @@ do (lhs, rhs)     ← target >>= match_eq,
    unify rhs new_rhs,
    exact heq
 
-/- Simp attribute support -/
+/-! Simp attribute support -/
 
 meta def to_simp_lemmas : simp_lemmas → list name → tactic simp_lemmas
 | S []      := return S
@@ -490,7 +490,7 @@ private meta def remove_deps (s : name_set) (h : expr) : name_set :=
 if s.empty then s
 else h.fold s (λ e o s, if e.is_local_constant then s.erase e.local_uniq_name else s)
 
-/- Return the list of hypothesis that are propositions and do not have
+/-- Return the list of hypothesis that are propositions and do not have
    forward dependencies. -/
 meta def non_dep_prop_hyps : tactic (list expr) :=
 do
@@ -518,7 +518,7 @@ meta structure simp_all_entry :=
 private meta def update_simp_lemmas (es : list simp_all_entry) (h : expr) : tactic (list simp_all_entry) :=
 es.mmap $ λ e, do new_s ← e.s.add h ff, return {s := new_s, ..e}
 
-/- Helper tactic for `init`.
+/-- Helper tactic for `init`.
    Remark: the following tactic is quadratic on the length of list expr (the list of non dependent propositions).
    We can make it more efficient as soon as we have an efficient simp_lemmas.erase. -/
 private meta def init_aux : list expr → simp_lemmas → list simp_all_entry → tactic (simp_lemmas × list simp_all_entry)
@@ -589,7 +589,7 @@ do hs      ← non_dep_prop_hyps,
 
 end simp_all
 
-/- debugging support for algebraic normalizer -/
+/-! debugging support for algebraic normalizer -/
 
 meta constant trace_algebra_info : expr → tactic unit
 

--- a/library/init/meta/smt/ematch.lean
+++ b/library/init/meta/smt/ematch.lean
@@ -145,7 +145,7 @@ structure ematch_config :=
 (max_instances  : nat := 10000)
 (max_generation : nat := 10)
 
-/- Ematching -/
+/-! Ematching -/
 meta constant ematch_state             : Type
 meta constant ematch_state.mk          : ematch_config → ematch_state
 meta constant ematch_state.internalize : ematch_state → expr → tactic ematch_state

--- a/library/init/meta/smt/smt_tactic.lean
+++ b/library/init/meta/smt/smt_tactic.lean
@@ -182,7 +182,7 @@ private meta def mk_smt_goals_for (cfg : smt_config) : list expr → list smt_go
   [new_tg] ← get_goals | tactic.failed,
   mk_smt_goals_for tgs (new_sg::sr) (new_tg::tr)
 
-/- See slift -/
+/-- See slift -/
 meta def slift_aux {α : Type} (t : tactic α) (cfg : smt_config) : smt_tactic α :=
 ⟨λ ss, do
    _::sgs  ← return ss | tactic.fail "slift tactic failed, there no smt goals to be solved",

--- a/library/init/meta/tactic.lean
+++ b/library/init/meta/tactic.lean
@@ -591,9 +591,9 @@ structure apply_cfg :=
     The fields `cfg.auto_param` and `cfg.opt_param` are ignored by this tactic (See `tactic.apply`).
     It returns a list of all introduced meta variables and the parameter name associated with them, even the assigned ones. -/
 meta constant apply_core (e : expr) (cfg : apply_cfg := {}) : tactic (list (name × expr))
-/- Create a fresh meta universe variable. -/
+/-- Create a fresh meta universe variable. -/
 meta constant mk_meta_univ  : tactic level
-/- Create a fresh meta-variable with the given type.
+/-- Create a fresh meta-variable with the given type.
    The scope of the new meta-variable is the local context of the main goal. -/
 meta constant mk_meta_var   : expr → tactic expr
 /-- Return the value assigned to the given universe meta-variable.
@@ -783,7 +783,7 @@ meta constant unfreeze_local_instances : tactic unit
 Freeze the current set of local instances.
 -/
 meta constant freeze_local_instances : tactic unit
-/- Return the list of frozen local instances. Return `none` if local instances were not frozen. -/
+/-- Return the list of frozen local instances. Return `none` if local instances were not frozen. -/
 meta constant frozen_local_instances : tactic (option (list expr))
 
 /-- Run the provided tactic, associating it to the given AST node. -/
@@ -962,7 +962,7 @@ Example: with `x : ℕ, h : P(x) ⊢ T(x)`, `revert x` returns `2` and produces 
 meta def revert (l : expr) : tactic nat :=
 revert_lst [l]
 
-/- Revert "all" hypotheses. Actually, the tactic only reverts
+/-- Revert "all" hypotheses. Actually, the tactic only reverts
    hypotheses occurring after the last frozen local instance.
    Recall that frozen local instances cannot be reverted,
    use `unfreezing revert_all` instead. -/
@@ -1675,7 +1675,7 @@ do env ← get_env,
    env ← returnex $ f env,
    set_env env
 
-/- Add a new inductive datatype to the environment
+/-- Add a new inductive datatype to the environment
    name, universe parameters, number of parameters, type, constructors (name and type), is_meta -/
 meta def add_inductive (n : name) (ls : list name) (p : nat) (ty : expr) (is : list (name × expr))
   (is_meta : bool := ff) : tactic unit :=
@@ -1828,7 +1828,7 @@ do h_type ← infer_type h,
 meta def main_goal : tactic expr :=
 do g::gs ← get_goals, return g
 
-/- Goal tagging support -/
+/-! Goal tagging support -/
 meta def with_enable_tags {α : Type} (t : tactic α) (b := tt) : tactic α :=
 do old ← tags_enabled,
    enable_tags b,
@@ -1873,7 +1873,7 @@ meta def any_of {α β} : list α → (α → tactic β) → tactic β
                    end
 end list
 
-/- Install monad laws tactic and use it to prove some instances. -/
+/-! Install monad laws tactic and use it to prove some instances. -/
 
 /-- Try to prove with `iff.refl`.-/
 meta def order_laws_tac := whnf_target >> intros >> to_expr ``(iff.refl _) >>= exact

--- a/library/init/propext.lean
+++ b/library/init/propext.lean
@@ -8,7 +8,7 @@ import init.logic
 
 constant propext {a b : Prop} : (a ↔ b) → a = b
 
-/- Additional congruence lemmas. -/
+/-! # Additional congruence lemmas. -/
 universes u v
 
 lemma forall_congr_eq {a : Sort u} {p q : a → Prop} (h : ∀ x, p x = q x) : (∀ x, p x) = ∀ x, q x :=

--- a/library/init/wf.lean
+++ b/library/init/wf.lean
@@ -80,7 +80,7 @@ lemma empty_wf {α : Sort u} : well_founded (@empty_relation α) :=
 well_founded.intro (λ (a : α),
   acc.intro a (λ (b : α) (lt : false), false.rec _ lt))
 
-/- Subrelation of a well-founded relation is well-founded -/
+/-! Subrelation of a well-founded relation is well-founded -/
 namespace subrelation
 section
   parameters {α : Sort u} {r Q : α → α → Prop}

--- a/library/system/io.lean
+++ b/library/system/io.lean
@@ -5,10 +5,10 @@ Authors: Luke Nelson, Jared Roesch and Leonardo de Moura
 -/
 import system.io_interface
 
-/- The following constants have a builtin implementation -/
+/-! The following constants have a builtin implementation -/
 constant io_core : Type → Type → Type
 
-/- Auxiliary definition used in the builtin implementation of monad_io_random_impl -/
+/-- Auxiliary definition used in the builtin implementation of monad_io_random_impl -/
 def io_rand_nat : std_gen → nat → nat → nat × std_gen :=
 rand_nat
 
@@ -34,7 +34,7 @@ monad_io_is_alternative io_core
 io_core io.error α
 
 namespace io
-/- Remark: the following definitions can be generalized and defined for any (m : Type -> Type -> Type)
+/-! Remark: the following definitions can be generalized and defined for any (m : Type -> Type -> Type)
    that implements the required type classes. However, the generalized versions are very inconvenient to use,
    (example: `#eval io.put_str "hello world"` does not work because we don't have enough information to infer `m`.).
 -/

--- a/library/system/random.lean
+++ b/library/system/random.lean
@@ -5,12 +5,13 @@ Authors: Leonardo de Moura
 -/
 universes u
 
-/-
-Basic random number generator support based on the one
-available on the Haskell library
+/-!
+# Basic random number generator support
+
+based on the one available on the Haskell library
 -/
 
-/- Interface for random number generators. -/
+/-- Interface for random number generators. -/
 class random_gen (g : Type u) :=
 /- `range` returns the range of values returned by
     the generator. -/
@@ -25,7 +26,7 @@ class random_gen (g : Type u) :=
   passing a random number generator down to recursive calls). -/
 (split : g → g × g)
 
-/- "Standard" random number generator. -/
+/-- "Standard" random number generator. -/
 structure std_gen :=
 (s1 : nat) (s2 : nat)
 
@@ -67,7 +68,7 @@ let q  := s / 2147483562,
     s2 := q % 2147483398 in
 ⟨s1 + 1, s2 + 1⟩
 
-/-
+/--
 Auxiliary function for random_nat_val.
 Generate random values until we exceed the target magnitude.
 `gen_lo` and `gen_mag` are the generator lower bound and magnitude.


### PR DESCRIPTION
This isn't exhaustive, but converts the majority.
It also does not check that the comments have reasonable markdown formatting.