### PR TITLE
[Merged by Bors] - fix: push null using_well_founded node after `:=`

### DIFF
--- a/src/frontends/lean/definition_cmds.cpp
+++ b/src/frontends/lean/definition_cmds.cpp
@@ -578,6 +578,7 @@ parser::parse_definition(ast_data * _parent, buffer<name> & lp_names, buffer<exp
             val = p.parse_expr();
             parent.push(p.get_id(val));
         }
+        parent.push(0);
     } else if (p.curr_is_token(get_bar_tk()) || p.curr_is_token(get_period_tk())) {
         if (is_abbrev)
             throw exception("invalid abbreviation, abbreviations should not be defined using pattern matching");


### PR DESCRIPTION
As [reported on Zulip](https://leanprover.zulipchat.com/#narrow/stream/287929-mathlib4/topic/11-20.20nightly.20mathlib3port/near/311686177).