### PR TITLE
[Merged by Bors] - fix(library/tactic/simplify): avoid an expensive copy in simp

### DIFF
--- a/src/library/tactic/simplify.cpp
+++ b/src/library/tactic/simplify.cpp
@@ -658,7 +658,7 @@ simp_result simplify_core_fn::visit(expr const & e, optional<expr> const & paren
     lean_simp_trace(m_ctx, "simplify", tout() << m_rel << ": " << e << "\n";);
 
     if (m_cfg.m_memoize) {
-        auto cache = m_cache[m_rel];
+        const auto& cache = m_cache[m_rel];
         auto it = cache.find(e);
         if (it != cache.end())
             return it->second;


### PR DESCRIPTION
In that context, `auto` is deduced to be `expr_map<simp_result>`, which creates a local copy of the map. However, the call to `find()` below can be made on a `const&`, so the copy is unnecessary.

We've measured this copy to be using ~1% of total runtime.

This is intended as a non-functional change. It was generated by automated tools.