### PR TITLE
fix: Add missing emscripten export

### DIFF
--- a/src/shell/CMakeLists.txt
+++ b/src/shell/CMakeLists.txt
@@ -42,7 +42,7 @@ if(${EMSCRIPTEN})
     add_dependencies(lean_js lean_js_library)
     set_target_properties(lean_js PROPERTIES COMPILE_FLAGS --bind -s NO_EXIT_RUNTIME=1)
 
-    set(LEAN_JS_OPTS "-sEXPORTED_RUNTIME_METHODS=FS,ERRNO_CODES -sEXPORTED_FUNCTIONS=_malloc,_free")
+    set(LEAN_JS_OPTS "-sEXPORTED_RUNTIME_METHODS=FS,ERRNO_CODES,PATH -sEXPORTED_FUNCTIONS=_malloc,_free")
     add_executable(lean_js_wasm lean_js.cpp lean_js_new.cpp server.cpp)
     target_link_libraries(lean_js_wasm leanstatic)
     set_target_properties(lean_js_wasm PROPERTIES LINK_FLAGS "-s WASM=1 ${LEAN_JS_OPTS}")

--- a/src/shell/CMakeLists.txt
+++ b/src/shell/CMakeLists.txt
@@ -42,7 +42,7 @@ if(${EMSCRIPTEN})
     add_dependencies(lean_js lean_js_library)
     set_target_properties(lean_js PROPERTIES COMPILE_FLAGS --bind -s NO_EXIT_RUNTIME=1)
 
-    set(LEAN_JS_OPTS "-sEXPORTED_RUNTIME_METHODS=FS -sEXPORTED_FUNCTIONS=_malloc,_free")
+    set(LEAN_JS_OPTS "-sEXPORTED_RUNTIME_METHODS=FS,ERRNO_CODES -sEXPORTED_FUNCTIONS=_malloc,_free")
     add_executable(lean_js_wasm lean_js.cpp lean_js_new.cpp server.cpp)
     target_link_libraries(lean_js_wasm leanstatic)
     set_target_properties(lean_js_wasm PROPERTIES LINK_FLAGS "-s WASM=1 ${LEAN_JS_OPTS}")


### PR DESCRIPTION
Combined with https://github.com/leanprover/lean-client-js/pull/58, this seems sufficient to fix the web editor.

Strictly only `ERRNO_CODES` seems necessary, but the code certainly expects `PATH` too.