### PR TITLE
[Merged by Bors] - fix(shell): add missing include

### DIFF
--- a/src/shell/lean_js.h
+++ b/src/shell/lean_js.h
@@ -5,6 +5,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Author: Leonardo de Moura
 */
 #pragma once
+#include <cstdint>
 #include <string>
 void initialize_emscripten();
 void finalize_emscripten();


### PR DESCRIPTION
This header inclusion was missing, resulting in build errors with recent versions of GCC:

```
In file included from /home/jonathan/Code/lean3/src/shell/lean_js_main.cpp:9:
/home/jonathan/Code/lean3/src/shell/lean_js.h:11:32: error: ‘uintptr_t’ was not declared in this scope
   11 | int emscripten_process_request(uintptr_t msg);
```