### PR TITLE
[Merged by Bors] - fix(frontends/lean/definition_cmds): put auto-bound universes before explicit

### DIFF
--- a/src/frontends/lean/definition_cmds.cpp
+++ b/src/frontends/lean/definition_cmds.cpp
@@ -189,7 +189,8 @@ static void finalize_definition(elaborator & elab, buffer<expr> const & params, 
         type = type_val[0];
         val  = type_val[1];
     }
-    lp_names.append(implicit_lp_names);
+    implicit_lp_names.append(lp_names);
+    lp_names = std::move(implicit_lp_names);
 }
 
 static certified_declaration check(parser_info const & p, environment const & env, name const & c_name, declaration const & d, pos_info const & pos) {
@@ -680,7 +681,8 @@ static void finalize_theorem_type(elaborator & elab, buffer<expr> const & params
     buffer<name> implicit_lp_names;
     std::tie(type, info) = elab.finalize_theorem_type(type, implicit_lp_names);
     type = unfold_untrusted_macros(elab.env(), type);
-    lp_names.append(implicit_lp_names);
+    implicit_lp_names.append(lp_names);
+    lp_names = std::move(implicit_lp_names);
 }
 
 static void finalize_theorem_proof(elaborator & elab, buffer<expr> const & params, expr & val,

--- a/src/frontends/lean/inductive_cmds.cpp
+++ b/src/frontends/lean/inductive_cmds.cpp
@@ -525,10 +525,13 @@ class inductive_cmd_fn {
 
         lean_assert(is_shifted_param || is_constant);
 
+        buffer<name> new_lp_names;
         for (name const & lp_name : implicit_lp_names) {
             if (!(is_shifted_param && param_id(m_u_meta_assignment_offset.first) == lp_name))
-                m_lp_names.emplace_back(lp_name);
+                new_lp_names.emplace_back(lp_name);
         }
+        new_lp_names.append(m_lp_names);
+        m_lp_names = std::move(new_lp_names);
 
         m_u_param = m_u_meta_assignment_offset.first;
         m_u_param_offset = m_u_meta_assignment_offset.second;

--- a/src/frontends/lean/structure_cmd.cpp
+++ b/src/frontends/lean/structure_cmd.cpp
@@ -1023,8 +1023,11 @@ struct structure_cmd_fn {
                             metavar_context mctx = m_ctx.mctx();
                             std::tie(new_tmp, new_ls) = m_p.elaborate_type(m_name, mctx, tmp, false);
                             m_ctx.set_mctx(mctx);
+                            buffer<name> new_lp_names;
                             for (auto new_l : new_ls)
-                                m_level_names.push_back(new_l);
+                                new_lp_names.push_back(new_l);
+                            new_lp_names.append(m_level_names);
+                            m_level_names = std::move(new_lp_names);
                             return new_tmp;
                         });
                     });

--- a/tests/lean/sec_param_pp.lean.expected.out
+++ b/tests/lean/sec_param_pp.lean.expected.out
@@ -1,4 +1,4 @@
 id2 : A
 pr f id2 : A
 pr f id2 : A
-pr2.{0} ℕ 10 : A
+pr2.{0 u_1} ℕ 10 : A


### PR DESCRIPTION
For compatibility with lean 4. See https://leanprover.zulipchat.com/#narrow/stream/287929-mathlib4/topic/list.2Etraverse/near/313206118